### PR TITLE
Fixing device code sample

### DIFF
--- a/apps/tests/devapps/device_code_flow_sample.go
+++ b/apps/tests/devapps/device_code_flow_sample.go
@@ -36,8 +36,8 @@ func acquireTokenDeviceCode() {
 		// either there was no cached account/token or the call to AcquireTokenSilent() failed
 		// make a new request to AAD
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+		defer cancel()
 		devCode, err := app.AcquireTokenByDeviceCode(ctx, config.Scopes)
-		cancel()
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Was trying the device code flow sample and it was broken because the context getting cancelled immediately. 
Suggesting this change to fix it. 