### PR TITLE
Adding additional fields in struct client info

### DIFF
--- a/internal/msalbase/token_response.go
+++ b/internal/msalbase/token_response.go
@@ -30,6 +30,8 @@ type tokenResponseJSONPayload struct {
 type ClientInfoJSONPayload struct {
 	UID  string `json:"uid"`
 	Utid string `json:"utid"`
+
+	AdditionalFields map[string]interface{}
 }
 
 // TokenResponse is the information that is returned from a token endpoint during a token acquisition flow.


### PR DESCRIPTION
When adding e2e test automation, found out that the changes introduced  in [PR 77](https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/77) broke some flows. 

Unmarshalling of ClientInfo gave an error as per [this](https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/dev/internal/json/design.md) doc in here : https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/dev/internal/json/struct.go#L27

Adding fix for this. 
