### PR TITLE
Fixed cacheAccessor option

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -128,7 +128,7 @@ func New(clientID string, authorityURI string, cacheAccessor cache.ExportReplace
 	return Client{ // Note: Hey, don't even THINK about making Base into *Base. See "design notes" in public.go and confidential.go
 		Token:         token,
 		AuthParams:    authParams,
-		cacheAccessor: noopCacheAccessor{},
+		cacheAccessor: cacheAccessor,
 		manager:       storage.New(token),
 	}, nil
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -35,11 +35,6 @@ type manager interface {
 	GetAllAccounts() ([]shared.Account, error)
 }
 
-type noopCacheAccessor struct{}
-
-func (n noopCacheAccessor) Replace(cache cache.Unmarshaler) {}
-func (n noopCacheAccessor) Export(cache cache.Marshaler)    {}
-
 // AcquireTokenSilentParameters contains the parameters to acquire a token silently (from cache).
 type AcquireTokenSilentParameters struct {
 	Scopes      []string

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -32,6 +32,11 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/shared"
 )
 
+type noopCacheAccessor struct{}
+
+func (n noopCacheAccessor) Replace(cache cache.Unmarshaler) {}
+func (n noopCacheAccessor) Export(cache cache.Marshaler)    {}
+
 // AuthResult contains the results of one token acquisition operation.
 // For details see https://aka.ms/msal-net-authenticationresult
 type AuthResult = base.AuthResult
@@ -85,7 +90,7 @@ type Client struct {
 
 // New is the constructor for Client.
 func New(clientID string, options ...Option) (Client, error) {
-	opts := Options{Authority: base.AuthorityPublicCloud}
+	opts := Options{Authority: base.AuthorityPublicCloud, Accessor: noopCacheAccessor{}}
 
 	for _, o := range options {
 		o(&opts)


### PR DESCRIPTION
Refactored `base.go` and `public.go` to accept the `cacheAccessor` parameters properly.