### PR TITLE
Fixing cache accessor

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -232,7 +232,7 @@ func New(clientID string, cred Credential, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, opts.Accessor, tokener)
+	base, err := base.New(clientID, opts.Authority, tokener, base.WithCacheAccessor(opts.Accessor))
 	if err != nil {
 		return Client{}, err
 	}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -123,11 +123,13 @@ func New(clientID string, authorityURI string, cacheAccessor cache.ExportReplace
 		return Client{}, err
 	}
 	authParams := authority.NewAuthParams(clientID, authInfo)
-
+	if cacheAccessor == nil {
+		cacheAccessor = noopCacheAccessor{}
+	}
 	return Client{ // Note: Hey, don't even THINK about making Base into *Base. See "design notes" in public.go and confidential.go
 		Token:         token,
 		AuthParams:    authParams,
-		cacheAccessor: noopCacheAccessor{},
+		cacheAccessor: cacheAccessor,
 		manager:       storage.New(token),
 	}, nil
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -116,22 +116,36 @@ type Client struct {
 	cacheAccessor cache.ExportReplace
 }
 
+// Option is an optional argument to the New constructor.
+type Option func(c *Client)
+
+// WithCacheAccessor allows you to set some type of cache for storing authentication tokens.
+func WithCacheAccessor(ca cache.ExportReplace) Option {
+	return func(c *Client) {
+		if ca != nil {
+			c.cacheAccessor = ca
+		}
+	}
+}
+
 // New is the constructor for Base.
-func New(clientID string, authorityURI string, cacheAccessor cache.ExportReplace, token *oauth.Client) (Client, error) {
+func New(clientID string, authorityURI string, token *oauth.Client, options ...Option) (Client, error) {
 	authInfo, err := authority.NewInfoFromAuthorityURI(authorityURI, true)
 	if err != nil {
 		return Client{}, err
 	}
 	authParams := authority.NewAuthParams(clientID, authInfo)
-	if cacheAccessor == nil {
-		cacheAccessor = noopCacheAccessor{}
-	}
-	return Client{ // Note: Hey, don't even THINK about making Base into *Base. See "design notes" in public.go and confidential.go
+	client := Client{ // Note: Hey, don't even THINK about making Base into *Base. See "design notes" in public.go and confidential.go
 		Token:         token,
 		AuthParams:    authParams,
-		cacheAccessor: cacheAccessor,
+		cacheAccessor: noopCacheAccessor{},
 		manager:       storage.New(token),
-	}, nil
+	}
+	for _, o := range options {
+		o(&client)
+	}
+	return client, nil
+
 }
 
 // AuthCodeURL creates a URL used to acquire an authorization code.

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -94,7 +94,7 @@ func New(clientID string, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, opts.Accessor, oauth.New())
+	base, err := base.New(clientID, opts.Authority, oauth.New(), base.withCacheAccessor(opts.Accessor))
 	if err != nil {
 		return Client{}, err
 	}

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -94,7 +94,7 @@ func New(clientID string, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, oauth.New(), base.withCacheAccessor(opts.Accessor))
+	base, err := base.New(clientID, opts.Authority, oauth.New(), base.WithCacheAccessor(opts.Accessor))
 	if err != nil {
 		return Client{}, err
 	}


### PR DESCRIPTION
#135  was opened to fix the usage of `noopCacheAccessor`. The PR breaks the integration tests due to a null pointer exception for confidential client with client secret scenario. 
This PR is opened to fix the bug in `base.go` instead of making the same changes in both `public.go` and `confidential.go`
