### PR TITLE
Make basic read/write methods private on storage.Manager

### DIFF
--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -95,7 +95,7 @@ func TestGetAllAccounts(t *testing.T) {
 	}
 }
 
-func TestdeleteAccounts(t *testing.T) {
+func TestDeleteAccounts(t *testing.T) {
 
 	testAccOne := msalbase.NewAccount("hid", "env", "realm", "lid", msalbase.MSSTS, "username")
 	testAccTwo := msalbase.NewAccount("HID", "ENV", "REALM", "LID", msalbase.MSSTS, "USERNAME")
@@ -114,7 +114,7 @@ func TestdeleteAccounts(t *testing.T) {
 	}
 }
 
-func TestreadAccessToken(t *testing.T) {
+func TestReadAccessToken(t *testing.T) {
 	testAccessToken := createAccessTokenCacheItem(
 		"hid",
 		"env",
@@ -159,7 +159,7 @@ func TestreadAccessToken(t *testing.T) {
 	}
 }
 
-func TestwriteAccessToken(t *testing.T) {
+func TestWriteAccessToken(t *testing.T) {
 	storageManager := New()
 	testAccessToken := createAccessTokenCacheItem(
 		"hid",
@@ -183,7 +183,7 @@ func TestwriteAccessToken(t *testing.T) {
 	}
 }
 
-func TestreadAccount(t *testing.T) {
+func TestReadAccount(t *testing.T) {
 	testAcc := msalbase.NewAccount("hid", "env", "realm", "lid", msalbase.MSSTS, "username")
 
 	cache := &CacheSerializationContract{
@@ -208,7 +208,7 @@ func TestreadAccount(t *testing.T) {
 	}
 }
 
-func TestwriteAccount(t *testing.T) {
+func TestWriteAccount(t *testing.T) {
 	storageManager := New()
 	testAcc := msalbase.NewAccount("hid", "env", "realm", "lid", msalbase.MSSTS, "username")
 	key := testAcc.CreateKey()
@@ -221,7 +221,7 @@ func TestwriteAccount(t *testing.T) {
 	}
 }
 
-func TestreadAppMetadata(t *testing.T) {
+func TestReadAppMetadata(t *testing.T) {
 	testAppMeta := CreateAppMetadata("fid", "cid", "env")
 
 	cache := &CacheSerializationContract{
@@ -246,7 +246,7 @@ func TestreadAppMetadata(t *testing.T) {
 	}
 }
 
-func TestwriteAppMetadata(t *testing.T) {
+func TestWriteAppMetadata(t *testing.T) {
 	storageManager := New()
 	testAppMeta := CreateAppMetadata("fid", "cid", "env")
 	key := testAppMeta.CreateKey()
@@ -259,7 +259,7 @@ func TestwriteAppMetadata(t *testing.T) {
 	}
 }
 
-func TestreadIDToken(t *testing.T) {
+func TestReadIDToken(t *testing.T) {
 	testIDToken := CreateIDTokenCacheItem(
 		"hid",
 		"env",
@@ -300,7 +300,7 @@ func TestreadIDToken(t *testing.T) {
 	}
 }
 
-func TestwriteIDToken(t *testing.T) {
+func TestWriteIDToken(t *testing.T) {
 	storageManager := New()
 	testIDToken := CreateIDTokenCacheItem(
 		"hid",
@@ -535,7 +535,7 @@ func TestDefaultStorageManagerreadRefreshToken(t *testing.T) {
 	}
 }
 
-func TestwriteRefreshToken(t *testing.T) {
+func TestWriteRefreshToken(t *testing.T) {
 	storageManager := New()
 	testRefreshToken := CreateRefreshTokenCacheItem(
 		"hid",

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -95,7 +95,7 @@ func TestGetAllAccounts(t *testing.T) {
 	}
 }
 
-func TestDeleteAccounts(t *testing.T) {
+func TestdeleteAccounts(t *testing.T) {
 
 	testAccOne := msalbase.NewAccount("hid", "env", "realm", "lid", msalbase.MSSTS, "username")
 	testAccTwo := msalbase.NewAccount("HID", "ENV", "REALM", "LID", msalbase.MSSTS, "USERNAME")
@@ -108,13 +108,13 @@ func TestDeleteAccounts(t *testing.T) {
 	storageManager := New()
 	storageManager.Update(cache)
 
-	err := storageManager.DeleteAccounts("hid", []string{"hello", "env", "test"})
+	err := storageManager.deleteAccounts("hid", []string{"hello", "env", "test"})
 	if err != nil {
 		t.Errorf("Error is supposed to be nil; instead it is %v", err)
 	}
 }
 
-func TestReadAccessToken(t *testing.T) {
+func TestreadAccessToken(t *testing.T) {
 	testAccessToken := createAccessTokenCacheItem(
 		"hid",
 		"env",
@@ -134,7 +134,7 @@ func TestReadAccessToken(t *testing.T) {
 	storageManager := New()
 	storageManager.Update(cache)
 
-	retAccessToken, err := storageManager.ReadAccessToken(
+	retAccessToken, err := storageManager.readAccessToken(
 		"hid",
 		[]string{"hello", "env", "test"},
 		"realm",
@@ -142,12 +142,12 @@ func TestReadAccessToken(t *testing.T) {
 		[]string{"user.read", "openid"},
 	)
 	if err != nil {
-		t.Errorf("ReadAccessToken(): got err == %s, want err == nil", err)
+		t.Errorf("readAccessToken(): got err == %s, want err == nil", err)
 	}
 	if diff := pretty.Compare(testAccessToken, retAccessToken); diff != "" {
 		t.Fatalf("Returned access token is not the same as expected access token: -want/+got:\n%s", diff)
 	}
-	_, err = storageManager.ReadAccessToken(
+	_, err = storageManager.readAccessToken(
 		"this_should_break_it",
 		[]string{"hello", "env", "test"},
 		"realm",
@@ -155,11 +155,11 @@ func TestReadAccessToken(t *testing.T) {
 		[]string{"user.read", "openid"},
 	)
 	if err == nil {
-		t.Errorf("ReadAccessToken(): got err == nil, want err != nil")
+		t.Errorf("readAccessToken(): got err == nil, want err != nil")
 	}
 }
 
-func TestWriteAccessToken(t *testing.T) {
+func TestwriteAccessToken(t *testing.T) {
 	storageManager := New()
 	testAccessToken := createAccessTokenCacheItem(
 		"hid",
@@ -173,17 +173,17 @@ func TestWriteAccessToken(t *testing.T) {
 		"secret",
 	)
 	key := testAccessToken.CreateKey()
-	err := storageManager.WriteAccessToken(testAccessToken)
+	err := storageManager.writeAccessToken(testAccessToken)
 	if err != nil {
-		t.Fatalf("TestWriteAccessToken: got err == %s, want err == nil", err)
+		t.Fatalf("TestwriteAccessToken: got err == %s, want err == nil", err)
 	}
 
 	if diff := pretty.Compare(testAccessToken, storageManager.Contract().AccessTokens[key]); diff != "" {
-		t.Errorf("TestWriteAccessToken: -want/+got:\n%s", diff)
+		t.Errorf("TestwriteAccessToken: -want/+got:\n%s", diff)
 	}
 }
 
-func TestReadAccount(t *testing.T) {
+func TestreadAccount(t *testing.T) {
 	testAcc := msalbase.NewAccount("hid", "env", "realm", "lid", msalbase.MSSTS, "username")
 
 	cache := &CacheSerializationContract{
@@ -194,34 +194,34 @@ func TestReadAccount(t *testing.T) {
 	storageManager := New()
 	storageManager.Update(cache)
 
-	returnedAccount, err := storageManager.ReadAccount("hid", []string{"hello", "env", "test"}, "realm")
+	returnedAccount, err := storageManager.readAccount("hid", []string{"hello", "env", "test"}, "realm")
 	if err != nil {
-		t.Fatalf("TestReadAccount: got err == %s, want err == nil", err)
+		t.Fatalf("TestreadAccount: got err == %s, want err == nil", err)
 	}
 	if diff := pretty.Compare(testAcc, returnedAccount); diff != "" {
-		t.Errorf("TestReadAccount: -want/+got:\n%s", diff)
+		t.Errorf("TestreadAccount: -want/+got:\n%s", diff)
 	}
 
-	_, err = storageManager.ReadAccount("this_should_break_it", []string{"hello", "env", "test"}, "realm")
+	_, err = storageManager.readAccount("this_should_break_it", []string{"hello", "env", "test"}, "realm")
 	if err == nil {
-		t.Errorf("TestReadAccount: got err == nil, want err != nil")
+		t.Errorf("TestreadAccount: got err == nil, want err != nil")
 	}
 }
 
-func TestWriteAccount(t *testing.T) {
+func TestwriteAccount(t *testing.T) {
 	storageManager := New()
 	testAcc := msalbase.NewAccount("hid", "env", "realm", "lid", msalbase.MSSTS, "username")
 	key := testAcc.CreateKey()
-	err := storageManager.WriteAccount(testAcc)
+	err := storageManager.writeAccount(testAcc)
 	if err != nil {
-		t.Fatalf("TestWriteAccount: got err == %s, want err == nil", err)
+		t.Fatalf("TestwriteAccount: got err == %s, want err == nil", err)
 	}
 	if diff := pretty.Compare(testAcc, storageManager.Contract().Accounts[key]); diff != "" {
-		t.Errorf("TestWriteAccount: -want/+got:\n%s", diff)
+		t.Errorf("TestwriteAccount: -want/+got:\n%s", diff)
 	}
 }
 
-func TestReadAppMetadata(t *testing.T) {
+func TestreadAppMetadata(t *testing.T) {
 	testAppMeta := CreateAppMetadata("fid", "cid", "env")
 
 	cache := &CacheSerializationContract{
@@ -232,34 +232,34 @@ func TestReadAppMetadata(t *testing.T) {
 	storageManager := New()
 	storageManager.Update(cache)
 
-	returnedAppMeta, err := storageManager.ReadAppMetadata([]string{"hello", "test", "env"}, "cid")
+	returnedAppMeta, err := storageManager.readAppMetadata([]string{"hello", "test", "env"}, "cid")
 	if err != nil {
-		t.Fatalf("TestReadAppMetadata(ReadAppMetadata): got err == %s, want err == nil", err)
+		t.Fatalf("TestreadAppMetadata(readAppMetadata): got err == %s, want err == nil", err)
 	}
 	if diff := pretty.Compare(testAppMeta, returnedAppMeta); diff != "" {
-		t.Fatalf("TestReadAppMetadata(ReadAppMetadata): -want/+got:\n%s", diff)
+		t.Fatalf("TestreadAppMetadata(readAppMetadata): -want/+got:\n%s", diff)
 	}
 
-	_, err = storageManager.ReadAppMetadata([]string{"hello", "test", "env"}, "break_this")
+	_, err = storageManager.readAppMetadata([]string{"hello", "test", "env"}, "break_this")
 	if err == nil {
-		t.Fatalf("TestReadAppMetadata(bad ReadAppMetadata): got err == nil, want err != nil")
+		t.Fatalf("TestreadAppMetadata(bad readAppMetadata): got err == nil, want err != nil")
 	}
 }
 
-func TestWriteAppMetadata(t *testing.T) {
+func TestwriteAppMetadata(t *testing.T) {
 	storageManager := New()
 	testAppMeta := CreateAppMetadata("fid", "cid", "env")
 	key := testAppMeta.CreateKey()
-	err := storageManager.WriteAppMetadata(testAppMeta)
+	err := storageManager.writeAppMetadata(testAppMeta)
 	if err != nil {
-		t.Fatalf("TestWriteAppMetadata: got err == %s, want err == nil", err)
+		t.Fatalf("TestwriteAppMetadata: got err == %s, want err == nil", err)
 	}
 	if diff := pretty.Compare(testAppMeta, storageManager.Contract().AppMetadata[key]); diff != "" {
-		t.Errorf("TestWriteAppMetadata: -want/+got:\n%s", diff)
+		t.Errorf("TestwriteAppMetadata: -want/+got:\n%s", diff)
 	}
 }
 
-func TestReadIDToken(t *testing.T) {
+func TestreadIDToken(t *testing.T) {
 	testIDToken := CreateIDTokenCacheItem(
 		"hid",
 		"env",
@@ -275,7 +275,7 @@ func TestReadIDToken(t *testing.T) {
 	storageManager := New()
 	storageManager.Update(cache)
 
-	returnedIDToken, err := storageManager.ReadIDToken(
+	returnedIDToken, err := storageManager.readIDToken(
 		"hid",
 		[]string{"hello", "env", "test"},
 		"realm",
@@ -286,21 +286,21 @@ func TestReadIDToken(t *testing.T) {
 	}
 
 	if diff := pretty.Compare(testIDToken, returnedIDToken); diff != "" {
-		t.Fatalf("TestReadIDToken(good token): -want/+got:\n%s", diff)
+		t.Fatalf("TestreadIDToken(good token): -want/+got:\n%s", diff)
 	}
 
-	_, err = storageManager.ReadIDToken(
+	_, err = storageManager.readIDToken(
 		"this_should_break_it",
 		[]string{"hello", "env", "test"},
 		"realm",
 		"cid",
 	)
 	if err == nil {
-		t.Errorf("TestReadIDToken(bad token): got err == nil, want err != nil")
+		t.Errorf("TestreadIDToken(bad token): got err == nil, want err != nil")
 	}
 }
 
-func TestWriteIDToken(t *testing.T) {
+func TestwriteIDToken(t *testing.T) {
 	storageManager := New()
 	testIDToken := CreateIDTokenCacheItem(
 		"hid",
@@ -310,17 +310,17 @@ func TestWriteIDToken(t *testing.T) {
 		"secret",
 	)
 	key := testIDToken.CreateKey()
-	err := storageManager.WriteIDToken(testIDToken)
+	err := storageManager.writeIDToken(testIDToken)
 	if err != nil {
-		t.Fatalf("TestWriteIDToken: got err == %s, want err == nil", err)
+		t.Fatalf("TestwriteIDToken: got err == %s, want err == nil", err)
 	}
 
 	if diff := pretty.Compare(testIDToken, storageManager.Contract().IDTokens[key]); diff != "" {
-		t.Errorf("TestWriteIDToken: -want/+got:\n%s", diff)
+		t.Errorf("TestwriteIDToken: -want/+got:\n%s", diff)
 	}
 }
 
-func TestDefaultStorageManagerReadRefreshToken(t *testing.T) {
+func TestDefaultStorageManagerreadRefreshToken(t *testing.T) {
 	testRefreshTokenWithFID := CreateRefreshTokenCacheItem(
 		"hid",
 		"env",
@@ -518,24 +518,24 @@ func TestDefaultStorageManagerReadRefreshToken(t *testing.T) {
 	for _, test := range tests {
 		m.Update(test.contract)
 
-		got, err := m.ReadRefreshToken(test.args.homeAccountID, test.args.envAliases, test.args.familyID, test.args.clientID)
+		got, err := m.readRefreshToken(test.args.homeAccountID, test.args.envAliases, test.args.familyID, test.args.clientID)
 		switch {
 		case test.err && err == nil:
-			t.Errorf("TestDefaultStorageManagerReadRefreshToken(%s): got err == nil, want err != nil", test.name)
+			t.Errorf("TestDefaultStorageManagerreadRefreshToken(%s): got err == nil, want err != nil", test.name)
 			continue
 		case !test.err && err != nil:
-			t.Errorf("TestDefaultStorageManagerReadRefreshToken(%s): got err == %s, want err == nil", test.name, err)
+			t.Errorf("TestDefaultStorageManagerreadRefreshToken(%s): got err == %s, want err == nil", test.name, err)
 			continue
 		case err != nil:
 			continue
 		}
 		if diff := pretty.Compare(test.want, got); diff != "" {
-			t.Errorf("TestDefaultStorageManagerReadRefreshToken(%s): -want/+got:\n%s", test.name, diff)
+			t.Errorf("TestDefaultStorageManagerreadRefreshToken(%s): -want/+got:\n%s", test.name, diff)
 		}
 	}
 }
 
-func TestWriteRefreshToken(t *testing.T) {
+func TestwriteRefreshToken(t *testing.T) {
 	storageManager := New()
 	testRefreshToken := CreateRefreshTokenCacheItem(
 		"hid",
@@ -545,7 +545,7 @@ func TestWriteRefreshToken(t *testing.T) {
 		"fid",
 	)
 	key := testRefreshToken.CreateKey()
-	err := storageManager.WriteRefreshToken(testRefreshToken)
+	err := storageManager.writeRefreshToken(testRefreshToken)
 	if err != nil {
 		t.Errorf("Error should be nil, but it is %v", err)
 	}


### PR DESCRIPTION
The public interface here can be slimmed down.  Made all basic Read* or Write* methods into private methods.

This allows a move to a single mutex for used in CacheTokenResponse(), which is the only public writer.