### PR TITLE
Add fake oauth.Client implementation

### DIFF
--- a/apps/internal/oauth/fake/fake.go
+++ b/apps/internal/oauth/fake/fake.go
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package fake
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	internalTime "github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/json/types/time"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust/defs"
+)
+
+// ResolveEndpoints is a fake implementation of the oauth.resolveEndpointer interface.
+type ResolveEndpoints struct {
+	// Set this to true to have all APIs return an error.
+	Err bool
+}
+
+func (f ResolveEndpoints) ResolveEndpoints(ctx context.Context, authorityInfo authority.Info, userPrincipalName string) (authority.Endpoints, error) {
+	if f.Err {
+		return authority.Endpoints{}, errors.New("error")
+	}
+	return authority.Endpoints{}, nil
+}
+
+// AccessTokens is a fake implementation of the oauth.accessTokens interface.
+type AccessTokens struct {
+	// Set this to true to have all APIs return an error.
+	Err bool
+
+	// Result is for use with FromDeviceCodeResult. On each call it returns
+	// the next item in this slice. They must be either an error or nil.
+	Result []error
+	Next   int
+}
+
+func (f *AccessTokens) FromUsernamePassword(ctx context.Context, authParameters authority.AuthParams) (accesstokens.TokenResponse, error) {
+	if f.Err {
+		return accesstokens.TokenResponse{}, fmt.Errorf("error")
+	}
+	return accesstokens.TokenResponse{}, nil
+}
+func (f *AccessTokens) FromAuthCode(ctx context.Context, req accesstokens.AuthCodeRequest) (accesstokens.TokenResponse, error) {
+	if f.Err {
+		return accesstokens.TokenResponse{}, fmt.Errorf("error")
+	}
+	return accesstokens.TokenResponse{}, nil
+}
+func (f *AccessTokens) FromRefreshToken(ctx context.Context, appType accesstokens.AppType, authParams authority.AuthParams, cc *accesstokens.Credential, refreshToken string) (accesstokens.TokenResponse, error) {
+	if f.Err {
+		return accesstokens.TokenResponse{}, fmt.Errorf("error")
+	}
+	return accesstokens.TokenResponse{}, nil
+}
+func (f *AccessTokens) FromClientSecret(ctx context.Context, authParameters authority.AuthParams, clientSecret string) (accesstokens.TokenResponse, error) {
+	if f.Err {
+		return accesstokens.TokenResponse{}, fmt.Errorf("error")
+	}
+	return accesstokens.TokenResponse{}, nil
+}
+func (f *AccessTokens) FromAssertion(ctx context.Context, authParameters authority.AuthParams, assertion string) (accesstokens.TokenResponse, error) {
+	if f.Err {
+		return accesstokens.TokenResponse{}, fmt.Errorf("error")
+	}
+	return accesstokens.TokenResponse{}, nil
+}
+func (f *AccessTokens) DeviceCodeResult(ctx context.Context, authParameters authority.AuthParams) (accesstokens.DeviceCodeResult, error) {
+	if f.Err {
+		return accesstokens.DeviceCodeResult{}, fmt.Errorf("error")
+	}
+	return accesstokens.DeviceCodeResult{}, nil
+}
+func (f *AccessTokens) FromDeviceCodeResult(ctx context.Context, authParameters authority.AuthParams, deviceCodeResult accesstokens.DeviceCodeResult) (accesstokens.TokenResponse, error) {
+	if f.Next < len(f.Result) {
+		defer func() { f.Next++ }()
+		v := f.Result[f.Next]
+		if v == nil {
+			return accesstokens.TokenResponse{ExpiresOn: internalTime.DurationTime{T: time.Now().Add(5 * time.Minute)}}, nil
+		}
+		return accesstokens.TokenResponse{}, v
+	}
+	panic("AccessTokens.FromDeviceCodeResult() asked for more return values than provided")
+}
+func (f *AccessTokens) FromSamlGrant(ctx context.Context, authParameters authority.AuthParams, samlGrant wstrust.SamlTokenInfo) (accesstokens.TokenResponse, error) {
+	if f.Err {
+		return accesstokens.TokenResponse{}, fmt.Errorf("error")
+	}
+	return accesstokens.TokenResponse{}, nil
+}
+
+// Authority is a fake implementation of the oauth.fetchAuthority interface.
+type Authority struct {
+	// Set this to true to have all APIs return an error.
+	Err bool
+
+	// The fake UserRealm to return from the UserRealm() API.
+	Realm authority.UserRealm
+}
+
+func (f Authority) UserRealm(ctx context.Context, params authority.AuthParams) (authority.UserRealm, error) {
+	if f.Err {
+		return authority.UserRealm{}, errors.New("error")
+	}
+	return f.Realm, nil
+}
+
+func (f Authority) AADInstanceDiscovery(ctx context.Context, info authority.Info) (authority.InstanceDiscoveryResponse, error) {
+	if f.Err {
+		return authority.InstanceDiscoveryResponse{}, errors.New("error")
+	}
+	return authority.InstanceDiscoveryResponse{}, nil
+}
+
+// WSTrust is a fake implementation of the oauth.fetchWSTrust interface.
+type WSTrust struct {
+	// Set these to true to have their respective APIs return an error.
+	GetMexErr, GetSAMLTokenInfoErr bool
+}
+
+func (f WSTrust) Mex(ctx context.Context, federationMetadataURL string) (defs.MexDocument, error) {
+	if f.GetMexErr {
+		return defs.MexDocument{}, errors.New("error")
+	}
+	return defs.MexDocument{}, nil
+}
+
+func (f WSTrust) SAMLTokenInfo(ctx context.Context, authParameters authority.AuthParams, cloudAudienceURN string, endpoint defs.Endpoint) (wstrust.SamlTokenInfo, error) {
+	if f.GetSAMLTokenInfoErr {
+		return wstrust.SamlTokenInfo{}, errors.New("error")
+	}
+	return wstrust.SamlTokenInfo{}, nil
+}

--- a/apps/internal/oauth/oauth_test.go
+++ b/apps/internal/oauth/oauth_test.go
@@ -13,151 +13,37 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
-	internalTime "github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/json/types/time"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/fake"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
-	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust"
-	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust/defs"
 )
-
-type fakeResolveEndpoints struct {
-	err bool
-}
-
-func (f fakeResolveEndpoints) ResolveEndpoints(ctx context.Context, authorityInfo authority.Info, userPrincipalName string) (authority.Endpoints, error) {
-	if f.err {
-		return authority.Endpoints{}, errors.New("error")
-	}
-	return authority.Endpoints{}, nil
-}
-
-type fakeAccessTokens struct {
-	err bool
-
-	// deviceCodeResult is for use with FromDeviceCodeResult. On each call it returns
-	// the next item in this slice. They must be either an error or nil.
-	deviceCodeResult []interface{}
-	next             int
-}
-
-func (f *fakeAccessTokens) FromUsernamePassword(ctx context.Context, authParameters authority.AuthParams) (accesstokens.TokenResponse, error) {
-	if f.err {
-		return accesstokens.TokenResponse{}, fmt.Errorf("error")
-	}
-	return accesstokens.TokenResponse{}, nil
-}
-func (f *fakeAccessTokens) FromAuthCode(ctx context.Context, req accesstokens.AuthCodeRequest) (accesstokens.TokenResponse, error) {
-	if f.err {
-		return accesstokens.TokenResponse{}, fmt.Errorf("error")
-	}
-	return accesstokens.TokenResponse{}, nil
-}
-func (f *fakeAccessTokens) FromRefreshToken(ctx context.Context, appType accesstokens.AppType, authParams authority.AuthParams, cc *accesstokens.Credential, refreshToken string) (accesstokens.TokenResponse, error) {
-	if f.err {
-		return accesstokens.TokenResponse{}, fmt.Errorf("error")
-	}
-	return accesstokens.TokenResponse{}, nil
-}
-func (f *fakeAccessTokens) FromClientSecret(ctx context.Context, authParameters authority.AuthParams, clientSecret string) (accesstokens.TokenResponse, error) {
-	if f.err {
-		return accesstokens.TokenResponse{}, fmt.Errorf("error")
-	}
-	return accesstokens.TokenResponse{}, nil
-}
-func (f *fakeAccessTokens) FromAssertion(ctx context.Context, authParameters authority.AuthParams, assertion string) (accesstokens.TokenResponse, error) {
-	if f.err {
-		return accesstokens.TokenResponse{}, fmt.Errorf("error")
-	}
-	return accesstokens.TokenResponse{}, nil
-}
-func (f *fakeAccessTokens) DeviceCodeResult(ctx context.Context, authParameters authority.AuthParams) (accesstokens.DeviceCodeResult, error) {
-	if f.err {
-		return accesstokens.DeviceCodeResult{}, fmt.Errorf("error")
-	}
-	return accesstokens.DeviceCodeResult{}, nil
-}
-func (f *fakeAccessTokens) FromDeviceCodeResult(ctx context.Context, authParameters authority.AuthParams, deviceCodeResult accesstokens.DeviceCodeResult) (accesstokens.TokenResponse, error) {
-	if f.next < len(f.deviceCodeResult) {
-		defer func() { f.next++ }()
-		v := f.deviceCodeResult[f.next]
-		if v == nil {
-			return accesstokens.TokenResponse{ExpiresOn: internalTime.DurationTime{T: time.Now().Add(5 * time.Minute)}}, nil
-		}
-		return accesstokens.TokenResponse{}, v.(error)
-	}
-	panic("fakeAccessTokens.FromDeviceCodeResult() asked for more return values than provided")
-}
-func (f *fakeAccessTokens) FromSamlGrant(ctx context.Context, authParameters authority.AuthParams, samlGrant wstrust.SamlTokenInfo) (accesstokens.TokenResponse, error) {
-	if f.err {
-		return accesstokens.TokenResponse{}, fmt.Errorf("error")
-	}
-	return accesstokens.TokenResponse{}, nil
-}
-
-type fakeAuthority struct {
-	err       bool
-	userRealm authority.UserRealm
-}
-
-func (f fakeAuthority) UserRealm(ctx context.Context, params authority.AuthParams) (authority.UserRealm, error) {
-	if f.err {
-		return authority.UserRealm{}, errors.New("error")
-	}
-	return f.userRealm, nil
-}
-
-func (f fakeAuthority) AADInstanceDiscovery(ctx context.Context, info authority.Info) (authority.InstanceDiscoveryResponse, error) {
-	if f.err {
-		return authority.InstanceDiscoveryResponse{}, errors.New("error")
-	}
-	return authority.InstanceDiscoveryResponse{}, nil
-}
-
-type fakeWSTrust struct {
-	getMexErr, getSAMLTokenInfoErr bool
-}
-
-func (f fakeWSTrust) Mex(ctx context.Context, federationMetadataURL string) (defs.MexDocument, error) {
-	if f.getMexErr {
-		return defs.MexDocument{}, errors.New("error")
-	}
-	return defs.MexDocument{}, nil
-}
-
-func (f fakeWSTrust) SAMLTokenInfo(ctx context.Context, authParameters authority.AuthParams, cloudAudienceURN string, endpoint defs.Endpoint) (wstrust.SamlTokenInfo, error) {
-	if f.getSAMLTokenInfoErr {
-		return wstrust.SamlTokenInfo{}, errors.New("error")
-	}
-	return wstrust.SamlTokenInfo{}, nil
-}
 
 func TestAuthCode(t *testing.T) {
 	tests := []struct {
 		desc string
-		re   fakeResolveEndpoints
-		at   *fakeAccessTokens
+		re   fake.ResolveEndpoints
+		at   *fake.AccessTokens
 		err  bool
 	}{
 		{
 			desc: "Error: Unable to resolve endpoints",
-			re:   fakeResolveEndpoints{err: true},
-			at:   &fakeAccessTokens{},
+			re:   fake.ResolveEndpoints{Err: true},
+			at:   &fake.AccessTokens{},
 			err:  true,
 		},
 		{
 			desc: "Error: REST access token error",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{err: true},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{Err: true},
 			err:  true,
 		},
 		{
 			desc: "Success",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{},
 		},
 	}
 
@@ -179,16 +65,16 @@ func TestAuthCode(t *testing.T) {
 func TestCredential(t *testing.T) {
 	tests := []struct {
 		desc       string
-		re         fakeResolveEndpoints
-		at         *fakeAccessTokens
+		re         fake.ResolveEndpoints
+		at         *fake.AccessTokens
 		authParams authority.AuthParams
 		cred       *accesstokens.Credential
 		err        bool
 	}{
 		{
 			desc: "Error: Unable to resolve endpoints",
-			re:   fakeResolveEndpoints{err: true},
-			at:   &fakeAccessTokens{},
+			re:   fake.ResolveEndpoints{Err: true},
+			at:   &fake.AccessTokens{},
 			cred: &accesstokens.Credential{
 				Assertion: "assertion",
 				Expires:   time.Now().Add(-5 * time.Minute),
@@ -197,8 +83,8 @@ func TestCredential(t *testing.T) {
 		},
 		{
 			desc: "Error: REST access token error on secret",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{err: true},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{Err: true},
 			cred: &accesstokens.Credential{
 				Assertion: "assertion",
 				Expires:   time.Now().Add(-5 * time.Minute),
@@ -207,8 +93,8 @@ func TestCredential(t *testing.T) {
 		},
 		{
 			desc: "Error: could not generate JWT from cred assertion",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{err: true},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{Err: true},
 			cred: &accesstokens.Credential{
 				Assertion: "assertion",
 				Expires:   time.Now().Add(5 * time.Minute),
@@ -219,8 +105,8 @@ func TestCredential(t *testing.T) {
 		},
 		{
 			desc: "Error: REST access token error on assertion",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{err: true},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{Err: true},
 			cred: &accesstokens.Credential{
 				Assertion: "assertion",
 				Expires:   time.Now().Add(-5 * time.Minute),
@@ -229,16 +115,16 @@ func TestCredential(t *testing.T) {
 		},
 		{
 			desc: "Success: secret cred",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{},
 			cred: &accesstokens.Credential{
 				Secret: "secret",
 			},
 		},
 		{
 			desc: "Success: assertion cred",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{},
 			cred: &accesstokens.Credential{
 				Assertion: "assertion",
 				Expires:   time.Now().Add(-5 * time.Minute),
@@ -264,26 +150,26 @@ func TestCredential(t *testing.T) {
 func TestRefresh(t *testing.T) {
 	tests := []struct {
 		desc string
-		re   fakeResolveEndpoints
-		at   *fakeAccessTokens
+		re   fake.ResolveEndpoints
+		at   *fake.AccessTokens
 		err  bool
 	}{
 		{
 			desc: "Error: Unable to resolve endpoints",
-			re:   fakeResolveEndpoints{err: true},
-			at:   &fakeAccessTokens{},
+			re:   fake.ResolveEndpoints{Err: true},
+			at:   &fake.AccessTokens{},
 			err:  true,
 		},
 		{
 			desc: "Error: REST access token error",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{err: true},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{Err: true},
 			err:  true,
 		},
 		{
 			desc: "Success",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{},
 		},
 	}
 
@@ -311,60 +197,60 @@ func TestRefresh(t *testing.T) {
 func TestUsernamePassword(t *testing.T) {
 	tests := []struct {
 		desc string
-		re   fakeResolveEndpoints
-		at   *fakeAccessTokens
-		au   fakeAuthority
-		ws   fakeWSTrust
+		re   fake.ResolveEndpoints
+		at   *fake.AccessTokens
+		au   fake.Authority
+		ws   fake.WSTrust
 		err  bool
 	}{
 		{
 			desc: "Error: Unable to resolve endpoints",
-			re:   fakeResolveEndpoints{err: true},
-			at:   &fakeAccessTokens{},
-			au:   fakeAuthority{userRealm: authority.UserRealm{AccountType: authority.Managed}},
+			re:   fake.ResolveEndpoints{Err: true},
+			at:   &fake.AccessTokens{},
+			au:   fake.Authority{Realm: authority.UserRealm{AccountType: authority.Managed}},
 			err:  true,
 		},
 		{
 			desc: "Error: authority.Federated and Mex() error",
-			re:   fakeResolveEndpoints{err: false},
-			at:   &fakeAccessTokens{},
-			au:   fakeAuthority{userRealm: authority.UserRealm{AccountType: authority.Federated}},
-			ws:   fakeWSTrust{getMexErr: true},
+			re:   fake.ResolveEndpoints{Err: false},
+			at:   &fake.AccessTokens{},
+			au:   fake.Authority{Realm: authority.UserRealm{AccountType: authority.Federated}},
+			ws:   fake.WSTrust{GetMexErr: true},
 			err:  true,
 		},
 		{
 			desc: "Error: authority.Federated and SAMLTokenInfo() error",
-			re:   fakeResolveEndpoints{err: false},
-			at:   &fakeAccessTokens{},
-			au:   fakeAuthority{userRealm: authority.UserRealm{AccountType: authority.Federated}},
-			ws:   fakeWSTrust{getSAMLTokenInfoErr: true},
+			re:   fake.ResolveEndpoints{Err: false},
+			at:   &fake.AccessTokens{},
+			au:   fake.Authority{Realm: authority.UserRealm{AccountType: authority.Federated}},
+			ws:   fake.WSTrust{GetSAMLTokenInfoErr: true},
 			err:  true,
 		},
 		{
 			desc: "Error: authority.Federated and GetAccessTokenFromSamlGrant() error",
-			re:   fakeResolveEndpoints{err: false},
-			au:   fakeAuthority{userRealm: authority.UserRealm{AccountType: authority.Federated}},
-			at:   &fakeAccessTokens{err: true},
+			re:   fake.ResolveEndpoints{Err: false},
+			au:   fake.Authority{Realm: authority.UserRealm{AccountType: authority.Federated}},
+			at:   &fake.AccessTokens{Err: true},
 			err:  true,
 		},
 		{
 			desc: "Error: authority.Managed and REST access token error",
-			re:   fakeResolveEndpoints{err: false},
-			at:   &fakeAccessTokens{err: true},
-			au:   fakeAuthority{userRealm: authority.UserRealm{AccountType: authority.Managed}},
+			re:   fake.ResolveEndpoints{Err: false},
+			at:   &fake.AccessTokens{Err: true},
+			au:   fake.Authority{Realm: authority.UserRealm{AccountType: authority.Managed}},
 			err:  true,
 		},
 		{
 			desc: "Success: authority.Managed",
-			re:   fakeResolveEndpoints{err: false},
-			at:   &fakeAccessTokens{},
-			au:   fakeAuthority{userRealm: authority.UserRealm{AccountType: authority.Managed}},
+			re:   fake.ResolveEndpoints{Err: false},
+			at:   &fake.AccessTokens{},
+			au:   fake.Authority{Realm: authority.UserRealm{AccountType: authority.Managed}},
 		},
 		{
 			desc: "Success: authority.Federated",
-			re:   fakeResolveEndpoints{err: false},
-			at:   &fakeAccessTokens{},
-			au:   fakeAuthority{userRealm: authority.UserRealm{AccountType: authority.Federated}},
+			re:   fake.ResolveEndpoints{Err: false},
+			at:   &fake.AccessTokens{},
+			au:   fake.Authority{Realm: authority.UserRealm{AccountType: authority.Federated}},
 		},
 	}
 
@@ -399,8 +285,8 @@ func TestDeviceCode(t *testing.T) {
 		{
 			desc: "Error: FromDeviceCodeResult() returned a !isWaitDeviceCodeErr",
 			dc: DeviceCode{
-				accessTokens: &fakeAccessTokens{
-					deviceCodeResult: []interface{}{errors.New("authorization_pending"), errors.New("slow_down"), errors.New("bad error"), nil},
+				accessTokens: &fake.AccessTokens{
+					Result: []error{errors.New("authorization_pending"), errors.New("slow_down"), errors.New("bad error"), nil},
 				},
 			},
 			err: true,
@@ -411,8 +297,8 @@ func TestDeviceCode(t *testing.T) {
 				Result: accesstokens.DeviceCodeResult{
 					ExpiresOn: time.Now().Add(5 * time.Minute),
 				},
-				accessTokens: &fakeAccessTokens{
-					deviceCodeResult: []interface{}{errors.New("authorization_pending"), errors.New("slow_down"), nil},
+				accessTokens: &fake.AccessTokens{
+					Result: []error{errors.New("authorization_pending"), errors.New("slow_down"), nil},
 				},
 			},
 		},
@@ -432,26 +318,26 @@ func TestDeviceCode(t *testing.T) {
 func TestDeviceCodeToken(t *testing.T) {
 	tests := []struct {
 		desc string
-		re   fakeResolveEndpoints
-		at   *fakeAccessTokens
+		re   fake.ResolveEndpoints
+		at   *fake.AccessTokens
 		err  bool
 	}{
 		{
 			desc: "Error: Unable to resolve endpoints",
-			re:   fakeResolveEndpoints{err: true},
-			at:   &fakeAccessTokens{},
+			re:   fake.ResolveEndpoints{Err: true},
+			at:   &fake.AccessTokens{},
 			err:  true,
 		},
 		{
 			desc: "Error: REST access token error",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{err: true},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{Err: true},
 			err:  true,
 		},
 		{
 			desc: "Success",
-			re:   fakeResolveEndpoints{},
-			at:   &fakeAccessTokens{},
+			re:   fake.ResolveEndpoints{},
+			at:   &fake.AccessTokens{},
 		},
 	}
 


### PR DESCRIPTION
Move existing fakes out of oauth_test.go and into its own package for
consumption by other tests.