### PR TITLE
Adding json custom encoder/decoder

### DIFF
--- a/internal/json/design.md
+++ b/internal/json/design.md
@@ -45,7 +45,7 @@ They provide streaming processing (efficient) and return errors on bad JSON.
 Support for json.Marshaler/Unmarshaler allows for us to use non-basic types
 that must be specially encoded/decoded (like time.Time objects).
 
-We don't support types that can't custome unmarshal or have AdditionalFields
+We don't support types that can't customer unmarshal or have AdditionalFields
 in order to prevent future devs from forgetting that important field and
 generating bad return values.
 

--- a/internal/json/design.md
+++ b/internal/json/design.md
@@ -1,0 +1,140 @@
+# JSON Package Design
+Author: John Doak(jdoak@microsoft.com)
+
+## Why?
+
+This project needs a special type of marshal/unmarshal not directly supported
+by the encoding/json package. 
+
+The need revolves around a few key wants/needs:
+- unmarshal and marshal structs representing JSON messages
+- fields in the messgage not in the struct must be maintained when unmarshalled
+- those same fields must be marshalled back when encoded again
+
+The initial version used map[string]interface{} to put in the keys that
+were known and then any other keys were put into a field called AdditionalFields.
+
+This has a few negatives:
+- Dual marshaling/unmarshalling is required
+- Adding a struct field requires manually adding a key by name to be encoded/decoded from the map (which is a loosely coupled construct), which can lead to bugs that aren't detected or have bad side effects
+- Tests can become quickly disconnected if those keys aren't put
+in tests as well. So you think you have support working, but you
+don't. Existing tests were found that didn't test the marshalling output.
+- There is no enforcement that if AdditionalFields is required on one struct, it should be on all containers
+that don't have custom marshal/unmarshal.
+
+This package aims to support our needs by providing custom Marshal()/Unmarshal() functions.
+
+This prevents all the negatives in the initial solution listed above. However, it does add its own negative:
+- Custom encoding/decoding via reflection is messy (as can be  seen in encoding/json itself)
+
+Go proverb: Reflection is never clear
+Suggested reading: https://blog.golang.org/laws-of-reflection
+
+## Important design decisions
+
+- We don't want to understand all JSON decoding rules
+- We don't want to deal with all the quoting, commas, etc on decode
+- Need support for json.Marshaler/Unmarshaler, so we can support types like time.Time
+- If struct does not implement json.Unmarshaler, it must have AdditionalFields defined
+- We only support root level objects that are \*struct or struct
+
+To faciliate these goals, we will utilize the json.Encoder and json.Decoder.
+They provide streaming processing (efficient) and return errors on bad JSON.
+
+Support for json.Marshaler/Unmarshaler allows for us to use non-basic types
+that must be specially encoded/decoded (like time.Time objects).
+
+We don't support types that can't custome unmarshal or have AdditionalFields
+in order to prevent future devs from forgetting that important field and
+generating bad return values.
+
+Support for root level objects of \*struct or struct simply acknowledges the
+fact that this is designed only for the purposes listed in the Introduction.
+Outside that (like encoding a lone number) should be done with the
+regular json package (as it will not have additional fields).
+
+We don't support a few things on json supported reference types and structs:
+- \*map: no need for pointers to maps
+- \*slice: no need for pointers to slices
+- any further pointers on struct after \*struct
+
+There should never be a need for this in Go.
+
+## Design
+
+## State Machines
+
+This uses state machine designs that based upon the Rob Pike talk on 
+lexers and parsers: https://www.youtube.com/watch?v=HxaD_trXwRE
+
+This is the most common pattern for state machines in Go and
+the model to follow closesly when dealing with streaming 
+processing of textual data.
+
+Our state machines are based on the type:
+```go
+type stateFn func() (stateFn, error)
+```
+
+The state machine itself is simply a struct that has methods that
+satisfy stateFn. 
+
+Our state machines have a few standard calls
+- run(): runs the state machine
+- start(): always the first stateFn to be called
+
+All state machines have the following logic:
+* run() is called
+* start() is called and returns the next stateFn or error
+* stateFn is called
+    - If returned stateFn(next state) is non-nil, call it
+    - If error is non-nil, run() returns the error
+    - If stateFn == nil and err == nil, run() return err == nil
+
+## Supporting types
+
+Marshalling/Unmarshalling must support(within top level struct):
+- struct
+- \*struct
+- []struct
+- []\*struct
+- []map[string]structContainer
+- [][]structContainer
+
+**Term note:** structContainer == type that has a struct or \*struct inside it
+
+We specifically do not support []interface or map[string]interface
+where the interface value would hold some value with a struct in it.
+
+Those will still marshal/unmarshal, but without support for 
+AdditionalFields. 
+
+## Marshalling
+
+The marshalling design will be based around a statemachine design. 
+
+The basic logic is as follows:
+
+* If struct has custom marshaller, call it and return
+* If struct has field "AdditionalFields", it must be a map[string]interface{}
+* If struct does not have "AdditionalFields", give an error
+* Get struct tag detailing json names to go names, create mapping
+* For each public field name
+    - Write field name out
+    - If field value is a struct, recursively call our state machine
+    - Otherwise, use the json.Encoder to write out the value
+
+## Unmarshalling
+
+The unmarshalling desin is also based around a statemachine design. The 
+basic logic is as follows:
+
+* If struct has custom marhaller, call it
+* If struct has field "AdditionalFields", it must be a map[string]interface{}
+* Get struct tag detailing json names to go names, create mapping
+* For each key found
+    - If key exists, 
+        - If value is basic type, extract value into struct field using Decoder
+        - If value is struct type, recursively call statemachine
+    - If key doesn't exist, add it to AdditionalFields if it exists using Decoder

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -56,7 +56,7 @@ func Marshal(i interface{}) ([]byte, error) {
 // a field called AdditionalFields of type map[string]interface{}, JSON data representing fields not in the struct
 // will be written as key/value pairs to AdditionalFields.
 func Unmarshal(b []byte, i interface{}) error {
-	if b == nil || len(b) == 0 {
+	if len(b) == 0 {
 		return nil
 	}
 
@@ -101,10 +101,7 @@ func delimIs(got json.Token, want rune) bool {
 func hasMarshalJSON(v reflect.Value) bool {
 	if method := v.MethodByName(marshalJSON); method.Kind() != reflect.Invalid {
 		_, ok := v.Interface().(json.Marshaler)
-		if ok {
-			return true
-		}
-		return false
+		return ok
 	}
 
 	if v.Kind() == reflect.Ptr {
@@ -118,10 +115,7 @@ func hasMarshalJSON(v reflect.Value) bool {
 
 	if method := v.MethodByName(marshalJSON); method.Kind() != reflect.Invalid {
 		_, ok := v.Interface().(json.Marshaler)
-		if ok {
-			return true
-		}
-		return false
+		return ok
 	}
 	return false
 }

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -1,0 +1,186 @@
+// Package json provide functions for marshalling an unmarshalling types to JSON. These functions are meant to
+// be utilized inside of structs that implement json.Unmarshaler and json.Marshaler interfaces.
+// This package provides the additional functionality of writing fields that are not in the struct when marshalling
+// to a field called AdditionalFields if that field exists and is a map[string]interface{}.
+// When marshalling, if the struct has all the same prerequisites, it will uses the keys in AdditionalFields as
+// extra fields. This package uses encoding/json underneath.
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+const addField = "AdditionalFields"
+const (
+	marshalJSON   = "MarshalJSON"
+	unmarshalJSON = "UnmarshalJSON"
+)
+
+var (
+	leftBrace  = []byte("{")[0]
+	rightBrace = []byte("}")[0]
+	comma      = []byte(",")[0]
+	leftParen  = []byte("[")[0]
+	rightParen = []byte("]")[0]
+)
+
+var mapStrInterType = reflect.TypeOf(map[string]interface{}{})
+
+// stateFn defines a state machine function. This will be used in all state
+// machines in this package.
+type stateFn func() (stateFn, error)
+
+// Marshal is used to marshal a type into its JSON representation. It
+// wraps the stdlib calls in order to marshal a struct or *struct so
+// that a field called "AdditionalFields" of type map[string]interface{}
+// with "-" used inside struct tag `json:"-"` can be marshalled as if
+// they were fields within the struct.
+func Marshal(i interface{}) ([]byte, error) {
+	buff := bytes.Buffer{}
+	enc := json.NewEncoder(&buff)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "")
+
+	err := marshalStruct(reflect.ValueOf(i), &buff, enc)
+	if err != nil {
+		return nil, err
+	}
+	return buff.Bytes(), nil
+}
+
+// Unmarshal unmarshals a []byte representing JSON into i, which must be a *struct. In addition, if the struct has
+// a field called AdditionalFields of type map[string]interface{}, JSON data representing fields not in the struct
+// will be written as key/value pairs to AdditionalFields.
+func Unmarshal(b []byte, i interface{}) error {
+	if b == nil || len(b) == 0 {
+		return nil
+	}
+
+	jdec := json.NewDecoder(bytes.NewBuffer(b))
+	jdec.UseNumber()
+	return unmarshalStruct(jdec, i)
+}
+
+// MarshalRaw marshals i into a json.RawMessage. If I cannot be marshalled,
+// this will panic. This is exposed to help test AdditionalField values
+// which are stored as json.RawMessage.
+func MarshalRaw(i interface{}) json.RawMessage {
+	b, err := json.Marshal(i)
+	if err != nil {
+		panic(err)
+	}
+	return json.RawMessage(b)
+}
+
+// isDelim simply tests to see if a json.Token is a delimeter.
+func isDelim(got json.Token) bool {
+	switch got.(type) {
+	case json.Delim:
+		return true
+	}
+	return false
+}
+
+// delimIs tests got to see if it is want.
+func delimIs(got json.Token, want rune) bool {
+	switch v := got.(type) {
+	case json.Delim:
+		if v == json.Delim(want) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasMarshalJSON will determine if the value or a pointer to this value has
+// the MarshalJSON method.
+func hasMarshalJSON(v reflect.Value) bool {
+	if method := v.MethodByName(marshalJSON); method.Kind() != reflect.Invalid {
+		_, ok := v.Interface().(json.Marshaler)
+		if ok {
+			return true
+		}
+		return false
+	}
+
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	} else {
+		if !v.CanAddr() {
+			return false
+		}
+		v = v.Addr()
+	}
+
+	if method := v.MethodByName(marshalJSON); method.Kind() != reflect.Invalid {
+		_, ok := v.Interface().(json.Marshaler)
+		if ok {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// callMarshalJSON will call MarshalJSON() method on the value or a pointer to this value.
+// This will panic if the method is not defined.
+func callMarshalJSON(v reflect.Value) ([]byte, error) {
+	if method := v.MethodByName(marshalJSON); method.Kind() != reflect.Invalid {
+		marsh := v.Interface().(json.Marshaler)
+		return marsh.MarshalJSON()
+	}
+
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	} else {
+		if v.CanAddr() {
+			v = v.Addr()
+		}
+		panic(fmt.Sprintf("callMarshalJSON called on type %T that does not have MarshalJSON defined", v.Interface()))
+	}
+
+	if method := v.MethodByName(unmarshalJSON); method.Kind() != reflect.Invalid {
+		marsh := v.Interface().(json.Marshaler)
+		return marsh.MarshalJSON()
+	}
+
+	panic(fmt.Sprintf("callMarshalJSON called on type %T that does not have MarshalJSON defined", v.Interface()))
+}
+
+// hasUnmarshalJSON will determine if the value or a pointer to this value has
+// the UnmarshalJSON method.
+func hasUnmarshalJSON(v reflect.Value) bool {
+	// You can't unmarshal on a non-pointer type.
+	if v.Kind() != reflect.Ptr {
+		if !v.CanAddr() {
+			return false
+		}
+		v = v.Addr()
+	}
+
+	if method := v.MethodByName(unmarshalJSON); method.Kind() != reflect.Invalid {
+		_, ok := v.Interface().(json.Unmarshaler)
+		if ok {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// hasOmitEmpty indicates if the field has instructed us to not output
+// the field if omitempty is set on the tag. tag is the string
+// returned by reflect.StructField.Tag().Get().
+func hasOmitEmpty(tag string) bool {
+	sl := strings.Split(tag, ",")
+	for _, str := range sl {
+		if str == "omitempty" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -1,0 +1,186 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+type StructA struct {
+	Name             string
+	ID               int `json:"id"`
+	Meta             *StructB
+	AdditionalFields map[string]interface{}
+}
+
+type StructB struct {
+	Address          string
+	AdditionalFields map[string]interface{}
+}
+
+type StructC struct {
+	Time             time.Time
+	Project          StructD
+	AdditionalFields map[string]interface{}
+}
+
+type StructD struct {
+	Project          string
+	Info             StructE
+	AdditionalFields map[string]interface{}
+}
+
+type StructE struct {
+	Employees        int
+	AdditionalFields map[string]interface{}
+}
+
+func TestUnmarshal(t *testing.T) {
+	now := time.Now()
+	nowJSON, err := now.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+
+	tests := []struct {
+		desc string
+		b    []byte
+		got  interface{}
+		want interface{}
+		err  bool
+	}{
+		{
+			desc: "receiver not a pointer",
+			got:  StructA{},
+			b:    []byte(`{"content": "value"}`),
+			err:  true,
+		},
+		{
+			desc: "receiver not a pointer to a struct",
+			got:  new(string),
+			b:    []byte(`{"content": "value"}`),
+			err:  true,
+		},
+		{
+			desc: "AdditionalFields not a map",
+			b:    []byte(`{"content": "value"}`),
+			got: &struct {
+				AdditionalFields string
+			}{},
+			err: true,
+		},
+		{
+			desc: "Success, no json.Unmarshaler types",
+			b: []byte(
+				`
+				{
+					"Name": "John",
+					"id": 3,
+					"Meta": {
+						"Address": "291 Street",
+						"unknown0": 3.2
+					},
+					"unknown0": 10,
+					"unknown1": "hello"
+				}
+				`,
+			),
+			got: &StructA{},
+			want: &StructA{
+				Name: "John",
+				ID:   3,
+				Meta: &StructB{
+					Address: "291 Street",
+					AdditionalFields: map[string]interface{}{
+						"unknown0": MarshalRaw(3.2),
+					},
+				},
+				AdditionalFields: map[string]interface{}{
+					"unknown0": MarshalRaw(10),
+					"unknown1": MarshalRaw("hello"),
+				},
+			},
+		},
+		{
+			desc: "Success, a type has json.Unmarshaler",
+			b: []byte(fmt.Sprintf(`
+				{
+					"Time":%s,
+					"Project": {
+						"Project":"myProject",
+						"Info":{
+							"Employees":2
+						}
+					}
+				}
+			`, string(nowJSON))),
+			got: &StructC{},
+			want: &StructC{
+				Time: now,
+				Project: StructD{
+					Project: "myProject",
+					Info: StructE{
+						Employees: 2,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		err := Unmarshal(test.b, test.got)
+		switch {
+		case err == nil && test.err:
+			t.Errorf("TestUnmarshal(%s): got err == nil, want err != nil", test.desc)
+			continue
+		case err != nil && !test.err:
+			t.Errorf("TestUnmarshal(%s): got err == %s, want err == nil", test.desc, err)
+			continue
+		case err != nil:
+			continue
+		}
+		if diff := (&pretty.Config{IncludeUnexported: false}).Compare(test.want, test.got); diff != "" {
+			t.Errorf("TestUnmarshal(%s): -want/+got:\n%s", test.desc, diff)
+		}
+	}
+}
+
+func TestIsDelim(t *testing.T) {
+	tests := []struct {
+		desc  string
+		token json.Token
+		want  bool
+	}{
+		{desc: "Is delim", token: json.Delim('{'), want: true},
+		{desc: "Not a delim", token: json.Token("{"), want: false},
+	}
+
+	for _, test := range tests {
+		got := isDelim(test.token)
+		if got != test.want {
+			t.Errorf("TestIsDelim(%s): got %v, want %v", test.desc, got, test.want)
+		}
+	}
+}
+
+func TestDelimIs(t *testing.T) {
+	tests := []struct {
+		desc  string
+		token json.Token
+		delim rune
+		want  bool
+	}{
+		{desc: "Token is a match", token: json.Delim('{'), delim: '{', want: true},
+		{desc: "Token is not a match", token: json.Delim('{'), delim: '}', want: false},
+	}
+
+	for _, test := range tests {
+		got := delimIs(test.token, test.delim)
+		if got != test.want {
+			t.Errorf("TestDelimIs(%s): got %v, want %v", test.desc, got, test.want)
+		}
+	}
+}

--- a/internal/json/mapslice.go
+++ b/internal/json/mapslice.go
@@ -190,7 +190,6 @@ func unmarshalSlice(dec *json.Decoder, ptrSlice reflect.Value) error {
 type sliceWalk struct {
 	dec           *json.Decoder
 	s             reflect.Value // *[]slice
-	skipOpenParen bool
 	valueType     reflect.Type
 }
 
@@ -253,8 +252,8 @@ func (s *sliceWalk) next() (stateFn, error) {
 		return s.storeValue, nil
 	}
 	// Nothing left in the slice, remove closing ]
-	s.dec.Token()
-	return nil, nil
+	_, err := s.dec.Token()
+	return nil, err
 }
 
 func (s *sliceWalk) storeValue() (stateFn, error) {

--- a/internal/json/mapslice.go
+++ b/internal/json/mapslice.go
@@ -1,0 +1,331 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// unmarshalMap unmarshal's a map.
+func unmarshalMap(dec *json.Decoder, m reflect.Value) error {
+	if m.Kind() != reflect.Ptr || m.Elem().Kind() != reflect.Map {
+		panic("unmarshalMap called on non-*map value")
+	}
+	mapValueType := m.Elem().Type().Elem()
+	walk := mapWalk{dec: dec, m: m, valueType: mapValueType}
+	if err := walk.run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+type mapWalk struct {
+	dec       *json.Decoder
+	key       string
+	m         reflect.Value
+	valueType reflect.Type
+}
+
+// run runs our decoder state machine.
+func (m *mapWalk) run() error {
+	var state = m.start
+	var err error
+	for {
+		state, err = state()
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			return nil
+		}
+	}
+}
+
+func (m *mapWalk) start() (stateFn, error) {
+	// maps can have custom unmarshaler's.
+	if hasUnmarshalJSON(m.m) {
+		err := m.dec.Decode(m.m)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	// We only want to use this if the map value is:
+	// *struct/struct/map/slice
+	// otherwise use standard decode
+	t, _ := m.valueBaseType()
+	switch t.Kind() {
+	case reflect.Struct, reflect.Map, reflect.Slice:
+		delim, err := m.dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		// This indicates the value was set to JSON null.
+		if delim == nil {
+			return nil, nil
+		}
+		if !delimIs(delim, '{') {
+			return nil, fmt.Errorf("Unmarshal expected opening {, received %v", delim)
+		}
+		return m.next, nil
+	case reflect.Ptr:
+		return nil, fmt.Errorf("do not support maps with values of '**type' or '*reference")
+	}
+
+	// This is a basic map type, so just use Decode().
+	if err := m.dec.Decode(m.m.Interface()); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (m *mapWalk) next() (stateFn, error) {
+	if m.dec.More() {
+		key, err := m.dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		m.key = key.(string)
+		return m.storeValue, nil
+	}
+	// No more entries, so remove final }.
+	_, err := m.dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (m *mapWalk) storeValue() (stateFn, error) {
+	v := m.valueType
+	for {
+		switch v.Kind() {
+		case reflect.Ptr:
+			v = v.Elem()
+			continue
+		case reflect.Struct:
+			return m.storeStruct, nil
+		case reflect.Map:
+			return m.storeMap, nil
+		case reflect.Slice:
+			return m.storeSlice, nil
+		}
+		return nil, fmt.Errorf("bug: mapWalk.storeValue() called on unsupported type: %v", v.Kind())
+	}
+}
+
+func (m *mapWalk) storeStruct() (stateFn, error) {
+	v := newValue(m.valueType)
+	if err := unmarshalStruct(m.dec, v.Interface()); err != nil {
+		return nil, err
+	}
+
+	if m.valueType.Kind() == reflect.Ptr {
+		m.m.Elem().SetMapIndex(reflect.ValueOf(m.key), v)
+		return m.next, nil
+	}
+	m.m.Elem().SetMapIndex(reflect.ValueOf(m.key), v.Elem())
+
+	return m.next, nil
+}
+
+func (m *mapWalk) storeMap() (stateFn, error) {
+	v := reflect.MakeMap(m.valueType)
+	ptr := newValue(v.Type())
+	ptr.Elem().Set(v)
+	if err := unmarshalMap(m.dec, ptr); err != nil {
+		return nil, err
+	}
+
+	m.m.Elem().SetMapIndex(reflect.ValueOf(m.key), v)
+
+	return m.next, nil
+}
+
+func (m *mapWalk) storeSlice() (stateFn, error) {
+	v := newValue(m.valueType)
+	if err := unmarshalSlice(m.dec, v); err != nil {
+		return nil, err
+	}
+
+	m.m.Elem().SetMapIndex(reflect.ValueOf(m.key), v.Elem())
+
+	return m.next, nil
+}
+
+// valueType returns the underlying Type. So a *struct would yield
+// struct, etc...
+func (m *mapWalk) valueBaseType() (reflect.Type, bool) {
+	ptr := false
+	v := m.valueType
+	if v.Kind() == reflect.Ptr {
+		ptr = true
+		v = v.Elem()
+	}
+	return v, ptr
+}
+
+// unmarshalSlice unmarshal's the next value, which must be a slice, into
+// ptrSlice, which must be a pointer to a slice. newValue() can be use to
+// create the slice.
+func unmarshalSlice(dec *json.Decoder, ptrSlice reflect.Value) error {
+	if ptrSlice.Kind() != reflect.Ptr || ptrSlice.Elem().Kind() != reflect.Slice {
+		panic("unmarshalSlice called on non-*[]slice value")
+	}
+	sliceValueType := ptrSlice.Elem().Type().Elem()
+	walk := sliceWalk{
+		dec:       dec,
+		s:         ptrSlice,
+		valueType: sliceValueType,
+	}
+	if err := walk.run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type sliceWalk struct {
+	dec           *json.Decoder
+	s             reflect.Value // *[]slice
+	skipOpenParen bool
+	valueType     reflect.Type
+}
+
+// run runs our decoder state machine.
+func (s *sliceWalk) run() error {
+	var state = s.start
+	var err error
+	for {
+		state, err = state()
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			return nil
+		}
+	}
+}
+
+func (s *sliceWalk) start() (stateFn, error) {
+	// slices can have custom unmarshaler's.
+	if hasUnmarshalJSON(s.s) {
+		err := s.dec.Decode(s.s.Interface())
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	// We only want to use this if the slice value is:
+	// []*struct/[]struct/[]map/[]slice
+	// otherwise use standard decode
+	t := s.valueBaseType()
+
+	switch t.Kind() {
+	case reflect.Ptr:
+		return nil, fmt.Errorf("cannot unmarshal into a **<type> or *<reference>")
+	case reflect.Struct, reflect.Map, reflect.Slice:
+		delim, err := s.dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		// This indicates the value was set to nil.
+		if delim == nil {
+			return nil, nil
+		}
+		if !delimIs(delim, '[') {
+			return nil, fmt.Errorf("Unmarshal expected opening [, received %v", delim)
+		}
+		return s.next, nil
+	}
+
+	if err := s.dec.Decode(s.s.Interface()); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (s *sliceWalk) next() (stateFn, error) {
+	if s.dec.More() {
+		return s.storeValue, nil
+	}
+	// Nothing left in the slice, remove closing ]
+	s.dec.Token()
+	return nil, nil
+}
+
+func (s *sliceWalk) storeValue() (stateFn, error) {
+	t := s.valueBaseType()
+	switch t.Kind() {
+	case reflect.Ptr:
+		return nil, fmt.Errorf("do not support 'pointer to pointer' or 'pointer to reference' types")
+	case reflect.Struct:
+		return s.storeStruct, nil
+	case reflect.Map:
+		return s.storeMap, nil
+	case reflect.Slice:
+		return s.storeSlice, nil
+	}
+	return nil, fmt.Errorf("bug: sliceWalk.storeValue() called on unsupported type: %v", t.Kind())
+}
+
+func (s *sliceWalk) storeStruct() (stateFn, error) {
+	v := newValue(s.valueType)
+	if err := unmarshalStruct(s.dec, v.Interface()); err != nil {
+		return nil, err
+	}
+
+	if s.valueType.Kind() == reflect.Ptr {
+		s.s.Elem().Set(reflect.Append(s.s.Elem(), v))
+		return s.next, nil
+	}
+
+	s.s.Elem().Set(reflect.Append(s.s.Elem(), v.Elem()))
+	return s.next, nil
+}
+
+func (s *sliceWalk) storeMap() (stateFn, error) {
+	v := reflect.MakeMap(s.valueType)
+	ptr := newValue(v.Type())
+	ptr.Elem().Set(v)
+
+	if err := unmarshalMap(s.dec, ptr); err != nil {
+		return nil, err
+	}
+
+	s.s.Elem().Set(reflect.Append(s.s.Elem(), v))
+
+	return s.next, nil
+}
+
+func (s *sliceWalk) storeSlice() (stateFn, error) {
+	v := newValue(s.valueType)
+	if err := unmarshalSlice(s.dec, v); err != nil {
+		return nil, err
+	}
+
+	s.s.Elem().Set(reflect.Append(s.s.Elem(), v.Elem()))
+
+	return s.next, nil
+}
+
+// valueType returns the underlying Type. So a *struct would yield
+// struct, etc...
+func (s *sliceWalk) valueBaseType() reflect.Type {
+	v := s.valueType
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	return v
+}
+
+// newValue() returns a new *type that represents type passed.
+func newValue(valueType reflect.Type) reflect.Value {
+	if valueType.Kind() == reflect.Ptr {
+		return reflect.New(valueType.Elem())
+	}
+	return reflect.New(valueType)
+}

--- a/internal/json/mapslice.go
+++ b/internal/json/mapslice.go
@@ -188,9 +188,9 @@ func unmarshalSlice(dec *json.Decoder, ptrSlice reflect.Value) error {
 }
 
 type sliceWalk struct {
-	dec           *json.Decoder
-	s             reflect.Value // *[]slice
-	valueType     reflect.Type
+	dec       *json.Decoder
+	s         reflect.Value // *[]slice
+	valueType reflect.Type
 }
 
 // run runs our decoder state machine.

--- a/internal/json/mapslice_test.go
+++ b/internal/json/mapslice_test.go
@@ -82,7 +82,7 @@ func TestUnmarshalMap(t *testing.T) {
 					`,
 			got: &map[string]*StructWithUnmarshal{},
 			want: map[string]*StructWithUnmarshal{
-				"key": &StructWithUnmarshal{
+				"key": {
 					Name: "John",
 				},
 			},
@@ -99,7 +99,7 @@ func TestUnmarshalMap(t *testing.T) {
 					`,
 			got: &map[string]StructName{},
 			want: map[string]StructName{
-				"key": StructName{
+				"key": {
 					Name: "John",
 					AdditionalFields: map[string]interface{}{
 						"extra": MarshalRaw("extra"),
@@ -119,7 +119,7 @@ func TestUnmarshalMap(t *testing.T) {
 					`,
 			got: &map[string]*StructName{},
 			want: map[string]*StructName{
-				"key": &StructName{
+				"key": {
 					Name: "John",
 					AdditionalFields: map[string]interface{}{
 						"extra": MarshalRaw("extra"),
@@ -141,7 +141,7 @@ func TestUnmarshalMap(t *testing.T) {
 				`,
 			got: &map[string][]StructName{},
 			want: map[string][]StructName{
-				"key": []StructName{
+				"key": {
 					{
 						Name: "John",
 						AdditionalFields: map[string]interface{}{
@@ -165,7 +165,7 @@ func TestUnmarshalMap(t *testing.T) {
 				`,
 			got: &map[string][]*StructName{},
 			want: map[string][]*StructName{
-				"key": []*StructName{
+				"key": {
 					{
 						Name: "John",
 						AdditionalFields: map[string]interface{}{
@@ -239,7 +239,7 @@ func TestUnmarshalSlice(t *testing.T) {
 				`,
 			got: new([]*StructWithUnmarshal),
 			want: []*StructWithUnmarshal{
-				&StructWithUnmarshal{
+				{
 					Name: "John",
 				},
 			},
@@ -346,8 +346,8 @@ func TestUnmarshalSlice(t *testing.T) {
 			`,
 			got: new([]map[string]StructName),
 			want: []map[string]StructName{
-				map[string]StructName{
-					"key": StructName{
+				{
+					"key": {
 						Name: "John",
 						AdditionalFields: map[string]interface{}{
 							"extra": MarshalRaw("extra"),

--- a/internal/json/mapslice_test.go
+++ b/internal/json/mapslice_test.go
@@ -1,0 +1,379 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+type StructWithUnmarshal struct {
+	Name string
+}
+
+type StructName struct {
+	Name             string
+	AdditionalFields map[string]interface{}
+}
+
+func (s *StructWithUnmarshal) UnmarshalJSON(b []byte) error {
+	// Note this looks sill, but you can't use json.Unmarshal
+	// in an UnmarshalJSON, it causes a recursion loop. This is
+	// just a simple workaround.
+	type unmarshal struct {
+		Name string
+	}
+
+	u := unmarshal{}
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		panic(err)
+	}
+	s.Name = u.Name
+	return nil
+}
+
+func TestUnmarshalMap(t *testing.T) {
+	tests := []struct {
+		desc  string
+		input string
+		got   interface{}
+		want  interface{}
+		err   bool
+	}{
+		{
+			desc: "error: struct has no AdditionalFields",
+			input: `
+				{
+					"key": {
+						"Name": "John"
+					}
+				}
+				`,
+			got: &map[string]struct{ Name string }{},
+			err: true,
+		},
+		{
+			desc: "success: basic map[string]interface{}",
+			input: `
+			{
+				"key": {
+					"Name": "John"
+				}
+			}
+			`,
+			got: &map[string]interface{}{},
+			want: map[string]interface{}{
+				"key": map[string]interface{}{
+					"Name": "John",
+				},
+			},
+		},
+		{
+			desc: "success: struct has UnmarshalJSON",
+			input: `
+					{
+						"key": {
+							"Name": "John"
+						}
+					}
+					`,
+			got: &map[string]*StructWithUnmarshal{},
+			want: map[string]*StructWithUnmarshal{
+				"key": &StructWithUnmarshal{
+					Name: "John",
+				},
+			},
+		},
+		{
+			desc: "success: map[string]struct",
+			input: `
+					{
+						"key": {
+							"Name": "John",
+							"extra": "extra"
+						}
+					}
+					`,
+			got: &map[string]StructName{},
+			want: map[string]StructName{
+				"key": StructName{
+					Name: "John",
+					AdditionalFields: map[string]interface{}{
+						"extra": MarshalRaw("extra"),
+					},
+				},
+			},
+		},
+		{
+			desc: "success: map[string]*struct",
+			input: `
+					{
+						"key": {
+							"Name": "John",
+							"extra": "extra"
+						}
+					}
+					`,
+			got: &map[string]*StructName{},
+			want: map[string]*StructName{
+				"key": &StructName{
+					Name: "John",
+					AdditionalFields: map[string]interface{}{
+						"extra": MarshalRaw("extra"),
+					},
+				},
+			},
+		},
+		{
+			desc: "success: map[string][]struct",
+			input: `
+					{
+						"key": [
+								{
+									"Name": "John",
+									"extra": "extra"
+								}
+						]
+					}
+				`,
+			got: &map[string][]StructName{},
+			want: map[string][]StructName{
+				"key": []StructName{
+					{
+						Name: "John",
+						AdditionalFields: map[string]interface{}{
+							"extra": MarshalRaw("extra"),
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "success: map[string][]*struct",
+			input: `
+					{
+						"key": [
+								{
+									"Name": "John",
+									"extra": "extra"
+								}
+						]
+					}
+				`,
+			got: &map[string][]*StructName{},
+			want: map[string][]*StructName{
+				"key": []*StructName{
+					{
+						Name: "John",
+						AdditionalFields: map[string]interface{}{
+							"extra": MarshalRaw("extra"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		dec := json.NewDecoder(bytes.NewBuffer([]byte(test.input)))
+		err := unmarshalMap(dec, reflect.ValueOf(test.got))
+		switch {
+		case err == nil && test.err:
+			t.Errorf("TestUnmarshalMap(%s): err == nil, want err != nil", test.desc)
+			continue
+		case err != nil && !test.err:
+			t.Errorf("TestUnmarshalMap(%s): err == %s, want err == nil", test.desc, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		if diff := pretty.Compare(test.want, test.got); diff != "" {
+			t.Errorf("TestUnmarshalMap(%s): -want/+got\n%s", test.desc, diff)
+		}
+	}
+}
+
+func TestUnmarshalSlice(t *testing.T) {
+	tests := []struct {
+		desc  string
+		input string
+		got   interface{}
+		want  interface{}
+		err   bool
+	}{
+		{
+			desc: "error: struct has no AdditionalFields",
+			input: `
+			[
+				{
+					"Name": "John"
+				}
+			]
+			`,
+			got: new([]struct{ Name string }),
+			err: true,
+		},
+		{
+			desc: "success: basic slice",
+			input: `
+					[
+						"John",
+						"Steve"
+					]
+				`,
+			got:  new([]string),
+			want: []string{"John", "Steve"},
+		},
+		{
+			desc: "success: struct has UnmarshalJSON",
+			input: `
+					[
+						{
+							"Name": "John"
+						}
+					]
+				`,
+			got: new([]*StructWithUnmarshal),
+			want: []*StructWithUnmarshal{
+				&StructWithUnmarshal{
+					Name: "John",
+				},
+			},
+		},
+		{
+			desc: "success: []struct",
+			input: `
+				[
+					{
+						"Name": "John",
+						"extra": "extra"
+					}
+				]
+			`,
+			got: new([]StructName),
+			want: []StructName{
+				{
+					Name: "John",
+					AdditionalFields: map[string]interface{}{
+						"extra": MarshalRaw("extra"),
+					},
+				},
+			},
+		},
+		{
+			desc: "success: []*struct",
+			input: `
+				[
+					{
+						"Name": "John",
+						"extra": "extra"
+					}
+				]
+			`,
+			got: new([]*StructName),
+			want: []*StructName{
+				{
+					Name: "John",
+					AdditionalFields: map[string]interface{}{
+						"extra": MarshalRaw("extra"),
+					},
+				},
+			},
+		},
+		{
+			desc: "success: [][]struct",
+			input: `
+					[
+						[
+							{
+								"Name": "John",
+								"extra": "extra"
+							}
+						]
+					]
+				`,
+			got: new([][]StructName),
+			want: [][]StructName{
+				{
+					{
+						Name: "John",
+						AdditionalFields: map[string]interface{}{
+							"extra": MarshalRaw("extra"),
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "success: [][]*struct",
+			input: `
+				[
+					[
+						{
+							"Name": "John",
+							"extra": "extra"
+						}
+					]
+				]
+			`,
+			got: new([][]*StructName),
+			want: [][]*StructName{
+				{
+					{
+						Name: "John",
+						AdditionalFields: map[string]interface{}{
+							"extra": MarshalRaw("extra"),
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "success: []map[string]struct",
+			input: `
+				[
+					{
+						"key": {
+							"Name": "John",
+							"extra": "extra"
+						}
+					}
+				]
+			`,
+			got: new([]map[string]StructName),
+			want: []map[string]StructName{
+				map[string]StructName{
+					"key": StructName{
+						Name: "John",
+						AdditionalFields: map[string]interface{}{
+							"extra": MarshalRaw("extra"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		dec := json.NewDecoder(bytes.NewBuffer([]byte(test.input)))
+		err := unmarshalSlice(dec, reflect.ValueOf(test.got))
+		switch {
+		case err == nil && test.err:
+			t.Errorf("TestUnmarshalSlice(%s): err == nil, want err != nil", test.desc)
+			continue
+		case err != nil && !test.err:
+			t.Errorf("TestUnmarshalSlice(%s): err == %s, want err == nil", test.desc, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		if diff := pretty.Compare(test.want, test.got); diff != "" {
+			t.Errorf("TestUnmarshalSlice(%s): -want/+got\n%s", test.desc, diff)
+		}
+	}
+}

--- a/internal/json/marshal.go
+++ b/internal/json/marshal.go
@@ -1,0 +1,332 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"unicode"
+)
+
+// marshalStruct takes in i, which must be a *struct or struct and marshals its content
+// as JSON into buff (sometimes with writes to buff directly, sometimes via enc).
+// This call is recursive for all fields of *struct or struct type.
+func marshalStruct(v reflect.Value, buff *bytes.Buffer, enc *json.Encoder) error {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	// We only care about custom Marshalling a struct.
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("bug: marshal() received a non *struct or struct, received type %T", v.Interface())
+	}
+
+	if hasMarshalJSON(v) {
+		b, err := callMarshalJSON(v)
+		if err != nil {
+			return err
+		}
+		buff.Write(b)
+		return nil
+	}
+
+	t := v.Type()
+
+	// If it has an AdditionalFields field make sure its the right type.
+	f := v.FieldByName(addField)
+	if f.Kind() != reflect.Invalid {
+		if f.Kind() != reflect.Map {
+			return fmt.Errorf("type %T has field 'AdditionalFields' that is not a map[string]interface{}", v.Interface())
+		}
+		if !f.Type().AssignableTo(mapStrInterType) {
+			return fmt.Errorf("type %T has field 'AdditionalFields' that is not a map[string]interface{}", v.Interface())
+		}
+	}
+
+	translator, err := findFields(v)
+	if err != nil {
+		return err
+	}
+
+	buff.WriteByte(leftBrace)
+	for x := 0; x < v.NumField(); x++ {
+		field := v.Field(x)
+
+		// We don't access private fields.
+		if unicode.IsLower(rune(t.Field(x).Name[0])) {
+			continue
+		}
+
+		if t.Field(x).Name == addField {
+			if v.Field(x).Len() > 0 {
+				if err := writeAddFields(field.Interface(), buff, enc); err != nil {
+					return err
+				}
+				buff.WriteByte(comma)
+			}
+			continue
+		}
+
+		// If they have omitempty set, we don't write out the field if
+		// it is the zero value.
+		if hasOmitEmpty(t.Field(x).Tag.Get("json")) {
+			if v.Field(x).IsZero() {
+				continue
+			}
+		}
+
+		// Write out the field name part.
+		jsonName := translator.jsonName(t.Field(x).Name)
+		buff.WriteString(fmt.Sprintf("%q:", jsonName))
+
+		if field.Kind() == reflect.Ptr {
+			field = field.Elem()
+		}
+
+		err := func() error {
+			// Determine if we need a trailing comma.
+			defer buff.WriteByte(comma)
+
+			switch field.Kind() {
+			// If it was a *struct or struct, we need to recursively all marshal().
+			case reflect.Struct:
+				if err := marshalStruct(field, buff, enc); err != nil {
+					return err
+				}
+				return nil
+			case reflect.Map:
+				if err := marshalMap(field, buff, enc); err != nil {
+					return err
+				}
+				return nil
+			case reflect.Slice:
+				if err := marshalSlice(field, buff, enc); err != nil {
+					return err
+				}
+				return nil
+			}
+
+			// It is just a basic type, so encode it.
+			if err := enc.Encode(field.Interface()); err != nil {
+				return err
+			}
+			buff.Truncate(buff.Len() - 1) // Remove Encode() added \n
+
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+	}
+
+	buff.Truncate(buff.Len() - 1) // Remove final comma
+	buff.WriteByte(rightBrace)
+
+	return nil
+}
+
+func marshalMap(v reflect.Value, buff *bytes.Buffer, enc *json.Encoder) error {
+	if v.Kind() != reflect.Map {
+		return fmt.Errorf("bug: marshalMap() called on %T", v.Interface())
+	}
+	encoder := mapEncode{m: v, buff: buff, enc: enc}
+	return encoder.run()
+}
+
+type mapEncode struct {
+	m    reflect.Value
+	buff *bytes.Buffer
+	enc  *json.Encoder
+
+	valueBaseType reflect.Type
+}
+
+// run runs our encoder state machine.
+func (m *mapEncode) run() error {
+	var state = m.start
+	var err error
+	for {
+		state, err = state()
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			return nil
+		}
+	}
+}
+
+func (m *mapEncode) start() (stateFn, error) {
+	if hasMarshalJSON(m.m) {
+		b, err := callMarshalJSON(m.m)
+		if err != nil {
+			return nil, err
+		}
+		m.buff.Write(b)
+		return nil, nil
+	}
+
+	valueBaseType := m.m.Type().Elem()
+	if valueBaseType.Kind() == reflect.Ptr {
+		valueBaseType = valueBaseType.Elem()
+	}
+	m.valueBaseType = valueBaseType
+
+	switch valueBaseType.Kind() {
+	case reflect.Ptr:
+		return nil, fmt.Errorf("Marshal does not support **<type> or *<reference>")
+	case reflect.Struct, reflect.Map, reflect.Slice:
+		return m.encode, nil
+	}
+
+	// If the map value doesn't have a struct/map/slice, just Encode() it.
+	if err := m.enc.Encode(m.m.Interface()); err != nil {
+		return nil, err
+	}
+	m.buff.Truncate(m.buff.Len() - 1) // Remove Encode() added \n
+	return nil, nil
+}
+
+func (m *mapEncode) encode() (stateFn, error) {
+	m.buff.WriteByte(leftBrace)
+
+	iter := m.m.MapRange()
+	for iter.Next() {
+		// Write the key.
+		k := iter.Key()
+		m.buff.WriteString(fmt.Sprintf("%q:", k.String()))
+
+		v := iter.Value()
+		switch m.valueBaseType.Kind() {
+		case reflect.Struct:
+			if err := marshalStruct(v, m.buff, m.enc); err != nil {
+				return nil, err
+			}
+		case reflect.Map:
+			if err := marshalMap(v, m.buff, m.enc); err != nil {
+				return nil, err
+			}
+		case reflect.Slice:
+			if err := marshalSlice(v, m.buff, m.enc); err != nil {
+				return nil, err
+			}
+		default:
+			panic(fmt.Sprintf("critical bug: mapEncode.encode() called with value base type: %v", m.valueBaseType.Kind()))
+		}
+		m.buff.WriteByte(comma)
+	}
+	m.buff.Truncate(m.buff.Len() - 1) // Remove final comma
+	m.buff.WriteByte(rightBrace)
+
+	return nil, nil
+}
+
+func marshalSlice(v reflect.Value, buff *bytes.Buffer, enc *json.Encoder) error {
+	if v.Kind() != reflect.Slice {
+		return fmt.Errorf("bug: marshalSlice() called on %T", v.Interface())
+	}
+	encoder := sliceEncode{s: v, buff: buff, enc: enc}
+	return encoder.run()
+}
+
+type sliceEncode struct {
+	s    reflect.Value
+	buff *bytes.Buffer
+	enc  *json.Encoder
+
+	valueBaseType reflect.Type
+}
+
+// run runs our encoder state machine.
+func (s *sliceEncode) run() error {
+	var state = s.start
+	var err error
+	for {
+		state, err = state()
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			return nil
+		}
+	}
+}
+
+func (s *sliceEncode) start() (stateFn, error) {
+	if hasMarshalJSON(s.s) {
+		b, err := callMarshalJSON(s.s)
+		if err != nil {
+			return nil, err
+		}
+		s.buff.Write(b)
+		return nil, nil
+	}
+
+	valueBaseType := s.s.Type().Elem()
+	if valueBaseType.Kind() == reflect.Ptr {
+		valueBaseType = valueBaseType.Elem()
+	}
+	s.valueBaseType = valueBaseType
+
+	switch valueBaseType.Kind() {
+	case reflect.Ptr:
+		return nil, fmt.Errorf("Marshal does not support **<type> or *<reference>")
+	case reflect.Struct, reflect.Map, reflect.Slice:
+		return s.encode, nil
+	}
+
+	// If the map value doesn't have a struct/map/slice, just Encode() it.
+	if err := s.enc.Encode(s.s.Interface()); err != nil {
+		return nil, err
+	}
+	s.buff.Truncate(s.buff.Len() - 1) // Remove Encode added \n
+
+	return nil, nil
+}
+
+func (s *sliceEncode) encode() (stateFn, error) {
+	s.buff.WriteByte(leftParen)
+	for i := 0; i < s.s.Len(); i++ {
+		v := s.s.Index(i)
+		switch s.valueBaseType.Kind() {
+		case reflect.Struct:
+			if err := marshalStruct(v, s.buff, s.enc); err != nil {
+				return nil, err
+			}
+		case reflect.Map:
+			if err := marshalMap(v, s.buff, s.enc); err != nil {
+				return nil, err
+			}
+		case reflect.Slice:
+			if err := marshalSlice(v, s.buff, s.enc); err != nil {
+				return nil, err
+			}
+		default:
+			panic(fmt.Sprintf("critical bug: mapEncode.encode() called with value base type: %v", s.valueBaseType.Kind()))
+		}
+		s.buff.WriteByte(comma)
+	}
+	s.buff.Truncate(s.buff.Len() - 1) // Remove final comma
+	s.buff.WriteByte(rightParen)
+	return nil, nil
+}
+
+// writeAddFields writes the AdditionalFields struct field out to JSON as field
+// values. i must be a map[string]interface{} or this will panic.
+func writeAddFields(i interface{}, buff *bytes.Buffer, enc *json.Encoder) error {
+	m := i.(map[string]interface{})
+
+	x := 0
+	for k, v := range m {
+		buff.WriteString(fmt.Sprintf("%q:", k))
+		if err := enc.Encode(v); err != nil {
+			return err
+		}
+		buff.Truncate(buff.Len() - 1) // Remove Encode() added \n
+
+		if x+1 != len(m) {
+			buff.WriteByte(comma)
+		}
+		x++
+	}
+	return nil
+}

--- a/internal/json/marshal_test.go
+++ b/internal/json/marshal_test.go
@@ -1,0 +1,211 @@
+package json
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func TestMarshalStruct(t *testing.T) {
+	tests := []struct {
+		desc  string
+		value interface{}
+		want  map[string]interface{}
+		err   bool
+	}{
+		{
+			desc: "struct with no additional fields",
+			value: struct {
+				Name string
+				Int  int
+			}{
+				Name: "my name",
+				Int:  5,
+			},
+			want: map[string]interface{}{
+				"Name": "my name",
+				"Int":  5,
+			},
+		},
+		{
+			desc: "*struct with AdditionalFields",
+			value: &struct {
+				Name             string
+				Int              int
+				AdditionalFields map[string]interface{} `json:"-"`
+			}{
+				Name: "John Doak",
+				Int:  45,
+				AdditionalFields: map[string]interface{}{
+					"Hello": "World",
+					"Float": 3.2,
+				},
+			},
+			want: map[string]interface{}{
+				"Name":  "John Doak",
+				"Int":   45,
+				"Float": 3.2,
+				"Hello": "World",
+			},
+		},
+		{
+			desc: "AdditionalFields is not a map",
+			value: struct {
+				AdditionalFields string `json:"-"`
+			}{
+				AdditionalFields: "hello",
+			},
+			err: true,
+		},
+		{
+			desc: "AdditionalFields is not a map[string]interface{}",
+			value: struct {
+				AdditionalFields map[string]string `json:"-"`
+			}{
+				AdditionalFields: map[string]string{
+					"Hello": "World",
+				},
+			},
+			err: true,
+		},
+		{
+			desc: "Multiple Structs",
+			value: &StructA{
+				Name: "John",
+				ID:   3,
+				Meta: &StructB{
+					Address: "291 Street",
+					AdditionalFields: map[string]interface{}{
+						"unknown0": MarshalRaw(3.2),
+					},
+				},
+				AdditionalFields: map[string]interface{}{
+					"unknown0": MarshalRaw(10),
+					"unknown1": MarshalRaw("hello"),
+				},
+			},
+			want: map[string]interface{}{
+				"Name": "John",
+				"id":   3,
+				"Meta": map[string]interface{}{
+					"Address":  "291 Street",
+					"unknown0": 3.2,
+				},
+				"unknown0": 10,
+				"unknown1": "hello",
+			},
+		},
+		{
+			desc: "Struct with map[string]interface{}",
+			value: struct {
+				Name             string
+				Map              map[string]interface{}
+				AdditionalFields map[string]interface{}
+			}{
+				Name: "John",
+				Map: map[string]interface{}{
+					"key": "value",
+				},
+			},
+			want: map[string]interface{}{
+				"Name": "John",
+				"Map": map[string]interface{}{
+					"key": "value",
+				},
+			},
+		},
+		{
+			desc: "Struct with map[string]struct{}",
+			value: struct {
+				Name             string
+				Map              map[string]StructB
+				AdditionalFields map[string]interface{}
+			}{
+				Name: "John",
+				Map: map[string]StructB{
+					"key": StructB{
+						Address: "addr",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"Name": "John",
+				"Map": map[string]interface{}{
+					"key": map[string]interface{}{
+						"Address": "addr",
+					},
+				},
+			},
+		},
+		{
+			desc: "Struct with map[string][]<basic type>",
+			value: struct {
+				Name             string
+				Map              map[string]interface{}
+				AdditionalFields map[string]interface{}
+			}{
+				Name: "John",
+				Map: map[string]interface{}{
+					"key": []string{
+						"apples",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"Name": "John",
+				"Map": map[string]interface{}{
+					"key": []string{"apples"},
+				},
+			},
+		},
+		{
+			desc: "Struct with map[string][]struct",
+			value: struct {
+				Name             string
+				Map              map[string][]StructB
+				AdditionalFields map[string]interface{}
+			}{
+				Name: "John",
+				Map: map[string][]StructB{
+					"key": []StructB{
+						{Address: "addr"},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"Name": "John",
+				"Map": map[string]interface{}{
+					"key": []interface{}{
+						map[string]interface{}{
+							"Address": "addr",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		b, err := Marshal(test.value)
+		switch {
+		case err == nil && test.err:
+			t.Errorf("TestMarshal(%s): got err == nil, want err != nil", test.desc)
+			continue
+		case err != nil && !test.err:
+			t.Errorf("TestMarshal(%s): got err == %s, want err == nil", test.desc, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		got := map[string]interface{}{}
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Errorf("TestMarshal(%s): Marshal produced invalid JSON:\n%s\n%s", test.desc, err, string(b))
+			continue
+		}
+		if diff := pretty.Compare(test.want, got); diff != "" {
+			t.Errorf("TestMarshal(%s): -want/+got:\n%s", test.desc, diff)
+		}
+	}
+}

--- a/internal/json/marshal_test.go
+++ b/internal/json/marshal_test.go
@@ -124,7 +124,7 @@ func TestMarshalStruct(t *testing.T) {
 			}{
 				Name: "John",
 				Map: map[string]StructB{
-					"key": StructB{
+					"key": {
 						Address: "addr",
 					},
 				},
@@ -168,7 +168,7 @@ func TestMarshalStruct(t *testing.T) {
 			}{
 				Name: "John",
 				Map: map[string][]StructB{
-					"key": []StructB{
+					"key": {
 						{Address: "addr"},
 					},
 				},

--- a/internal/json/struct.go
+++ b/internal/json/struct.go
@@ -39,7 +39,6 @@ type decoder struct {
 	dec        *json.Decoder
 	value      reflect.Value // This will be a reflect.Struct
 	translator translateFields
-	hasAdd     bool
 	key        string
 }
 

--- a/internal/json/struct.go
+++ b/internal/json/struct.go
@@ -1,0 +1,288 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func unmarshalStruct(jdec *json.Decoder, i interface{}) error {
+	v := reflect.ValueOf(i)
+	if v.Kind() != reflect.Ptr {
+		return fmt.Errorf("Unmarshal() received type %T, which is not a *struct", i)
+	}
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("Unmarshal() received type %T, which is not a *struct", i)
+	}
+
+	if hasUnmarshalJSON(v) {
+		// Indicates that this type has a custom Unmarshaler.
+		return jdec.Decode(v.Addr().Interface())
+	}
+
+	f := v.FieldByName(addField)
+	if f.Kind() == reflect.Invalid {
+		return fmt.Errorf("Unmarshal(%T) only supports structs that have the field AdditionalFields or implements json.Unmarshaler", i)
+	}
+
+	if f.Kind() != reflect.Map || !f.Type().AssignableTo(mapStrInterType) {
+		return fmt.Errorf("type %T has field 'AdditionalFields' that is not a map[string]interface{}", i)
+	}
+
+	dec := newDecoder(jdec, v)
+	return dec.run()
+}
+
+type decoder struct {
+	dec        *json.Decoder
+	value      reflect.Value // This will be a reflect.Struct
+	translator translateFields
+	hasAdd     bool
+	key        string
+}
+
+func newDecoder(dec *json.Decoder, value reflect.Value) *decoder {
+	return &decoder{value: value, dec: dec}
+}
+
+// run runs our decoder state machine.
+func (d *decoder) run() error {
+	var state = d.start
+	var err error
+	for {
+		state, err = state()
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			return nil
+		}
+	}
+}
+
+// start looks for our opening delimeter '{' and then transitions to looping through our fields.
+func (d *decoder) start() (stateFn, error) {
+	var err error
+	d.translator, err = findFields(d.value)
+	if err != nil {
+		return nil, err
+	}
+
+	delim, err := d.dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if !delimIs(delim, '{') {
+		return nil, fmt.Errorf("Unmarshal expected opening {, received %v", delim)
+	}
+
+	return d.next, nil
+}
+
+// next gets the next struct field name from the raw json or stops the machine if we get our closing }.
+func (d *decoder) next() (stateFn, error) {
+	if !d.dec.More() {
+		// Remove the closing }.
+		if _, err := d.dec.Token(); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	key, err := d.dec.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	d.key = key.(string)
+	return d.storeValue, nil
+}
+
+// storeValue takes the next value and stores it our struct. If the field can't be found
+// in the struct, it pushes the operation to storeAdditional().
+func (d *decoder) storeValue() (stateFn, error) {
+	goName := d.translator.goName(d.key)
+	if goName == "" {
+		goName = d.key
+	}
+
+	// We don't have the field in the struct, so it goes in AdditionalFields.
+	f := d.value.FieldByName(goName)
+	if f.Kind() == reflect.Invalid {
+		return d.storeAdditional, nil
+	}
+
+	// Indicates that this type has a custom Unmarshaler.
+	if hasUnmarshalJSON(f) {
+		err := d.dec.Decode(f.Addr().Interface())
+		if err != nil {
+			return nil, err
+		}
+		return d.next, nil
+	}
+
+	t, isPtr, err := fieldBaseType(d.value, goName)
+	if err != nil {
+		return nil, fmt.Errorf("type(%s) had field(%s) %w", d.value.Type().Name(), goName, err)
+	}
+
+	switch t.Kind() {
+	// We need to recursively call ourselves on any *struct or struct.
+	case reflect.Struct:
+		if isPtr {
+			if f.IsNil() {
+				f.Set(reflect.New(t))
+			}
+		} else {
+			f = f.Addr()
+		}
+		if err := unmarshalStruct(d.dec, f.Interface()); err != nil {
+			return nil, err
+		}
+		return d.next, nil
+	case reflect.Map:
+		v := reflect.MakeMap(f.Type())
+		ptr := newValue(f.Type())
+		ptr.Elem().Set(v)
+		if err := unmarshalMap(d.dec, ptr); err != nil {
+			return nil, err
+		}
+		f.Set(ptr.Elem())
+		return d.next, nil
+	case reflect.Slice:
+		v := reflect.MakeSlice(f.Type(), 0, 0)
+		ptr := newValue(f.Type())
+		ptr.Elem().Set(v)
+		if err := unmarshalSlice(d.dec, ptr); err != nil {
+			return nil, err
+		}
+		f.Set(ptr.Elem())
+		return d.next, nil
+	}
+
+	if !isPtr {
+		f = f.Addr()
+	}
+
+	// For values that are pointers, we need them to be non-nil in order
+	// to decode into them.
+	if f.IsNil() {
+		f.Set(reflect.New(t))
+	}
+
+	if err := d.dec.Decode(f.Interface()); err != nil {
+		return nil, err
+	}
+
+	return d.next, nil
+}
+
+// storeAdditional pushes the key/value into our .AdditionalFields map.
+func (d *decoder) storeAdditional() (stateFn, error) {
+	rw := json.RawMessage{}
+	if err := d.dec.Decode(&rw); err != nil {
+		return nil, err
+	}
+	field := d.value.FieldByName(addField)
+	if field.IsNil() {
+		field.Set(reflect.MakeMap(field.Type()))
+	}
+	field.SetMapIndex(reflect.ValueOf(d.key), reflect.ValueOf(rw))
+	return d.next, nil
+}
+
+func fieldBaseType(v reflect.Value, fieldName string) (t reflect.Type, isPtr bool, err error) {
+	sf, ok := v.Type().FieldByName(fieldName)
+	if !ok {
+		return nil, false, fmt.Errorf("bug: fieldBaseType() lookup of field(%s) on type(%s): do not have field", fieldName, v.Type().Name())
+	}
+	t = sf.Type
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		isPtr = true
+	}
+	if t.Kind() == reflect.Ptr {
+		return nil, isPtr, fmt.Errorf("received pointer to pointer type, not supported")
+	}
+	return t, isPtr, nil
+}
+
+type translateField struct {
+	jsonName string
+	goName   string
+}
+
+// translateFields is a list of translateFields with a handy lookup method.
+type translateFields []translateField
+
+// goName loops through a list of fields looking for one contaning the jsonName and
+// returning the goName. If not found, returns the empty string.
+// Note: not a map because at this size slices are faster even in tight loops.
+func (t translateFields) goName(jsonName string) string {
+	for _, entry := range t {
+		if entry.jsonName == jsonName {
+			return entry.goName
+		}
+	}
+	return ""
+}
+
+// jsonName loops through a list of fields looking for one contaning the goName and
+// returning the jsonName. If not found, returns the empty string.
+// Note: not a map because at this size slices are faster even in tight loops.
+func (t translateFields) jsonName(goName string) string {
+	for _, entry := range t {
+		if entry.goName == goName {
+			return entry.jsonName
+		}
+	}
+	return ""
+}
+
+var umarshalerType = reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
+
+// findFields parses a struct and writes the field tags for lookup. It will return an error
+// if any field has a type of *struct or struct that does not implement json.Marshaler.
+func findFields(v reflect.Value) (translateFields, error) {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("findFields received a %s type, expected *struct or struct", v.Type().Name())
+	}
+	tfs := make([]translateField, 0, v.NumField())
+	for i := 0; i < v.NumField(); i++ {
+		tf := translateField{
+			goName:   v.Type().Field(i).Name,
+			jsonName: parseTag(v.Type().Field(i).Tag.Get("json")),
+		}
+		switch tf.jsonName {
+		case "", "-":
+			tf.jsonName = tf.goName
+		}
+		tfs = append(tfs, tf)
+
+		f := v.Field(i)
+		if f.Kind() == reflect.Ptr {
+			f = f.Elem()
+		}
+		if f.Kind() == reflect.Struct {
+			if f.Type().Implements(umarshalerType) {
+				return nil, fmt.Errorf("struct type %q which has field %q which "+
+					"doesn't implement json.Unmarshaler", v.Type().Name(), v.Type().Field(i).Name)
+			}
+		}
+	}
+	return tfs, nil
+}
+
+// parseTag just returns the first entry in the tag. tag is the string
+// returned by reflect.StructField.Tag().Get().
+func parseTag(tag string) string {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx]
+	}
+	return tag
+}

--- a/internal/json/struct_test.go
+++ b/internal/json/struct_test.go
@@ -1,0 +1,249 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func TestDecoderStart(t *testing.T) {
+	tests := []struct {
+		desc    string
+		b       []byte
+		i       interface{}
+		stateFn stateFn
+		err     bool
+	}{
+		{
+			desc:    "No content to decode",
+			i:       &StructA{},
+			stateFn: nil,
+			err:     true,
+		},
+		{
+			desc:    "No opening brace",
+			b:       []byte("3"),
+			i:       &StructA{},
+			stateFn: nil,
+			err:     true,
+		},
+		{
+			desc:    "Success",
+			b:       []byte(`{"Name": "value"}`),
+			i:       &StructA{},
+			stateFn: (new(decoder).next),
+		},
+	}
+
+	for _, test := range tests {
+		dec := newDecoder(json.NewDecoder(bytes.NewBuffer(test.b)), reflect.ValueOf(test.i))
+		stateFn, err := dec.start()
+		switch {
+		case err == nil && test.err:
+			t.Errorf("TestDecoderStart(%s): got err == nil, want err != nil", test.desc)
+			continue
+		case err != nil && !test.err:
+			t.Errorf("TestDecoderStart(%s): got err == %s, want err == nil", test.desc, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		gotStateFn := runtime.FuncForPC(reflect.ValueOf(stateFn).Pointer()).Name()
+		wantStateFn := runtime.FuncForPC(reflect.ValueOf(test.stateFn).Pointer()).Name()
+		if gotStateFn != wantStateFn {
+			t.Errorf("TestDecoderStart(%s): got(stateFn) %s, want %s", test.desc, gotStateFn, wantStateFn)
+		}
+	}
+}
+
+func TestDecoderNext(t *testing.T) {
+	tests := []struct {
+		desc string
+		b    []byte
+		// advToken advanced the decoder this may Token() calls, as the decoder only works
+		// on well formed JSON.
+		advToken int
+		i        interface{}
+		key      string
+		stateFn  stateFn
+		err      bool
+	}{
+		{
+			desc:    "No content to decode",
+			i:       &StructA{},
+			stateFn: nil,
+			err:     true,
+		},
+		{
+			desc:     "Bad ] found",
+			b:        []byte("{]"),
+			advToken: 1,
+			i:        &StructA{},
+			stateFn:  nil,
+			err:      true,
+		},
+		{
+			desc:     "Closing brace",
+			b:        []byte("{}"),
+			advToken: 1,
+			i:        &StructA{},
+			stateFn:  nil,
+			err:      false,
+		},
+		{
+			desc:     "Success",
+			b:        []byte(`{"Name": "value"}`),
+			advToken: 1,
+			i:        &StructA{},
+			key:      "Name",
+			stateFn:  (new(decoder).storeValue),
+		},
+	}
+
+	for _, test := range tests {
+		dec := newDecoder(json.NewDecoder(bytes.NewBuffer(test.b)), reflect.ValueOf(test.i))
+		for i := 0; i < test.advToken; i++ {
+			dec.dec.Token()
+		}
+
+		stateFn, err := dec.next()
+		switch {
+		case err == nil && test.err:
+			t.Errorf("TestDecoderNext(%s): got err == nil, want err != nil", test.desc)
+			continue
+		case err != nil && !test.err:
+			t.Errorf("TestDecoderNext(%s): got err == %s, want err == nil", test.desc, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		if dec.key != test.key {
+			t.Errorf("TestDecoderNext(%s): got(.key) %s, want %s", test.desc, dec.key, test.key)
+		}
+
+		gotStateFn := runtime.FuncForPC(reflect.ValueOf(stateFn).Pointer()).Name()
+		wantStateFn := runtime.FuncForPC(reflect.ValueOf(test.stateFn).Pointer()).Name()
+		if gotStateFn != wantStateFn {
+			t.Errorf("TestDecoderNext(%s): got(stateFn) %s, want %s", test.desc, gotStateFn, wantStateFn)
+		}
+	}
+}
+
+func TestDecoderStoreValue(t *testing.T) {
+	tests := []struct {
+		desc    string
+		b       []byte
+		want    StructA
+		stateFn stateFn
+	}{
+		{
+			desc:    "Field found, no struct tag",
+			b:       []byte(`{"Name": "myName"}`),
+			want:    StructA{Name: "myName"},
+			stateFn: (new(decoder).next),
+		},
+		{
+			desc:    "Field found, using struct tag",
+			b:       []byte(`{"id": 3}`),
+			want:    StructA{ID: 3},
+			stateFn: (new(decoder).next),
+		},
+		{
+			desc:    "Field not found, go to storeAdditional()",
+			b:       []byte(`{"blah": 3}`),
+			want:    StructA{},
+			stateFn: (new(decoder).storeAdditional),
+		},
+	}
+
+	for _, test := range tests {
+		got := StructA{}
+		dec := newDecoder(json.NewDecoder(bytes.NewBuffer(test.b)), reflect.ValueOf(&got).Elem())
+		dec.start() // populates our translator field
+		dec.next()
+
+		stateFn, err := dec.storeValue()
+		if err != nil {
+			t.Errorf("TestDecoderStoreValue(%s): got err == %s, want err == nil", test.desc, err)
+			continue
+		}
+
+		if diff := pretty.Compare(test.want, got); diff != "" {
+			t.Errorf("TestDecoderStoreValue(%s): -want/+got:\n%s", test.desc, diff)
+			continue
+		}
+
+		gotStateFn := runtime.FuncForPC(reflect.ValueOf(stateFn).Pointer()).Name()
+		wantStateFn := runtime.FuncForPC(reflect.ValueOf(test.stateFn).Pointer()).Name()
+		if gotStateFn != wantStateFn {
+			t.Errorf("TestDecoderStoreValue(%s): got(stateFn) %s, want %s", test.desc, gotStateFn, wantStateFn)
+		}
+	}
+}
+
+func TestDecoderStoreAdditional(t *testing.T) {
+	tests := []struct {
+		desc    string
+		b       []byte
+		got     StructA
+		want    StructA
+		stateFn stateFn
+	}{
+		{
+			desc: "Map not initialized",
+			b:    []byte(`{"blah": "whatever"}`),
+			got:  StructA{},
+			want: StructA{
+				AdditionalFields: map[string]interface{}{
+					"blah": json.RawMessage(`"whatever"`),
+				},
+			},
+			stateFn: (new(decoder).next),
+		},
+		{
+			desc: "Map exists",
+			b:    []byte(`{"blah": "whatever"}`),
+			got: StructA{
+				AdditionalFields: map[string]interface{}{
+					"else": json.RawMessage(`"if"`),
+				},
+			},
+			want: StructA{
+				AdditionalFields: map[string]interface{}{
+					"else": json.RawMessage(`"if"`),
+					"blah": json.RawMessage(`"whatever"`),
+				},
+			},
+			stateFn: (new(decoder).next),
+		},
+	}
+
+	for _, test := range tests {
+		dec := newDecoder(json.NewDecoder(bytes.NewBuffer(test.b)), reflect.ValueOf(&test.got).Elem())
+		dec.start() // populates our translator field
+		dec.next()
+
+		stateFn, err := dec.storeAdditional()
+		if err != nil {
+			t.Errorf("TestDecoderStoreAdditional(%s): got err == %s, want err == nil", test.desc, err)
+			continue
+		}
+
+		if diff := pretty.Compare(test.want, test.got); diff != "" {
+			t.Errorf("TestDecoderStoreAdditional(%s): -want/+got:\n%s", test.desc, diff)
+			continue
+		}
+
+		gotStateFn := runtime.FuncForPC(reflect.ValueOf(stateFn).Pointer()).Name()
+		wantStateFn := runtime.FuncForPC(reflect.ValueOf(test.stateFn).Pointer()).Name()
+		if gotStateFn != wantStateFn {
+			t.Errorf("TestDecoderStoreAdditional(%s): got(stateFn) %s, want %s", test.desc, gotStateFn, wantStateFn)
+		}
+	}
+}


### PR DESCRIPTION
I was unable to locate an encoder/decoder that did what I wanted here.  Third-party json packages are really focused around speed, mostly by going to generated calls or reducing allocations.  

Unfortunately, I think the best way to look at this is the way you'd look at third-party code. You'd use it to see if it did what you wanted, and if it did, you'd import it (kinda like what you do with encoding/json).  

This code isn't going to be for the feint of heart.  It must use reflection and uses a state machine design.  This just means it is hard to follow, just like anything that uses reflection.  In essence, this is a JSON parser and json.Encoder/Decoder act as the lexer.  

I've included the design doc in markdown in the directory.  

This might be adding more code than is being removed.  However, when there is an error in this code, this seems to be a straightforward error that is returned vs silent errors when keys just don't get recorded.  In the most general sense, if the calls that use it work, then it works vs. the current situation where the tests will likely be silent.  

I did not do the integrations here, just the package add.  I'm still working on the integrations, as this necessitated a bunch of type conversions from pointers (yea!), interface changes, fixing tests, etc....  About 90% done there.  Once this goes in I'll send the next up. 