### PR TITLE
Add support for custom HTTP clients

### DIFF
--- a/apps/internal/oauth/oauth.go
+++ b/apps/internal/oauth/oauth.go
@@ -52,8 +52,8 @@ type Client struct {
 }
 
 // New is the constructor for Token.
-func New() *Client {
-	r := ops.New()
+func New(httpClient ops.HTTPClient) *Client {
+	r := ops.New(httpClient)
 	return &Client{
 		resolver:     newAuthorityEndpoint(r),
 		accessTokens: r.AccessTokens(),

--- a/apps/internal/oauth/ops/internal/comm/comm.go
+++ b/apps/internal/oauth/ops/internal/comm/comm.go
@@ -29,7 +29,10 @@ const version = "0.1.0"
 // HTTPClient represents an HTTP client.
 // It's usually an *http.Client from the standard library.
 type HTTPClient interface {
+	// Do sends an HTTP request and returns an HTTP response.
 	Do(req *http.Request) (*http.Response, error)
+
+	// CloseIdleConnections closes any idle connections in a "keep-alive" state.
 	CloseIdleConnections()
 }
 

--- a/apps/internal/oauth/ops/internal/comm/comm.go
+++ b/apps/internal/oauth/ops/internal/comm/comm.go
@@ -26,13 +26,20 @@ import (
 
 const version = "0.1.0"
 
+// HTTPClient represents an HTTP client.
+// It's usually an *http.Client from the standard library.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+	CloseIdleConnections()
+}
+
 // Client provides a wrapper to our *http.Client that handles compression and serialization needs.
 type Client struct {
-	client *http.Client
+	client HTTPClient
 }
 
 // New returns a new Client object.
-func New(httpClient *http.Client) *Client {
+func New(httpClient HTTPClient) *Client {
 	if httpClient == nil {
 		panic("http.Client cannot == nil")
 	}

--- a/apps/internal/oauth/ops/ops.go
+++ b/apps/internal/oauth/ops/ops.go
@@ -17,13 +17,13 @@ Usage is simple:
 package ops
 
 import (
-	"net/http"
-
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/internal/comm"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust"
 )
+
+type HTTPClient = comm.HTTPClient
 
 // REST provides REST clients for communicating with various backends used by MSAL.
 type REST struct {
@@ -31,8 +31,8 @@ type REST struct {
 }
 
 // New is the constructor for REST.
-func New() *REST {
-	return &REST{client: comm.New(&http.Client{})}
+func New(httpClient HTTPClient) *REST {
+	return &REST{client: comm.New(httpClient)}
 }
 
 // Authority returns a client for querying information about various authorities.

--- a/apps/internal/oauth/ops/ops.go
+++ b/apps/internal/oauth/ops/ops.go
@@ -23,6 +23,8 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust"
 )
 
+// HTTPClient represents an HTTP client.
+// It's usually an *http.Client from the standard library.
 type HTTPClient = comm.HTTPClient
 
 // REST provides REST clients for communicating with various backends used by MSAL.

--- a/apps/internal/shared/shared.go
+++ b/apps/internal/shared/shared.go
@@ -4,6 +4,7 @@
 package shared
 
 import (
+	"net/http"
 	"strings"
 )
 
@@ -45,3 +46,6 @@ func NewAccount(homeAccountID, env, realm, localAccountID, authorityType, userna
 func (acc Account) Key() string {
 	return strings.Join([]string{acc.HomeAccountID, acc.Environment, acc.Realm}, CacheKeySeparator)
 }
+
+// DefaultClient is our default shared HTTP client.
+var DefaultClient = &http.Client{}


### PR DESCRIPTION
This adds an option for public and confidential clients to specify their
own HTTP client.  By default, the clients use a shared *http.Client.