### PR TITLE
Adding ID Token check in E2E tests 

### DIFF
--- a/apps/tests/integration/integration_test.go
+++ b/apps/tests/integration/integration_test.go
@@ -197,6 +197,9 @@ func TestUsernamePassword(t *testing.T) {
 		if result.AccessToken == "" {
 			t.Fatalf("TestUsernamePassword(%s): got AccessToken == '', want AccessToken == non-empty string", test.desc)
 		}
+		if result.IDToken.IsZero() {
+			t.Fatalf("TestUsernamePassword(%s): got IDToken == empty, want IDToken == non-empty struct", test.desc)
+		}
 		if result.Account.PreferredUsername != user.Upn {
 			t.Fatalf("TestUsernamePassword(%s): got Username == %s, want Username == %s", test.desc, result.Account.PreferredUsername, user.Upn)
 		}


### PR DESCRIPTION
Adding the IDToken check in E2E tests now that IDtoken is exposed : https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/107 as a part of this PR : https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/117