### PR TITLE
Refactored public surface area for device code flow

### DIFF
--- a/msal/acquire_token_auth_code_parameters.go
+++ b/msal/acquire_token_auth_code_parameters.go
@@ -14,7 +14,6 @@ import (
 // https://tools.ietf.org/html/rfc7636.
 type acquireTokenAuthCodeParameters struct {
 	commonParameters *acquireTokenCommonParameters
-	redirectURI      string
 	Code             string
 	CodeChallenge    string
 	clientCredential *msalbase.ClientCredential
@@ -23,15 +22,14 @@ type acquireTokenAuthCodeParameters struct {
 
 // createAcquireTokenAuthCodeParameters creates an AcquireTokenAuthCodeParameters instance.
 // Pass in the scopes required, the redirect URI for your application.
-func createAcquireTokenAuthCodeParameters(scopes []string, redirectURI string) *acquireTokenAuthCodeParameters {
+func createAcquireTokenAuthCodeParameters(scopes []string) *acquireTokenAuthCodeParameters {
 	return &acquireTokenAuthCodeParameters{
 		commonParameters: createAcquireTokenCommonParameters(scopes),
-		redirectURI:      redirectURI,
 	}
 }
 
 func (p *acquireTokenAuthCodeParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
 	p.commonParameters.augmentAuthenticationParameters(authParams)
-	authParams.Redirecturi = p.redirectURI
+	authParams.Redirecturi = "https://login.microsoftonline.com/common/oauth2/nativeclient"
 	authParams.AuthorizationType = msalbase.AuthorizationTypeAuthCode
 }

--- a/msal/acquire_token_auth_code_parameters.go
+++ b/msal/acquire_token_auth_code_parameters.go
@@ -12,7 +12,7 @@ import (
 // To use PKCE, set the CodeChallengeParameter.
 // Code challenges are used to secure authorization code grants; for more information, visit
 // https://tools.ietf.org/html/rfc7636.
-type AcquireTokenAuthCodeParameters struct {
+type acquireTokenAuthCodeParameters struct {
 	commonParameters *acquireTokenCommonParameters
 	redirectURI      string
 	Code             string
@@ -21,18 +21,16 @@ type AcquireTokenAuthCodeParameters struct {
 	requestType      requests.AuthCodeRequestType
 }
 
-// CreateAcquireTokenAuthCodeParameters creates an AcquireTokenAuthCodeParameters instance.
+// createAcquireTokenAuthCodeParameters creates an AcquireTokenAuthCodeParameters instance.
 // Pass in the scopes required, the redirect URI for your application.
-func CreateAcquireTokenAuthCodeParameters(scopes []string,
-	redirectURI string) *AcquireTokenAuthCodeParameters {
-	p := &AcquireTokenAuthCodeParameters{
+func createAcquireTokenAuthCodeParameters(scopes []string, redirectURI string) *acquireTokenAuthCodeParameters {
+	return &acquireTokenAuthCodeParameters{
 		commonParameters: createAcquireTokenCommonParameters(scopes),
 		redirectURI:      redirectURI,
 	}
-	return p
 }
 
-func (p *AcquireTokenAuthCodeParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
+func (p *acquireTokenAuthCodeParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
 	p.commonParameters.augmentAuthenticationParameters(authParams)
 	authParams.Redirecturi = p.redirectURI
 	authParams.AuthorizationType = msalbase.AuthorizationTypeAuthCode

--- a/msal/acquire_token_auth_code_parameters_test.go
+++ b/msal/acquire_token_auth_code_parameters_test.go
@@ -12,8 +12,7 @@ import (
 
 func TestCreateAcquireTokenAuthCodeParameters(t *testing.T) {
 	expectedScopes := []string{"user.read"}
-	expectedRedirectURI := "http://localhost:3000/redirect"
-	params := createAcquireTokenAuthCodeParameters(expectedScopes, expectedRedirectURI)
+	params := createAcquireTokenAuthCodeParameters(expectedScopes)
 	if params == nil {
 		t.Error("Parameters cannot be nil.")
 	}
@@ -21,29 +20,18 @@ func TestCreateAcquireTokenAuthCodeParameters(t *testing.T) {
 	if !reflect.DeepEqual(expectedScopes, actualScopes) {
 		t.Errorf("Actual scopes %v differ from expected scopes %v", actualScopes, expectedScopes)
 	}
-	actualRedirectURI := params.redirectURI
-	if !reflect.DeepEqual(expectedRedirectURI, actualRedirectURI) {
-		t.Errorf("Actual redirect URI %v differs from expected redirect URI %v", actualRedirectURI, expectedRedirectURI)
-	}
 }
 
 func TestAugmentAuthenticationParametersForAuth(t *testing.T) {
 	testScopes := []string{"user.read"}
-	testRedirectURI := "http://localhost:3000/redirect"
 	testAuthParams := &msalbase.AuthParametersInternal{}
 	testTokenCommonParams := &acquireTokenCommonParameters{testScopes}
 	testAuthCodeParams := &acquireTokenAuthCodeParameters{
 		commonParameters: testTokenCommonParams,
-		redirectURI:      testRedirectURI,
 	}
 	testAuthCodeParams.augmentAuthenticationParameters(testAuthParams)
 	actualScopes := testAuthParams.Scopes
 	if !reflect.DeepEqual(testScopes, actualScopes) {
 		t.Errorf("Actual scopes %v differ from expected scopes %v", actualScopes, testScopes)
 	}
-	actualRedirectURI := testAuthParams.Redirecturi
-	if !reflect.DeepEqual(testRedirectURI, actualRedirectURI) {
-		t.Errorf("Actual redirect URI %v differs from expected redirect URI %v", actualRedirectURI, testRedirectURI)
-	}
-
 }

--- a/msal/acquire_token_auth_code_parameters_test.go
+++ b/msal/acquire_token_auth_code_parameters_test.go
@@ -13,7 +13,7 @@ import (
 func TestCreateAcquireTokenAuthCodeParameters(t *testing.T) {
 	expectedScopes := []string{"user.read"}
 	expectedRedirectURI := "http://localhost:3000/redirect"
-	params := CreateAcquireTokenAuthCodeParameters(expectedScopes, expectedRedirectURI)
+	params := createAcquireTokenAuthCodeParameters(expectedScopes, expectedRedirectURI)
 	if params == nil {
 		t.Error("Parameters cannot be nil.")
 	}
@@ -32,7 +32,7 @@ func TestAugmentAuthenticationParametersForAuth(t *testing.T) {
 	testRedirectURI := "http://localhost:3000/redirect"
 	testAuthParams := &msalbase.AuthParametersInternal{}
 	testTokenCommonParams := &acquireTokenCommonParameters{testScopes}
-	testAuthCodeParams := &AcquireTokenAuthCodeParameters{
+	testAuthCodeParams := &acquireTokenAuthCodeParameters{
 		commonParameters: testTokenCommonParams,
 		redirectURI:      testRedirectURI,
 	}

--- a/msal/acquire_token_client_credential_parameters.go
+++ b/msal/acquire_token_client_credential_parameters.go
@@ -6,20 +6,19 @@ package msal
 import "github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
 
 // AcquireTokenClientCredentialParameters contains the parameters required to acquire an access token using the client credential flow.
-type AcquireTokenClientCredentialParameters struct {
+type acquireTokenClientCredentialParameters struct {
 	commonParameters *acquireTokenCommonParameters
 }
 
 // CreateAcquireTokenClientCredentialParameters creates an AcquireTokenClientCredentialParameters instance.
 // Pass in the scopes required.
-func CreateAcquireTokenClientCredentialParameters(scopes []string) *AcquireTokenClientCredentialParameters {
-	params := &AcquireTokenClientCredentialParameters{
+func createAcquireTokenClientCredentialParameters(scopes []string) *acquireTokenClientCredentialParameters {
+	return &acquireTokenClientCredentialParameters{
 		commonParameters: createAcquireTokenCommonParameters(scopes),
 	}
-	return params
 }
 
-func (p *AcquireTokenClientCredentialParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
+func (p *acquireTokenClientCredentialParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
 	p.commonParameters.augmentAuthenticationParameters(authParams)
 	authParams.AuthorizationType = msalbase.AuthorizationTypeClientCredentials
 }

--- a/msal/acquire_token_device_code_parameters.go
+++ b/msal/acquire_token_device_code_parameters.go
@@ -9,9 +9,11 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
 )
 
-// AcquireTokenDeviceCodeOptions contains the optional parameters required to acquire an access token using the device code flow.
-type AcquireTokenDeviceCodeOptions struct {
-	// placeholder for future optional args
+// acquireTokenDeviceCodeParameters contains the parameters required to acquire an access token using the device code flow.
+type acquireTokenDeviceCodeParameters struct {
+	commonParameters   *acquireTokenCommonParameters
+	deviceCodeCallback func(DeviceCodeResultProvider)
+	cancelCtx          context.Context
 }
 
 // CreateAcquireTokenDeviceCodeParameters creates an AcquireTokenDeviceCodeParameters instance.
@@ -20,9 +22,8 @@ type AcquireTokenDeviceCodeOptions struct {
 // The DeviceCode object is provided through the DeviceCodeResultProvider callback, and the end-user should be instructed to use
 // another device to navigate to the verification URI to input credentials. Since the client cannot receive incoming requests,
 // MSAL polls the authorization server repeatedly until the end-user completes input of credentials. Use cancelCtx to cancel the polling.
-func CreateAcquireTokenDeviceCodeParameters(cancelCtx context.Context, scopes []string,
-	deviceCodeCallback func(DeviceCodeResultProvider)) *AcquireTokenDeviceCodeParameters {
-	p := &AcquireTokenDeviceCodeParameters{
+func createAcquireTokenDeviceCodeParameters(cancelCtx context.Context, scopes []string, deviceCodeCallback func(DeviceCodeResultProvider)) *acquireTokenDeviceCodeParameters {
+	p := &acquireTokenDeviceCodeParameters{
 		commonParameters:   createAcquireTokenCommonParameters(scopes),
 		deviceCodeCallback: deviceCodeCallback,
 		cancelCtx:          cancelCtx,
@@ -30,7 +31,7 @@ func CreateAcquireTokenDeviceCodeParameters(cancelCtx context.Context, scopes []
 	return p
 }
 
-func (p *AcquireTokenDeviceCodeParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
+func (p *acquireTokenDeviceCodeParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
 	p.commonParameters.augmentAuthenticationParameters(authParams)
 	authParams.AuthorizationType = msalbase.AuthorizationTypeDeviceCode
 }

--- a/msal/acquire_token_device_code_parameters.go
+++ b/msal/acquire_token_device_code_parameters.go
@@ -9,11 +9,9 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
 )
 
-// AcquireTokenDeviceCodeParameters contains the parameters required to acquire an access token using the device code flow.
-type AcquireTokenDeviceCodeParameters struct {
-	commonParameters   *acquireTokenCommonParameters
-	deviceCodeCallback func(DeviceCodeResultProvider)
-	cancelCtx          context.Context
+// AcquireTokenDeviceCodeOptions contains the optional parameters required to acquire an access token using the device code flow.
+type AcquireTokenDeviceCodeOptions struct {
+	// placeholder for future optional args
 }
 
 // CreateAcquireTokenDeviceCodeParameters creates an AcquireTokenDeviceCodeParameters instance.

--- a/msal/acquire_token_device_code_parameters_test.go
+++ b/msal/acquire_token_device_code_parameters_test.go
@@ -14,7 +14,7 @@ func TestAugmentAuthenticationParametersDeviceCode(t *testing.T) {
 	testScopes := []string{"user.read"}
 	testAuthParams := &msalbase.AuthParametersInternal{}
 	testTokenCommonParams := &acquireTokenCommonParameters{testScopes}
-	testDeviceCodeParams := &AcquireTokenDeviceCodeParameters{
+	testDeviceCodeParams := &acquireTokenDeviceCodeParameters{
 		commonParameters: testTokenCommonParams,
 	}
 	testDeviceCodeParams.augmentAuthenticationParameters(testAuthParams)

--- a/msal/acquire_token_silent_parameters.go
+++ b/msal/acquire_token_silent_parameters.go
@@ -5,18 +5,21 @@ package msal
 
 import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/requests"
 )
 
-// AcquireTokenSilentOptions contains the optional parameters to acquire a token silently (from cache).
-type AcquireTokenSilentOptions struct {
-	// Account specifies the account to use when acquiring a token from the cache.
-	Account *msalbase.Account
+// AcquireTokenSilentParameters contains the parameters to acquire a token silently (from cache).
+type acquireTokenSilentParameters struct {
+	commonParameters *acquireTokenCommonParameters
+	account          AccountProvider
+	requestType      requests.RefreshTokenReqType
+	clientCredential *msalbase.ClientCredential
 }
 
 // CreateAcquireTokenSilentParameters creates an AcquireTokenSilentParameters instance with an empty account.
 // This can be used in the case where tokens are acquired as the application instelf.
-func CreateAcquireTokenSilentParameters(scopes []string) *AcquireTokenSilentParameters {
-	p := &AcquireTokenSilentParameters{
+func createAcquireTokenSilentParameters(scopes []string) *acquireTokenSilentParameters {
+	p := &acquireTokenSilentParameters{
 		commonParameters: createAcquireTokenCommonParameters(scopes),
 		account:          &msalbase.Account{},
 	}
@@ -25,15 +28,15 @@ func CreateAcquireTokenSilentParameters(scopes []string) *AcquireTokenSilentPara
 
 // CreateAcquireTokenSilentParametersWithAccount creates an AcquireTokenSilentParameters instance from an account.
 // This account can be pulled from the cache by calling GetAccounts
-func CreateAcquireTokenSilentParametersWithAccount(scopes []string, account AccountProvider) *AcquireTokenSilentParameters {
-	p := &AcquireTokenSilentParameters{
+func createAcquireTokenSilentParametersWithAccount(scopes []string, account AccountProvider) *acquireTokenSilentParameters {
+	p := &acquireTokenSilentParameters{
 		commonParameters: createAcquireTokenCommonParameters(scopes),
 		account:          account,
 	}
 	return p
 }
 
-func (p *AcquireTokenSilentParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
+func (p *acquireTokenSilentParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
 	p.commonParameters.augmentAuthenticationParameters(authParams)
 	authParams.AuthorizationType = msalbase.AuthorizationTypeRefreshTokenExchange
 	authParams.HomeaccountID = p.account.GetHomeAccountID()

--- a/msal/acquire_token_silent_parameters.go
+++ b/msal/acquire_token_silent_parameters.go
@@ -5,15 +5,12 @@ package msal
 
 import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
-	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/requests"
 )
 
-// AcquireTokenSilentParameters contains the parameters to acquire a token silently (from cache).
-type AcquireTokenSilentParameters struct {
-	commonParameters *acquireTokenCommonParameters
-	account          AccountProvider
-	requestType      requests.RefreshTokenReqType
-	clientCredential *msalbase.ClientCredential
+// AcquireTokenSilentOptions contains the optional parameters to acquire a token silently (from cache).
+type AcquireTokenSilentOptions struct {
+	// Account specifies the account to use when acquiring a token from the cache.
+	Account *msalbase.Account
 }
 
 // CreateAcquireTokenSilentParameters creates an AcquireTokenSilentParameters instance with an empty account.

--- a/msal/acquire_token_silent_parameters_test.go
+++ b/msal/acquire_token_silent_parameters_test.go
@@ -18,7 +18,7 @@ func TestAugmentAuthenticationParametersSilent(t *testing.T) {
 	testAccount := &msalbase.Account{
 		HomeAccountID: homeAccountID,
 	}
-	testSilentParams := &AcquireTokenSilentParameters{
+	testSilentParams := &acquireTokenSilentParameters{
 		commonParameters: testTokenCommonParams,
 		account:          testAccount,
 	}

--- a/msal/acquire_token_username_password_parameters.go
+++ b/msal/acquire_token_username_password_parameters.go
@@ -6,7 +6,7 @@ package msal
 import "github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
 
 // AcquireTokenUsernamePasswordParameters contains the parameters required to acquire an access token using a username and password.
-type AcquireTokenUsernamePasswordParameters struct {
+type acquireTokenUsernamePasswordParameters struct {
 	commonParameters *acquireTokenCommonParameters
 	username         string
 	password         string
@@ -14,16 +14,15 @@ type AcquireTokenUsernamePasswordParameters struct {
 
 // CreateAcquireTokenUsernamePasswordParameters creates an AcquireTokenUsernamePasswordParameters instance.
 // Pass in the scopes as well as the user's username and password.
-func CreateAcquireTokenUsernamePasswordParameters(scopes []string, username string, password string) *AcquireTokenUsernamePasswordParameters {
-	p := &AcquireTokenUsernamePasswordParameters{
+func createAcquireTokenUsernamePasswordParameters(scopes []string, username string, password string) *acquireTokenUsernamePasswordParameters {
+	return &acquireTokenUsernamePasswordParameters{
 		commonParameters: createAcquireTokenCommonParameters(scopes),
 		username:         username,
 		password:         password,
 	}
-	return p
 }
 
-func (p *AcquireTokenUsernamePasswordParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
+func (p *acquireTokenUsernamePasswordParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
 	p.commonParameters.augmentAuthenticationParameters(authParams)
 	authParams.AuthorizationType = msalbase.AuthorizationTypeUsernamePassword
 	authParams.Username = p.username

--- a/msal/acquire_token_username_password_parameters_test.go
+++ b/msal/acquire_token_username_password_parameters_test.go
@@ -16,7 +16,7 @@ func TestAugmentAuthenticationParametersForUsernamePass(t *testing.T) {
 	testPassword := "testPass"
 	testAuthParams := &msalbase.AuthParametersInternal{}
 	testTokenCommonParams := &acquireTokenCommonParameters{testScopes}
-	tokenUserPassParams := &AcquireTokenUsernamePasswordParameters{
+	tokenUserPassParams := &acquireTokenUsernamePasswordParameters{
 		commonParameters: testTokenCommonParams,
 		username:         testUsername,
 		password:         testPassword,

--- a/msal/authorization_code_url_parameters.go
+++ b/msal/authorization_code_url_parameters.go
@@ -27,18 +27,17 @@ type AuthorizationCodeURLParameters struct {
 
 // CreateAuthorizationCodeURLParameters creates an AuthorizationCodeURLParameters instance. These are the basic required parameters to create this URL.
 // However, if you want other parameters to be in the URL, you can just set the fields of the struct.
-func CreateAuthorizationCodeURLParameters(clientID string, redirectURI string, scopes []string) *AuthorizationCodeURLParameters {
-	p := &AuthorizationCodeURLParameters{
+func CreateAuthorizationCodeURLParameters(clientID string, redirectURI string, scopes []string) AuthorizationCodeURLParameters {
+	return AuthorizationCodeURLParameters{
 		ClientID:     clientID,
 		ResponseType: msalbase.DefaultAuthCodeResponseType,
 		RedirectURI:  redirectURI,
 		Scopes:       scopes,
 	}
-	return p
 }
 
 //createURL creates the URL required to generate an authorization code from the parameters
-func (p *AuthorizationCodeURLParameters) createURL(wrm requests.WebRequestManager, authParams *msalbase.AuthParametersInternal) (string, error) {
+func (p AuthorizationCodeURLParameters) createURL(wrm requests.WebRequestManager, authParams *msalbase.AuthParametersInternal) (string, error) {
 	resolutionManager := requests.CreateAuthorityEndpointResolutionManager(wrm)
 	endpoints, err := resolutionManager.ResolveEndpoints(authParams.AuthorityInfo, "")
 	if err != nil {
@@ -78,6 +77,6 @@ func (p *AuthorizationCodeURLParameters) createURL(wrm requests.WebRequestManage
 	return baseURL.String(), nil
 }
 
-func (p *AuthorizationCodeURLParameters) getSeparatedScopes() string {
+func (p AuthorizationCodeURLParameters) getSeparatedScopes() string {
 	return msalbase.ConcatenateScopes(p.Scopes)
 }

--- a/msal/client_application.go
+++ b/msal/client_application.go
@@ -36,12 +36,11 @@ func createClientApplication(clientID string, authority string) *clientApplicati
 	return client
 }
 
-func (client *clientApplication) createAuthCodeURL(authCodeURLParameters *AuthorizationCodeURLParameters) (string, error) {
+func (client *clientApplication) createAuthCodeURL(authCodeURLParameters AuthorizationCodeURLParameters) (string, error) {
 	return authCodeURLParameters.createURL(client.webRequestManager, client.clientApplicationParameters.createAuthenticationParameters())
 }
 
-func (client *clientApplication) acquireTokenSilent(
-	silentParameters *AcquireTokenSilentParameters) (AuthenticationResultProvider, error) {
+func (client *clientApplication) acquireTokenSilent(silentParameters *acquireTokenSilentParameters) (*msalbase.AuthenticationResult, error) {
 	authParams := client.clientApplicationParameters.createAuthenticationParameters()
 	silentParameters.augmentAuthenticationParameters(authParams)
 	if client.cacheAccessor != nil {
@@ -73,8 +72,7 @@ func (client *clientApplication) acquireTokenSilent(
 	return nil, errors.New("no cache entry found")
 }
 
-func (client *clientApplication) acquireTokenByAuthCode(
-	authCodeParams *AcquireTokenAuthCodeParameters) (AuthenticationResultProvider, error) {
+func (client *clientApplication) acquireTokenByAuthCode(authCodeParams *acquireTokenAuthCodeParameters) (*msalbase.AuthenticationResult, error) {
 	authParams := client.clientApplicationParameters.createAuthenticationParameters()
 	authCodeParams.augmentAuthenticationParameters(authParams)
 	req := requests.CreateAuthCodeRequest(client.webRequestManager, authParams, authCodeParams.requestType)
@@ -96,9 +94,7 @@ func (client *clientApplication) executeTokenRequestWithoutCacheWrite(
 	return msalbase.CreateAuthenticationResult(tokenResponse, nil)
 }
 
-func (client *clientApplication) executeTokenRequestWithCacheWrite(
-	req requests.TokenRequester,
-	authParams *msalbase.AuthParametersInternal) (AuthenticationResultProvider, error) {
+func (client *clientApplication) executeTokenRequestWithCacheWrite(req requests.TokenRequester, authParams *msalbase.AuthParametersInternal) (*msalbase.AuthenticationResult, error) {
 	tokenResponse, err := req.Execute()
 	if err != nil {
 		return nil, err

--- a/msal/client_application.go
+++ b/msal/client_application.go
@@ -114,8 +114,7 @@ func (client *clientApplication) executeTokenRequestWithCacheWrite(
 	return msalbase.CreateAuthenticationResult(tokenResponse, account)
 }
 
-func (client *clientApplication) getAccounts() []AccountProvider {
-	returnedAccounts := []AccountProvider{}
+func (client *clientApplication) getAccounts() []*msalbase.Account {
 	if client.cacheAccessor != nil {
 		client.cacheAccessor.BeforeCacheAccess(client.cacheContext)
 	}
@@ -123,8 +122,5 @@ func (client *clientApplication) getAccounts() []AccountProvider {
 	if client.cacheAccessor != nil {
 		client.cacheAccessor.AfterCacheAccess(client.cacheContext)
 	}
-	for _, acc := range accounts {
-		returnedAccounts = append(returnedAccounts, acc)
-	}
-	return returnedAccounts
+	return accounts
 }

--- a/msal/client_application_test.go
+++ b/msal/client_application_test.go
@@ -31,7 +31,7 @@ var (
 
 func TestAcquireTokenSilent(t *testing.T) {
 	account := &msalbase.Account{}
-	silentParams := &AcquireTokenSilentParameters{
+	silentParams := &acquireTokenSilentParameters{
 		commonParameters: tokenCommonParams,
 		account:          account,
 	}

--- a/msal/confidential_client_application.go
+++ b/msal/confidential_client_application.go
@@ -19,13 +19,13 @@ type ConfidentialClientApplicationOptions struct {
 
 	// Client sets the transport for making HTTP requests.
 	// Leave this as nil to use the default HTTP transport.
-	Client HTTPClient
+	HTTPClient HTTPClient
 }
 
 // DefaultConfidentialClientApplicationOptions returns an instance of ConfidentialClientApplicationOptions initialized with default values.
 func DefaultConfidentialClientApplicationOptions() ConfidentialClientApplicationOptions {
 	return ConfidentialClientApplicationOptions{
-		Client: http.DefaultClient,
+		HTTPClient: http.DefaultClient,
 	}
 }
 

--- a/msal/confidential_client_application.go
+++ b/msal/confidential_client_application.go
@@ -17,6 +17,9 @@ type ConfidentialClientApplicationOptions struct {
 	// By default there is no cache persistence.
 	Accessor CacheAccessor
 
+	// The host of the Azure Active Directory authority. The default is https://login.microsoftonline.com/common.
+	Authority string
+
 	// Client sets the transport for making HTTP requests.
 	// Leave this as nil to use the default HTTP transport.
 	HTTPClient HTTPClient
@@ -25,6 +28,7 @@ type ConfidentialClientApplicationOptions struct {
 // DefaultConfidentialClientApplicationOptions returns an instance of ConfidentialClientApplicationOptions initialized with default values.
 func DefaultConfidentialClientApplicationOptions() ConfidentialClientApplicationOptions {
 	return ConfidentialClientApplicationOptions{
+		Authority:  authorityPublicCloud,
 		HTTPClient: http.DefaultClient,
 	}
 }
@@ -41,12 +45,16 @@ type ConfidentialClientApplication struct {
 // NewConfidentialClientApplication creates a ConfidentialClientApplication instance given a client ID, authority URL and client credential.
 // Pass nil for options to accept the default values; this is the same as passing the result
 // from a call to DefaultConfidentialClientApplicationOptions().
-func NewConfidentialClientApplication(clientID string, authority string, clientCredential ClientCredentialProvider, options *ConfidentialClientApplicationOptions) (*ConfidentialClientApplication, error) {
+func NewConfidentialClientApplication(clientID string, clientCredential ClientCredentialProvider, options *ConfidentialClientApplicationOptions) (*ConfidentialClientApplication, error) {
 	cred, err := createInternalClientCredential(clientCredential)
 	if err != nil {
 		return nil, err
 	}
-	clientApp := createClientApplication(clientID, authority)
+	if options == nil {
+		def := DefaultConfidentialClientApplicationOptions()
+		options = &def
+	}
+	clientApp := createClientApplication(clientID, options.Authority)
 	return &ConfidentialClientApplication{
 		clientApplication: clientApp,
 		clientCredential:  cred,

--- a/msal/confidential_client_application.go
+++ b/msal/confidential_client_application.go
@@ -4,9 +4,30 @@
 package msal
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/requests"
 )
+
+// ConfidentialClientApplicationOptions configures the PublicClientApplication's behavior.
+type ConfidentialClientApplicationOptions struct {
+	// Accessor controls cache persistence.
+	// By default there is no cache persistence.
+	Accessor CacheAccessor
+
+	// Client sets the transport for making HTTP requests.
+	// Leave this as nil to use the default HTTP transport.
+	Client HTTPClient
+}
+
+// DefaultConfidentialClientApplicationOptions returns an instance of ConfidentialClientApplicationOptions initialized with default values.
+func DefaultConfidentialClientApplicationOptions() ConfidentialClientApplicationOptions {
+	return ConfidentialClientApplicationOptions{
+		Client: http.DefaultClient,
+	}
+}
 
 // ConfidentialClientApplication is a representation of confidential client applications.
 // These are apps that run on servers (web apps, web API apps, or even service/daemon apps),
@@ -17,10 +38,10 @@ type ConfidentialClientApplication struct {
 	clientCredential  *msalbase.ClientCredential
 }
 
-// CreateConfidentialClientApplication creates a ConfidentialClientApplication instance given a client ID, authority URL and client credential.
-func CreateConfidentialClientApplication(
-	clientID string, authority string, clientCredential ClientCredentialProvider,
-) (*ConfidentialClientApplication, error) {
+// NewConfidentialClientApplication creates a ConfidentialClientApplication instance given a client ID, authority URL and client credential.
+// Pass nil for options to accept the default values; this is the same as passing the result
+// from a call to DefaultConfidentialClientApplicationOptions().
+func NewConfidentialClientApplication(clientID string, authority string, clientCredential ClientCredentialProvider, options *ConfidentialClientApplicationOptions) (*ConfidentialClientApplication, error) {
 	cred, err := createInternalClientCredential(clientCredential)
 	if err != nil {
 		return nil, err
@@ -45,52 +66,48 @@ func createInternalClientCredential(interfaceCred ClientCredentialProvider) (*ms
 	return msalbase.CreateClientCredentialFromAssertion(interfaceCred.GetAssertion().ClientAssertionJWT)
 }
 
-// SetHTTPManager allows users to use their own implementation of HTTPManager.
-func (cca *ConfidentialClientApplication) SetHTTPManager(httpManager HTTPManager) {
-	webRequestManager := createWebRequestManager(httpManager)
-	cca.clientApplication.webRequestManager = webRequestManager
-}
-
-// SetCacheAccessor allows users to use an implementation of CacheAccessor to handle cache persistence.
-func (cca *ConfidentialClientApplication) SetCacheAccessor(accessor CacheAccessor) {
-	cca.clientApplication.cacheAccessor = accessor
-}
-
 // CreateAuthCodeURL creates a URL used to acquire an authorization code. Users need to call CreateAuthorizationCodeURLParameters and pass it in.
-func (cca *ConfidentialClientApplication) CreateAuthCodeURL(authCodeURLParameters *AuthorizationCodeURLParameters) (string, error) {
+func (cca *ConfidentialClientApplication) CreateAuthCodeURL(authCodeURLParameters AuthorizationCodeURLParameters) (string, error) {
 	return cca.clientApplication.createAuthCodeURL(authCodeURLParameters)
 }
 
 // AcquireTokenSilent acquires a token from either the cache or using a refresh token
 // Users need to create an AcquireTokenSilentParameters instance and pass it in.
-func (cca *ConfidentialClientApplication) AcquireTokenSilent(
-	silentParameters *AcquireTokenSilentParameters) (AuthenticationResultProvider, error) {
+func (cca *ConfidentialClientApplication) AcquireTokenSilent(ctx context.Context, scopes []string, options *AcquireTokenSilentOptions) (*msalbase.AuthenticationResult, error) {
+	silentParameters := createAcquireTokenSilentParameters(scopes)
 	silentParameters.requestType = requests.RefreshTokenConfidential
 	silentParameters.clientCredential = cca.clientCredential
+	if options != nil {
+		silentParameters.account = options.Account
+	}
 	return cca.clientApplication.acquireTokenSilent(silentParameters)
 }
 
 // AcquireTokenByAuthCode is a request to acquire a security token from the authority, using an authorization code.
 // Users need to create an AcquireTokenAuthCodeParameters instance and pass it in.
-func (cca *ConfidentialClientApplication) AcquireTokenByAuthCode(
-	authCodeParams *AcquireTokenAuthCodeParameters) (AuthenticationResultProvider, error) {
+func (cca *ConfidentialClientApplication) AcquireTokenByAuthCode(ctx context.Context, scopes []string, redirectURI string, options *AcquireTokenByAuthCodeOptions) (*msalbase.AuthenticationResult, error) {
+	authCodeParams := createAcquireTokenAuthCodeParameters(scopes, redirectURI)
 	authCodeParams.requestType = requests.AuthCodeConfidential
 	authCodeParams.clientCredential = cca.clientCredential
+	if options != nil {
+		authCodeParams.Code = options.Code
+		authCodeParams.CodeChallenge = options.CodeChallenge
+	}
 	return cca.clientApplication.acquireTokenByAuthCode(authCodeParams)
 
 }
 
 // AcquireTokenByClientCredential acquires a security token from the authority, using the client credentials grant.
 // Users need to create an AcquireTokenClientCredentialParameters instance and pass it in.
-func (cca *ConfidentialClientApplication) AcquireTokenByClientCredential(
-	clientCredParams *AcquireTokenClientCredentialParameters) (AuthenticationResultProvider, error) {
+func (cca *ConfidentialClientApplication) AcquireTokenByClientCredential(ctx context.Context, scopes []string) (*msalbase.AuthenticationResult, error) {
 	authParams := cca.clientApplication.clientApplicationParameters.createAuthenticationParameters()
+	clientCredParams := createAcquireTokenClientCredentialParameters(scopes)
 	clientCredParams.augmentAuthenticationParameters(authParams)
 	req := requests.CreateClientCredentialRequest(cca.clientApplication.webRequestManager, authParams, cca.clientCredential)
 	return cca.clientApplication.executeTokenRequestWithCacheWrite(req, authParams)
 }
 
-// GetAccounts gets all the accounts in the token cache.
-func (cca *ConfidentialClientApplication) GetAccounts() []AccountProvider {
+// Accounts gets all the accounts in the token cache.
+func (cca *ConfidentialClientApplication) Accounts() []*msalbase.Account {
 	return cca.clientApplication.getAccounts()
 }

--- a/msal/confidential_client_application.go
+++ b/msal/confidential_client_application.go
@@ -93,8 +93,8 @@ func (cca *ConfidentialClientApplication) AcquireTokenSilent(ctx context.Context
 
 // AcquireTokenByAuthCode is a request to acquire a security token from the authority, using an authorization code.
 // Users need to create an AcquireTokenAuthCodeParameters instance and pass it in.
-func (cca *ConfidentialClientApplication) AcquireTokenByAuthCode(ctx context.Context, scopes []string, redirectURI string, options *AcquireTokenByAuthCodeOptions) (*msalbase.AuthenticationResult, error) {
-	authCodeParams := createAcquireTokenAuthCodeParameters(scopes, redirectURI)
+func (cca *ConfidentialClientApplication) AcquireTokenByAuthCode(ctx context.Context, scopes []string, options *AcquireTokenByAuthCodeOptions) (*msalbase.AuthenticationResult, error) {
+	authCodeParams := createAcquireTokenAuthCodeParameters(scopes)
 	authCodeParams.requestType = requests.AuthCodeConfidential
 	authCodeParams.clientCredential = cca.clientCredential
 	if options != nil {

--- a/msal/confidential_client_application_test.go
+++ b/msal/confidential_client_application_test.go
@@ -4,6 +4,7 @@
 package msal
 
 import (
+	"context"
 	"testing"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
@@ -28,8 +29,7 @@ func TestAcquireTokenByClientCredential(t *testing.T) {
 	actualTokenResp := &msalbase.TokenResponse{}
 	testWrm.On("GetAccessTokenWithClientSecret", mock.AnythingOfType("*msalbase.AuthParametersInternal"), "client_secret").Return(actualTokenResp, nil)
 	testCacheManager.On("CacheTokenResponse", mock.AnythingOfType("*msalbase.AuthParametersInternal"), actualTokenResp).Return(testAcc, nil)
-	clientCredParams := &AcquireTokenClientCredentialParameters{tokenCommonParams}
-	_, err := cca.AcquireTokenByClientCredential(clientCredParams)
+	_, err := cca.AcquireTokenByClientCredential(context.Background(), []string{"openid"})
 	if err != nil {
 		t.Errorf("Error should be nil, but it is %v", err)
 	}

--- a/msal/msal.go
+++ b/msal/msal.go
@@ -10,3 +10,8 @@ import "net/http"
 type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }
+
+const (
+	// default AAD authority host
+	authorityPublicCloud = "https://login.microsoftonline.com/common"
+)

--- a/msal/msal.go
+++ b/msal/msal.go
@@ -3,3 +3,10 @@
 
 // Package msal provides the Microsoft Authentication Library (MSAL) for the Go language.
 package msal
+
+import "net/http"
+
+// HTTPClient represents an HTTP transport used to send HTTP requests and receive responses.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}

--- a/msal/public_client_application.go
+++ b/msal/public_client_application.go
@@ -19,13 +19,13 @@ type PublicClientApplicationOptions struct {
 
 	// Client sets the transport for making HTTP requests.
 	// Leave this as nil to use the default HTTP transport.
-	Client HTTPClient
+	HTTPClient HTTPClient
 }
 
 // DefaultPublicClientApplicationOptions returns an instance of PublicClientApplicationOptions initialized with default values.
 func DefaultPublicClientApplicationOptions() PublicClientApplicationOptions {
 	return PublicClientApplicationOptions{
-		Client: http.DefaultClient,
+		HTTPClient: http.DefaultClient,
 	}
 }
 

--- a/msal/public_client_application.go
+++ b/msal/public_client_application.go
@@ -93,8 +93,8 @@ func (pca *PublicClientApplication) AcquireTokenByDeviceCode(ctx context.Context
 
 // AcquireTokenByAuthCode is a request to acquire a security token from the authority, using an authorization code.
 // Users need to create an AcquireTokenAuthCodeParameters instance and pass it in.
-func (pca *PublicClientApplication) AcquireTokenByAuthCode(ctx context.Context, scopes []string, redirectURI string, options *AcquireTokenByAuthCodeOptions) (*msalbase.AuthenticationResult, error) {
-	authCodeParams := createAcquireTokenAuthCodeParameters(scopes, redirectURI)
+func (pca *PublicClientApplication) AcquireTokenByAuthCode(ctx context.Context, scopes []string, options *AcquireTokenByAuthCodeOptions) (*msalbase.AuthenticationResult, error) {
+	authCodeParams := createAcquireTokenAuthCodeParameters(scopes)
 	authCodeParams.requestType = requests.AuthCodePublic
 	if options != nil {
 		authCodeParams.Code = options.Code

--- a/msal/public_client_application.go
+++ b/msal/public_client_application.go
@@ -11,13 +11,6 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/requests"
 )
 
-// PublicClientApplication is a representation of public client applications.
-// These are apps that run on devices or desktop computers or in a web browser and are not trusted to safely keep application secrets.
-// For more information, visit https://docs.microsoft.com/azure/active-directory/develop/msal-client-applications.
-type PublicClientApplication struct {
-	clientApplication *clientApplication
-}
-
 // PublicClientApplicationOptions configures the PublicClientApplication's behavior.
 type PublicClientApplicationOptions struct {
 	// Accessor controls cache persistence.
@@ -36,6 +29,13 @@ func DefaultPublicClientApplicationOptions() PublicClientApplicationOptions {
 	}
 }
 
+// PublicClientApplication is a representation of public client applications.
+// These are apps that run on devices or desktop computers or in a web browser and are not trusted to safely keep application secrets.
+// For more information, visit https://docs.microsoft.com/azure/active-directory/develop/msal-client-applications.
+type PublicClientApplication struct {
+	clientApplication *clientApplication
+}
+
 // NewPublicClientApplication creates a PublicClientApplication instance given a client ID and authority URL.
 // Pass nil for options to accept the default values; this is the same as passing the result
 // from a call to DefaultPublicClientApplicationOptions().
@@ -47,24 +47,27 @@ func NewPublicClientApplication(clientID string, authority string, options *Publ
 }
 
 // CreateAuthCodeURL creates a URL used to acquire an authorization code. Users need to call CreateAuthorizationCodeURLParameters and pass it in.
-func (pca *PublicClientApplication) CreateAuthCodeURL(authCodeURLParameters *AuthorizationCodeURLParameters) (string, error) {
+func (pca *PublicClientApplication) CreateAuthCodeURL(authCodeURLParameters AuthorizationCodeURLParameters) (string, error) {
 	return pca.clientApplication.createAuthCodeURL(authCodeURLParameters)
 }
 
 // AcquireTokenSilent acquires a token from either the cache or using a refresh token
 // Users need to create an AcquireTokenSilentParameters instance and pass it in.
 func (pca *PublicClientApplication) AcquireTokenSilent(ctx context.Context, scopes []string, options *AcquireTokenSilentOptions) (*msalbase.AuthenticationResult, error) {
+	silentParameters := createAcquireTokenSilentParameters(scopes)
 	silentParameters.requestType = requests.RefreshTokenPublic
+	if options != nil {
+		silentParameters.account = options.Account
+	}
 	return pca.clientApplication.acquireTokenSilent(silentParameters)
 }
 
 // AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
 // Users need to create an AcquireTokenUsernamePasswordParameters instance and pass it in.
 // NOTE: this flow is NOT recommended.
-func (pca *PublicClientApplication) AcquireTokenByUsernamePassword(
-	ctx context.Context,
-	usernamePasswordParameters *AcquireTokenUsernamePasswordParameters) (*msalbase.AuthenticationResult, error) {
+func (pca *PublicClientApplication) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (*msalbase.AuthenticationResult, error) {
 	authParams := pca.clientApplication.clientApplicationParameters.createAuthenticationParameters()
+	usernamePasswordParameters := createAcquireTokenUsernamePasswordParameters(scopes, username, password)
 	usernamePasswordParameters.augmentAuthenticationParameters(authParams)
 	req := requests.CreateUsernamePasswordRequest(pca.clientApplication.webRequestManager, authParams)
 	return pca.clientApplication.executeTokenRequestWithCacheWrite(req, authParams)
@@ -72,7 +75,8 @@ func (pca *PublicClientApplication) AcquireTokenByUsernamePassword(
 
 // AcquireTokenByDeviceCode acquires a security token from the authority, by acquiring a device code and using that to acquire the token.
 // Users need to create an AcquireTokenDeviceCodeParameters instance and pass it in.
-func (pca *PublicClientApplication) AcquireTokenByDeviceCode(ctx context.Context, scopes []string, callback func(DeviceCodeResultProvider), options *AcquireTokenDeviceCodeOptions) (*msalbase.AuthenticationResult, error) {
+func (pca *PublicClientApplication) AcquireTokenByDeviceCode(ctx context.Context, scopes []string, callback func(DeviceCodeResultProvider), options *AcquireTokenByDeviceCodeOptions) (*msalbase.AuthenticationResult, error) {
+	deviceCodeParameters := createAcquireTokenDeviceCodeParameters(ctx, scopes, callback)
 	authParams := pca.clientApplication.clientApplicationParameters.createAuthenticationParameters()
 	deviceCodeParameters.augmentAuthenticationParameters(authParams)
 	req := createDeviceCodeRequest(deviceCodeParameters.cancelCtx, pca.clientApplication.webRequestManager, authParams, deviceCodeParameters.deviceCodeCallback)
@@ -81,10 +85,13 @@ func (pca *PublicClientApplication) AcquireTokenByDeviceCode(ctx context.Context
 
 // AcquireTokenByAuthCode is a request to acquire a security token from the authority, using an authorization code.
 // Users need to create an AcquireTokenAuthCodeParameters instance and pass it in.
-func (pca *PublicClientApplication) AcquireTokenByAuthCode(
-	ctx context.Context,
-	authCodeParams *AcquireTokenAuthCodeParameters) (*msalbase.AuthenticationResult, error) {
+func (pca *PublicClientApplication) AcquireTokenByAuthCode(ctx context.Context, scopes []string, redirectURI string, options *AcquireTokenByAuthCodeOptions) (*msalbase.AuthenticationResult, error) {
+	authCodeParams := createAcquireTokenAuthCodeParameters(scopes, redirectURI)
 	authCodeParams.requestType = requests.AuthCodePublic
+	if options != nil {
+		authCodeParams.Code = options.Code
+		authCodeParams.CodeChallenge = options.CodeChallenge
+	}
 	return pca.clientApplication.acquireTokenByAuthCode(authCodeParams)
 }
 
@@ -92,4 +99,21 @@ func (pca *PublicClientApplication) AcquireTokenByAuthCode(
 // If there are no accounts in the cache the returned slice is empty.
 func (pca *PublicClientApplication) Accounts() []*msalbase.Account {
 	return pca.clientApplication.getAccounts()
+}
+
+// AcquireTokenSilentOptions contains the optional parameters to acquire a token silently (from cache).
+type AcquireTokenSilentOptions struct {
+	// Account specifies the account to use when acquiring a token from the cache.
+	Account *msalbase.Account
+}
+
+// AcquireTokenByDeviceCodeOptions contains the optional parameters used to acquire an access token using the device code flow.
+type AcquireTokenByDeviceCodeOptions struct {
+	// placeholder for future optional args
+}
+
+// AcquireTokenByAuthCodeOptions contains the optional parameters used to acquire an access token using the authorization code flow.
+type AcquireTokenByAuthCodeOptions struct {
+	Code          string
+	CodeChallenge string
 }

--- a/msal/public_client_application.go
+++ b/msal/public_client_application.go
@@ -17,6 +17,9 @@ type PublicClientApplicationOptions struct {
 	// By default there is no cache persistence.
 	Accessor CacheAccessor
 
+	// The host of the Azure Active Directory authority. The default is https://login.microsoftonline.com/common.
+	Authority string
+
 	// Client sets the transport for making HTTP requests.
 	// Leave this as nil to use the default HTTP transport.
 	HTTPClient HTTPClient
@@ -25,6 +28,7 @@ type PublicClientApplicationOptions struct {
 // DefaultPublicClientApplicationOptions returns an instance of PublicClientApplicationOptions initialized with default values.
 func DefaultPublicClientApplicationOptions() PublicClientApplicationOptions {
 	return PublicClientApplicationOptions{
+		Authority:  authorityPublicCloud,
 		HTTPClient: http.DefaultClient,
 	}
 }
@@ -39,8 +43,12 @@ type PublicClientApplication struct {
 // NewPublicClientApplication creates a PublicClientApplication instance given a client ID and authority URL.
 // Pass nil for options to accept the default values; this is the same as passing the result
 // from a call to DefaultPublicClientApplicationOptions().
-func NewPublicClientApplication(clientID string, authority string, options *PublicClientApplicationOptions) *PublicClientApplication {
-	clientApp := createClientApplication(clientID, authority)
+func NewPublicClientApplication(clientID string, options *PublicClientApplicationOptions) *PublicClientApplication {
+	if options == nil {
+		def := DefaultPublicClientApplicationOptions()
+		options = &def
+	}
+	clientApp := createClientApplication(clientID, options.Authority)
 	return &PublicClientApplication{
 		clientApplication: clientApp,
 	}

--- a/msal/public_client_application_test.go
+++ b/msal/public_client_application_test.go
@@ -56,7 +56,7 @@ func TestAcquireTokenByAuthCode(t *testing.T) {
 	actualTokenResp := &msalbase.TokenResponse{}
 	wrm.On("GetAccessTokenFromAuthCode", mock.AnythingOfType("*msalbase.AuthParametersInternal"), "", "", make(map[string]string)).Return(actualTokenResp, nil)
 	cacheManager.On("CacheTokenResponse", mock.AnythingOfType("*msalbase.AuthParametersInternal"), actualTokenResp).Return(testAcc, nil)
-	_, err := testPCA.AcquireTokenByAuthCode(context.Background(), []string{"openid"}, "", nil)
+	_, err := testPCA.AcquireTokenByAuthCode(context.Background(), []string{"openid"}, nil)
 	if err != nil {
 		t.Errorf("Error should be nil, instead it is %v", err)
 	}

--- a/test/devapps/authorization_code_sample.go
+++ b/test/devapps/authorization_code_sample.go
@@ -42,7 +42,7 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 	}
 	code := codes[0]
 	// Getting the access token using the authorization code
-	result, err := publicClientApp.AcquireTokenByAuthCode(context.Background(), config.Scopes, config.RedirectURI, &msal.AcquireTokenByAuthCodeOptions{
+	result, err := publicClientApp.AcquireTokenByAuthCode(context.Background(), config.Scopes, &msal.AcquireTokenByAuthCodeOptions{
 		Code:          code,
 		CodeChallenge: config.CodeChallenge,
 	})

--- a/test/devapps/authorization_code_sample.go
+++ b/test/devapps/authorization_code_sample.go
@@ -54,7 +54,9 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 }
 
 func acquireByAuthorizationCodePublic() {
-	publicClientApp = msal.NewPublicClientApplication(config.ClientID, config.Authority, nil)
+	options := msal.DefaultPublicClientApplicationOptions()
+	options.Authority = config.Authority
+	publicClientApp = msal.NewPublicClientApplication(config.ClientID, &options)
 	http.HandleFunc("/", redirectToURL)
 	// The redirect uri set in our app's registration is http://localhost:port/redirect
 	http.HandleFunc("/redirect", getToken)

--- a/test/devapps/authorization_code_sample.go
+++ b/test/devapps/authorization_code_sample.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -41,10 +42,10 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 	}
 	code := codes[0]
 	// Getting the access token using the authorization code
-	authCodeParams := msal.CreateAcquireTokenAuthCodeParameters(config.Scopes, config.RedirectURI)
-	authCodeParams.Code = code
-	authCodeParams.CodeChallenge = config.CodeChallenge
-	result, err := publicClientApp.AcquireTokenByAuthCode(authCodeParams)
+	result, err := publicClientApp.AcquireTokenByAuthCode(context.Background(), config.Scopes, config.RedirectURI, &msal.AcquireTokenByAuthCodeOptions{
+		Code:          code,
+		CodeChallenge: config.CodeChallenge,
+	})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -53,10 +54,7 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 }
 
 func acquireByAuthorizationCodePublic() {
-	publicClientApp, err = msal.CreatePublicClientApplication(config.ClientID, config.Authority)
-	if err != nil {
-		log.Fatal(err)
-	}
+	publicClientApp = msal.NewPublicClientApplication(config.ClientID, config.Authority, nil)
 	http.HandleFunc("/", redirectToURL)
 	// The redirect uri set in our app's registration is http://localhost:port/redirect
 	http.HandleFunc("/redirect", getToken)

--- a/test/devapps/client_certificate_sample.go
+++ b/test/devapps/client_certificate_sample.go
@@ -37,7 +37,8 @@ func acquireTokenClientCertificate() {
 	}
 	options := msal.DefaultConfidentialClientApplicationOptions()
 	options.Accessor = cacheAccessor
-	confidentialClientApp, err := msal.NewConfidentialClientApplication(confidentialConfig.ClientID, confidentialConfig.Authority, certificate, &options)
+	options.Authority = confidentialConfig.Authority
+	confidentialClientApp, err := msal.NewConfidentialClientApplication(confidentialConfig.ClientID, certificate, &options)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/devapps/client_certificate_sample.go
+++ b/test/devapps/client_certificate_sample.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,9 +14,7 @@ import (
 )
 
 func tryClientCertificateFlow(confidentialClientApp *msal.ConfidentialClientApplication) {
-	certificateParams := msal.CreateAcquireTokenClientCredentialParameters(
-		confidentialConfig.Scopes)
-	result, err := confidentialClientApp.AcquireTokenByClientCredential(certificateParams)
+	result, err := confidentialClientApp.AcquireTokenByClientCredential(context.Background(), confidentialConfig.Scopes)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -36,14 +35,13 @@ func acquireTokenClientCertificate() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	confidentialClientApp, err := msal.CreateConfidentialClientApplication(
-		confidentialConfig.ClientID, confidentialConfig.Authority, certificate)
+	options := msal.DefaultConfidentialClientApplicationOptions()
+	options.Accessor = cacheAccessor
+	confidentialClientApp, err := msal.NewConfidentialClientApplication(confidentialConfig.ClientID, confidentialConfig.Authority, certificate, &options)
 	if err != nil {
 		log.Fatal(err)
 	}
-	confidentialClientApp.SetCacheAccessor(cacheAccessor)
-	silentParams := msal.CreateAcquireTokenSilentParameters(confidentialConfig.Scopes)
-	result, err := confidentialClientApp.AcquireTokenSilent(silentParams)
+	result, err := confidentialClientApp.AcquireTokenSilent(context.Background(), confidentialConfig.Scopes, nil)
 	if err != nil {
 		log.Info(err)
 		tryClientCertificateFlow(confidentialClientApp)

--- a/test/devapps/client_secret_sample.go
+++ b/test/devapps/client_secret_sample.go
@@ -4,14 +4,15 @@
 package main
 
 import (
+	"context"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/msal"
 )
 
 func tryClientSecretFlow(confidentialClientApp *msal.ConfidentialClientApplication) {
-	clientSecretParams := msal.CreateAcquireTokenClientCredentialParameters(confidentialConfig.Scopes)
-	result, err := confidentialClientApp.AcquireTokenByClientCredential(clientSecretParams)
+	result, err := confidentialClientApp.AcquireTokenByClientCredential(context.Background(), confidentialConfig.Scopes)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -24,14 +25,13 @@ func acquireTokenClientSecret() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	confidentialClientApp, err := msal.CreateConfidentialClientApplication(
-		confidentialConfig.ClientID, confidentialConfig.Authority, secret)
+	options := msal.DefaultConfidentialClientApplicationOptions()
+	options.Accessor = cacheAccessor
+	confidentialClientApp, err := msal.NewConfidentialClientApplication(confidentialConfig.ClientID, confidentialConfig.Authority, secret, &options)
 	if err != nil {
 		log.Fatal(err)
 	}
-	confidentialClientApp.SetCacheAccessor(cacheAccessor)
-	silentParams := msal.CreateAcquireTokenSilentParameters(confidentialConfig.Scopes)
-	result, err := confidentialClientApp.AcquireTokenSilent(silentParams)
+	result, err := confidentialClientApp.AcquireTokenSilent(context.Background(), confidentialConfig.Scopes, nil)
 	if err != nil {
 		log.Info(err)
 		tryClientSecretFlow(confidentialClientApp)

--- a/test/devapps/client_secret_sample.go
+++ b/test/devapps/client_secret_sample.go
@@ -27,7 +27,8 @@ func acquireTokenClientSecret() {
 	}
 	options := msal.DefaultConfidentialClientApplicationOptions()
 	options.Accessor = cacheAccessor
-	confidentialClientApp, err := msal.NewConfidentialClientApplication(confidentialConfig.ClientID, confidentialConfig.Authority, secret, &options)
+	options.Authority = confidentialConfig.Authority
+	confidentialClientApp, err := msal.NewConfidentialClientApplication(confidentialConfig.ClientID, secret, &options)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/devapps/confidential_auth_code_sample.go
+++ b/test/devapps/confidential_auth_code_sample.go
@@ -83,7 +83,8 @@ func acquireByAuthorizationCodeConfidential() {
 	}
 	options := msal.DefaultConfidentialClientApplicationOptions()
 	options.Accessor = cacheAccessor
-	confidentialClientAuthCode, err = msal.NewConfidentialClientApplication(confidentialConfig.ClientID, confidentialConfig.Authority, certificate, &options)
+	options.Authority = confidentialConfig.Authority
+	confidentialClientAuthCode, err = msal.NewConfidentialClientApplication(confidentialConfig.ClientID, certificate, &options)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/devapps/confidential_auth_code_sample.go
+++ b/test/devapps/confidential_auth_code_sample.go
@@ -55,7 +55,7 @@ func getTokenConfidential(w http.ResponseWriter, r *http.Request) {
 	}
 	code := codes[0]
 	// Getting the access token using the authorization code
-	result, err := confidentialClientAuthCode.AcquireTokenByAuthCode(context.Background(), confidentialConfig.Scopes, confidentialConfig.RedirectURI, &msal.AcquireTokenByAuthCodeOptions{
+	result, err := confidentialClientAuthCode.AcquireTokenByAuthCode(context.Background(), confidentialConfig.Scopes, &msal.AcquireTokenByAuthCodeOptions{
 		Code:          code,
 		CodeChallenge: confidentialConfig.CodeChallenge,
 	})

--- a/test/devapps/device_code_flow_sample.go
+++ b/test/devapps/device_code_flow_sample.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/msal"
 	log "github.com/sirupsen/logrus"
 )
@@ -16,51 +17,45 @@ func deviceCodeCallback(deviceCodeResult msal.DeviceCodeResultProvider) {
 	log.Infof(deviceCodeResult.GetMessage())
 }
 
-func tryDeviceCodeFlow(publicClientApp *msal.PublicClientApplication) {
-	cancelTimeout := 100 //Change this for cancel timeout
-	cancelCtx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(cancelTimeout)*time.Second)
-	defer cancelFunc()
-	deviceCodeParams := msal.CreateAcquireTokenDeviceCodeParameters(cancelCtx, config.Scopes, deviceCodeCallback)
-	resultChannel := make(chan msal.AuthenticationResultProvider)
-	errChannel := make(chan error)
-	go func() {
-		result, err := publicClientApp.AcquireTokenByDeviceCode(deviceCodeParams)
-		errChannel <- err
-		resultChannel <- result
-	}()
-	err = <-errChannel
-	if err != nil {
-		log.Fatal(err)
-	}
-	result := <-resultChannel
-	fmt.Println("Access token is " + result.GetAccessToken())
-}
-
 func acquireTokenDeviceCode() {
 	config := createConfig("config.json")
-	publicClientApp, err := msal.CreatePublicClientApplication(config.ClientID, config.Authority)
-	if err != nil {
-		log.Fatal(err)
-	}
-	publicClientApp.SetCacheAccessor(cacheAccessor)
-	var userAccount msal.AccountProvider
-	accounts := publicClientApp.GetAccounts()
+	// create a PublicClientApplication with a  custom cache accessor
+	options := msal.DefaultPublicClientApplicationOptions()
+	options.Accessor = cacheAccessor
+	publicClientApp := msal.NewPublicClientApplication(config.ClientID, config.Authority, &options)
+
+	// look in the cache to see if the account to use has been cached
+	var userAccount *msalbase.Account
+	accounts := publicClientApp.Accounts()
 	for _, account := range accounts {
-		if account.GetUsername() == config.Username {
+		if account.PreferredUsername == config.Username {
 			userAccount = account
 		}
 	}
-	if userAccount == nil {
-		log.Info("No valid account found")
-		tryDeviceCodeFlow(publicClientApp)
-	} else {
-		silentParams := msal.CreateAcquireTokenSilentParametersWithAccount(config.Scopes, userAccount)
-		result, err := publicClientApp.AcquireTokenSilent(silentParams)
+	var result *msalbase.AuthenticationResult
+	var err error
+	if userAccount != nil {
+		// found a cached account, now see if an applicable token has been cached
+		// NOTE: this API conflates error states, i.e. err is non-nil if an applicable token isn't
+		//       cached or if something goes wrong (making the HTTP request, unmarshalling, etc).
+		result, err = publicClientApp.AcquireTokenSilent(context.Background(), config.Scopes, &msal.AcquireTokenSilentOptions{
+			Account: userAccount,
+		})
 		if err != nil {
+			// either there's no applicable token in the cache or something failed
 			log.Info(err)
-			tryDeviceCodeFlow(publicClientApp)
-		} else {
-			fmt.Println("Access token is " + result.GetAccessToken())
 		}
 	}
+	if result == nil {
+		// either there was no cached account/token or the call to AcquireTokenSilent() failed
+		// make a new request to AAD
+		cancelTimeout := 100 * time.Second //Change this for cancel timeout
+		cancelCtx, cancelFunc := context.WithTimeout(context.Background(), cancelTimeout)
+		defer cancelFunc()
+		result, err = publicClientApp.AcquireTokenByDeviceCode(cancelCtx, config.Scopes, deviceCodeCallback, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	fmt.Println("Access token is " + result.AccessToken)
 }

--- a/test/devapps/device_code_flow_sample.go
+++ b/test/devapps/device_code_flow_sample.go
@@ -22,7 +22,8 @@ func acquireTokenDeviceCode() {
 	// create a PublicClientApplication with a  custom cache accessor
 	options := msal.DefaultPublicClientApplicationOptions()
 	options.Accessor = cacheAccessor
-	publicClientApp := msal.NewPublicClientApplication(config.ClientID, config.Authority, &options)
+	options.Authority = config.Authority
+	publicClientApp := msal.NewPublicClientApplication(config.ClientID, &options)
 
 	// look in the cache to see if the account to use has been cached
 	var userAccount *msalbase.Account

--- a/test/devapps/main.go
+++ b/test/devapps/main.go
@@ -11,7 +11,6 @@ const port = "3000"
 var config = createConfig("config.json")
 var publicClientApp *msal.PublicClientApplication
 var err error
-var authCodeParams *msal.AcquireTokenAuthCodeParameters
 var cacheAccessor = &SampleCacheAccessor{"serialized_cache.json"}
 
 func main() {

--- a/test/devapps/username_password_sample.go
+++ b/test/devapps/username_password_sample.go
@@ -4,48 +4,50 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/AzureAD/microsoft-authentication-library-for-go/internal/msalbase"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/msal"
 	log "github.com/sirupsen/logrus"
 )
 
-func tryUsernamePasswordFlow(publicClientApp *msal.PublicClientApplication) {
-	userNameParams := msal.CreateAcquireTokenUsernamePasswordParameters(config.Scopes, config.Username, config.Password)
-	result, err := publicClientApp.AcquireTokenByUsernamePassword(userNameParams)
-	if err != nil {
-		log.Fatal(err)
-	}
-	accessToken := result.GetAccessToken()
-	log.Info("Access token is: " + accessToken)
-}
-
 func acquireByUsernamePasswordPublic() {
 	config := createConfig("config.json")
-	// Creating the Public Client Application
-	publicClientApp, err := msal.CreatePublicClientApplication(config.ClientID, config.Authority)
-	if err != nil {
-		log.Fatal(err)
-	}
-	publicClientApp.SetCacheAccessor(cacheAccessor)
-	var userAccount msal.AccountProvider
-	accounts := publicClientApp.GetAccounts()
+	// create a PublicClientApplication with a  custom cache accessor
+	options := msal.DefaultPublicClientApplicationOptions()
+	options.Accessor = cacheAccessor
+	publicClientApp := msal.NewPublicClientApplication(config.ClientID, config.Authority, &options)
+
+	// look in the cache to see if the account to use has been cached
+	var userAccount *msalbase.Account
+	accounts := publicClientApp.Accounts()
 	for _, account := range accounts {
-		if account.GetUsername() == config.Username {
+		if account.PreferredUsername == config.Username {
 			userAccount = account
 		}
 	}
-	if userAccount == nil {
-		log.Info("No valid account found")
-		tryUsernamePasswordFlow(publicClientApp)
-	} else {
-		silentParams := msal.CreateAcquireTokenSilentParametersWithAccount(config.Scopes, userAccount)
-		result, err := publicClientApp.AcquireTokenSilent(silentParams)
+	var result *msalbase.AuthenticationResult
+	var err error
+	if userAccount != nil {
+		// found a cached account, now see if an applicable token has been cached
+		// NOTE: this API conflates error states, i.e. err is non-nil if an applicable token isn't
+		//       cached or if something goes wrong (making the HTTP request, unmarshalling, etc).
+		result, err = publicClientApp.AcquireTokenSilent(context.Background(), config.Scopes, &msal.AcquireTokenSilentOptions{
+			Account: userAccount,
+		})
 		if err != nil {
+			// either there's no applicable token in the cache or something failed
 			log.Info(err)
-			tryUsernamePasswordFlow(publicClientApp)
-		} else {
-			fmt.Println("Access token is " + result.GetAccessToken())
 		}
 	}
+	if result == nil {
+		// either there was no cached account/token or the call to AcquireTokenSilent() failed
+		// make a new request to AAD
+		result, err = publicClientApp.AcquireTokenByUsernamePassword(context.Background(), config.Scopes, config.Username, config.Password)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	fmt.Println("Access token is " + result.AccessToken)
 }

--- a/test/devapps/username_password_sample.go
+++ b/test/devapps/username_password_sample.go
@@ -17,7 +17,8 @@ func acquireByUsernamePasswordPublic() {
 	// create a PublicClientApplication with a  custom cache accessor
 	options := msal.DefaultPublicClientApplicationOptions()
 	options.Accessor = cacheAccessor
-	publicClientApp := msal.NewPublicClientApplication(config.ClientID, config.Authority, &options)
+	options.Authority = config.Authority
+	publicClientApp := msal.NewPublicClientApplication(config.ClientID, &options)
 
 	// look in the cache to see if the account to use has been cached
 	var userAccount *msalbase.Account


### PR DESCRIPTION
Renamed PublicClientApplication constructor function and updated its sig
to take an options struct.
Updated AcquireTokenSilent() and AcquireTokenByDeviceCode() APIs to take
a context.Context and options structs.
Removed "Get" prefix from getter-type methods.
Replaced some interface return types with their underlying type.