### PR TITLE
Default cache doesn't handle family id correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/gdexlab/go-render v1.0.1
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/shirou/gopsutil v2.20.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/gdexlab/go-render v1.0.1 h1:rxqB3vo5s4n1kF0ySmoNeSPRYkEsyHgln4jFIQY7v0U=
+github.com/gdexlab/go-render v1.0.1/go.mod h1:wRi5nW2qfjiGj4mPukH4UV0IknS1cHD4VgFTmJX5JzM=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=

--- a/src/internal/tokencache/default_storage_manager.go
+++ b/src/internal/tokencache/default_storage_manager.go
@@ -96,23 +96,24 @@ func (m *defaultStorageManager) ReadRefreshToken(
 	defer lock.RUnlock()
 	if familyID != "" {
 		for _, rt := range m.refreshTokens {
-			if testClientIDRefreshToken(rt, homeAccountID, envAliases, clientID) {
+			if matchFamilyRefreshToken(rt, homeAccountID, envAliases) {
 				return rt
 			}
 		}
 		for _, rt := range m.refreshTokens {
-			if testFamilyRefreshToken(rt, homeAccountID, envAliases) {
+			if matchClientIDRefreshToken(rt, homeAccountID, envAliases, clientID) {
 				return rt
 			}
 		}
 	} else {
 		for _, rt := range m.refreshTokens {
-			if testFamilyRefreshToken(rt, homeAccountID, envAliases) {
+			if matchClientIDRefreshToken(rt, homeAccountID, envAliases, clientID) {
 				return rt
 			}
 		}
+
 		for _, rt := range m.refreshTokens {
-			if testClientIDRefreshToken(rt, homeAccountID, envAliases, clientID) {
+			if matchFamilyRefreshToken(rt, homeAccountID, envAliases) {
 				return rt
 			}
 		}
@@ -120,13 +121,13 @@ func (m *defaultStorageManager) ReadRefreshToken(
 	return nil
 }
 
-func testFamilyRefreshToken(rt *refreshTokenCacheItem, homeAccountID string, envAliases []string) bool {
+func matchFamilyRefreshToken(rt *refreshTokenCacheItem, homeAccountID string, envAliases []string) bool {
 	return msalbase.GetStringFromPointer(rt.HomeAccountID) == homeAccountID &&
 		checkAlias(msalbase.GetStringFromPointer(rt.Environment), envAliases) &&
 		msalbase.GetStringFromPointer(rt.FamilyID) != ""
 }
 
-func testClientIDRefreshToken(rt *refreshTokenCacheItem, homeAccountID string, envAliases []string, clientID string) bool {
+func matchClientIDRefreshToken(rt *refreshTokenCacheItem, homeAccountID string, envAliases []string, clientID string) bool {
 	return msalbase.GetStringFromPointer(rt.HomeAccountID) == homeAccountID &&
 		checkAlias(msalbase.GetStringFromPointer(rt.Environment), envAliases) &&
 		msalbase.GetStringFromPointer(rt.ClientID) == clientID

--- a/src/internal/tokencache/refresh_token_cache_item.go
+++ b/src/internal/tokencache/refresh_token_cache_item.go
@@ -42,7 +42,7 @@ func createRefreshTokenCacheItem(homeAccountID string,
 
 func (rt *refreshTokenCacheItem) CreateKey() string {
 	var fourth string
-	if rt.FamilyID == nil {
+	if msalbase.GetStringFromPointer(rt.FamilyID) == "" {
 		fourth = msalbase.GetStringFromPointer(rt.ClientID)
 	} else {
 		fourth = msalbase.GetStringFromPointer(rt.FamilyID)


### PR DESCRIPTION
Fixes #49 

Problem was both in the tests and the implementation.

This brings behavior more in line with MSAL4J's implementation: https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/0b20b1430ab57cd1f331935b79aa8542c5be9c9c/src/main/java/com/microsoft/aad/msal4j/TokenCache.java#L543

Could use an ack from someone on an MSAL team on cache key behavior.

Might be worth revisiting some of this API