### PR TITLE
Support for setting redirect-url in token-fetch portion of confidential-app authentication code flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The MSAL library for Go is part of the [Microsoft identity platform for develope
 
 Quick links:
 
-| [Getting Started](https://docs.microsoft.com/azure/active-directory/develop/#quickstarts) | [GoDoc](https://godoc.org/github.com/AzureAD/microsoft-authentication-library-for-go/msal) | [Wiki](https://github.com/AzureAD/microsoft-authentication-library-for-go/wiki) | [Samples](https://github.com/AzureAD/microsoft-authentication-library-for-go/tree/dev/examples) | [Support](README.md#community-help-and-support) |
+| [Getting Started](https://docs.microsoft.com/azure/active-directory/develop/#quickstarts) | [GoDoc](https://godoc.org/github.com/AzureAD/microsoft-authentication-library-for-go/msal) | [Wiki](https://github.com/AzureAD/microsoft-authentication-library-for-go/wiki) | [Samples](https://github.com/AzureAD/microsoft-authentication-library-for-go/tree/test/devapps) | [Support](README.md#community-help-and-support) |
 | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | 
 
 ## Build Status

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Quick links:
 To install Go, visit [this link](https://golang.org/dl/).
 
 ### Installing MSAL Go
-`go get -u github.com/AzureAD/microsoft-authentication-library-for-go/`
+`go get -u github.com/AzureAD/microsoft-authentication-library-for-go/msal`
 
 ## Usage
 Before using MSAL Go, you will need to [register your application with the Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/quickstart-v2-register-an-app).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Quick links:
 To install Go, visit [this link](https://golang.org/dl/).
 
 ### Installing MSAL Go
-`go get -u github.com/AzureAD/microsoft-authentication-library-for-go/msal`
+`go get github.com/AzureAD/microsoft-authentication-library-for-go/msal`
 
 ## Usage
 Before using MSAL Go, you will need to [register your application with the Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/quickstart-v2-register-an-app).

--- a/msal/acquire_token_auth_code_parameters.go
+++ b/msal/acquire_token_auth_code_parameters.go
@@ -18,6 +18,7 @@ type acquireTokenAuthCodeParameters struct {
 	CodeChallenge    string
 	clientCredential msalbase.ClientCredential
 	requestType      requests.AuthCodeRequestType
+	RedirectURI      string
 }
 
 // createAcquireTokenAuthCodeParameters creates an AcquireTokenAuthCodeParameters instance.
@@ -30,6 +31,11 @@ func createAcquireTokenAuthCodeParameters(scopes []string) *acquireTokenAuthCode
 
 func (p *acquireTokenAuthCodeParameters) augmentAuthenticationParameters(authParams *msalbase.AuthParametersInternal) {
 	p.commonParameters.augmentAuthenticationParameters(authParams)
-	authParams.Redirecturi = "https://login.microsoftonline.com/common/oauth2/nativeclient"
+	if p.RedirectURI != "" {
+		authParams.Redirecturi = p.RedirectURI
+	}
+	if authParams.Redirecturi == "" { // set it to default if it is still not set
+		authParams.Redirecturi = "https://login.microsoftonline.com/common/oauth2/nativeclient"
+	}
 	authParams.AuthorizationType = msalbase.AuthorizationTypeAuthCode
 }

--- a/msal/confidential_client_application.go
+++ b/msal/confidential_client_application.go
@@ -103,6 +103,7 @@ func (cca *ConfidentialClientApplication) AcquireTokenByAuthCode(ctx context.Con
 	if options != nil {
 		authCodeParams.Code = options.Code
 		authCodeParams.CodeChallenge = options.CodeChallenge
+		authCodeParams.RedirectURI = options.RedirectURI
 	}
 	return cca.clientApplication.acquireTokenByAuthCode(ctx, authCodeParams)
 

--- a/msal/public_client_application.go
+++ b/msal/public_client_application.go
@@ -129,4 +129,5 @@ type AcquireTokenByDeviceCodeOptions struct {
 type AcquireTokenByAuthCodeOptions struct {
 	Code          string
 	CodeChallenge string
+	RedirectURI   string
 }


### PR DESCRIPTION
Changes
1. Correcting some broken links in README
2. Support for adding RedirectURI in token-fetch portion of confidential-app authentication code flow. 

See also this comment elsewhere for context https://github.com/Azure/azure-sdk-for-go/pull/13565#issuecomment-739461185

The change retains the ability to have a default RedirectURI while still allowing the caller to set one if available.
@jhendrixMSFT 