### PR TITLE
Fixing acquire token silent in conf client scenarios with no accounts

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -30,7 +30,7 @@ const (
 // manager provides an internal cache. It is defined to allow faking the cache in tests.
 // In all production use it is a *storage.Manager.
 type manager interface {
-	Read(ctx context.Context, authParameters authority.AuthParams, account shared.Account) (storage.TokenResponse, error)
+	Read(ctx context.Context, authParameters authority.AuthParams, inputAccount shared.Account) (storage.TokenResponse, error)
 	Write(authParameters authority.AuthParams, tokenResponse accesstokens.TokenResponse) (shared.Account, error)
 	AllAccounts() ([]shared.Account, error)
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -30,7 +30,7 @@ const (
 // manager provides an internal cache. It is defined to allow faking the cache in tests.
 // In all production use it is a *storage.Manager.
 type manager interface {
-	Read(ctx context.Context, authParameters authority.AuthParams, inputAccount shared.Account) (storage.TokenResponse, error)
+	Read(ctx context.Context, authParameters authority.AuthParams, account shared.Account) (storage.TokenResponse, error)
 	Write(authParameters authority.AuthParams, tokenResponse accesstokens.TokenResponse) (shared.Account, error)
 	AllAccounts() ([]shared.Account, error)
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -30,7 +30,7 @@ const (
 // manager provides an internal cache. It is defined to allow faking the cache in tests.
 // In all production use it is a *storage.Manager.
 type manager interface {
-	Read(ctx context.Context, authParameters authority.AuthParams) (storage.TokenResponse, error)
+	Read(ctx context.Context, authParameters authority.AuthParams, account shared.Account) (storage.TokenResponse, error)
 	Write(authParameters authority.AuthParams, tokenResponse accesstokens.TokenResponse) (shared.Account, error)
 	AllAccounts() ([]shared.Account, error)
 }
@@ -207,7 +207,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 		defer b.cacheAccessor.Export(s)
 	}
 
-	storageTokenResponse, err := b.manager.Read(ctx, authParams)
+	storageTokenResponse, err := b.manager.Read(ctx, authParams, silent.Account)
 	if err != nil {
 		return AuthResult{}, err
 	}

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -86,7 +86,7 @@ func isMatchingScopes(scopesOne []string, scopesTwo string) bool {
 }
 
 // Read reads a storage token from the cache if it exists.
-func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams, inputAccount shared.Account) (TokenResponse, error) {
+func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams, account shared.Account) (TokenResponse, error) {
 	homeAccountID := authParameters.HomeaccountID
 	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID
@@ -106,39 +106,38 @@ func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams,
 		return TokenResponse{}, err
 	}
 
-	if !inputAccount.IsZero() {
-
-		idToken, err := m.readIDToken(homeAccountID, metadata.Aliases, realm, clientID)
-		if err != nil {
-			return TokenResponse{}, err
-		}
-
-		AppMetaData, err := m.readAppMetaData(metadata.Aliases, clientID)
-		if err != nil {
-			return TokenResponse{}, err
-		}
-		familyID := AppMetaData.FamilyID
-
-		refreshToken, err := m.readRefreshToken(homeAccountID, metadata.Aliases, familyID, clientID)
-		if err != nil {
-			return TokenResponse{}, err
-		}
-		account, err := m.readAccount(homeAccountID, metadata.Aliases, realm)
-		if err != nil {
-			return TokenResponse{}, err
-		}
+	if account.IsZero() {
 		return TokenResponse{
 			AccessToken:  accessToken,
-			RefreshToken: refreshToken,
-			IDToken:      idToken,
-			Account:      account,
+			RefreshToken: accesstokens.RefreshToken{},
+			IDToken:      IDToken{},
+			Account:      shared.Account{},
 		}, nil
+	}
+	idToken, err := m.readIDToken(homeAccountID, metadata.Aliases, realm, clientID)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+
+	AppMetaData, err := m.readAppMetaData(metadata.Aliases, clientID)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	familyID := AppMetaData.FamilyID
+
+	refreshToken, err := m.readRefreshToken(homeAccountID, metadata.Aliases, familyID, clientID)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	account, err = m.readAccount(homeAccountID, metadata.Aliases, realm)
+	if err != nil {
+		return TokenResponse{}, err
 	}
 	return TokenResponse{
 		AccessToken:  accessToken,
-		RefreshToken: accesstokens.RefreshToken{},
-		IDToken:      IDToken{},
-		Account:      shared.Account{},
+		RefreshToken: refreshToken,
+		IDToken:      idToken,
+		Account:      account,
 	}, nil
 }
 

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -813,7 +813,7 @@ func TestRead(t *testing.T) {
 		manager := newForTest(responder)
 		manager.update(contract)
 
-		got, err := manager.Read(context.Background(), authParameters)
+		got, err := manager.Read(context.Background(), authParameters, testAccount)
 		switch {
 		case err == nil && test.err:
 			t.Errorf("TestRead(%s): got err == nil, want err != nil", test.desc)

--- a/apps/internal/shared/shared.go
+++ b/apps/internal/shared/shared.go
@@ -45,3 +45,36 @@ func NewAccount(homeAccountID, env, realm, localAccountID, authorityType, userna
 func (acc Account) Key() string {
 	return strings.Join([]string{acc.HomeAccountID, acc.Environment, acc.Realm}, CacheKeySeparator)
 }
+
+//IsZero checks the zero value of account
+func (acc Account) IsZero() bool {
+	switch {
+	case acc.HomeAccountID != "":
+		return false
+	case acc.Environment != "":
+		return false
+	case acc.Realm != "":
+		return false
+	case acc.LocalAccountID != "":
+		return false
+	case acc.AuthorityType != "":
+		return false
+	case acc.PreferredUsername != "":
+		return false
+	case acc.GivenName != "":
+		return false
+	case acc.FamilyName != "":
+		return false
+	case acc.MiddleName != "":
+		return false
+	case acc.Name != "":
+		return false
+	case acc.AlternativeID != "":
+		return false
+	case acc.RawClientInfo != "":
+		return false
+	case acc.AdditionalFields != nil:
+		return false
+	}
+	return true
+}

--- a/apps/internal/shared/shared.go
+++ b/apps/internal/shared/shared.go
@@ -5,6 +5,7 @@ package shared
 
 import (
 	"net/http"
+	"reflect"
 	"strings"
 )
 
@@ -47,35 +48,20 @@ func (acc Account) Key() string {
 	return strings.Join([]string{acc.HomeAccountID, acc.Environment, acc.Realm}, CacheKeySeparator)
 }
 
-//IsZero checks the zero value of account
+// IsZero checks the zero value of account.
 func (acc Account) IsZero() bool {
-	switch {
-	case acc.HomeAccountID != "":
-		return false
-	case acc.Environment != "":
-		return false
-	case acc.Realm != "":
-		return false
-	case acc.LocalAccountID != "":
-		return false
-	case acc.AuthorityType != "":
-		return false
-	case acc.PreferredUsername != "":
-		return false
-	case acc.GivenName != "":
-		return false
-	case acc.FamilyName != "":
-		return false
-	case acc.MiddleName != "":
-		return false
-	case acc.Name != "":
-		return false
-	case acc.AlternativeID != "":
-		return false
-	case acc.RawClientInfo != "":
-		return false
-	case acc.AdditionalFields != nil:
-		return false
+	v := reflect.ValueOf(acc)
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if !field.IsZero() {
+			switch field.Kind() {
+			case reflect.Map, reflect.Slice:
+				if field.Len() == 0 {
+					continue
+				}
+			}
+			return false
+		}
 	}
 	return true
 }

--- a/apps/internal/shared/shared.go
+++ b/apps/internal/shared/shared.go
@@ -47,7 +47,6 @@ func (acc Account) Key() string {
 	return strings.Join([]string{acc.HomeAccountID, acc.Environment, acc.Realm}, CacheKeySeparator)
 }
 
-<<<<<<< HEAD
 //IsZero checks the zero value of account
 func (acc Account) IsZero() bool {
 	switch {
@@ -80,7 +79,6 @@ func (acc Account) IsZero() bool {
 	}
 	return true
 }
-=======
+
 // DefaultClient is our default shared HTTP client.
 var DefaultClient = &http.Client{}
->>>>>>> 40939a8f618dff697fd15fe09444b29dea9a4033

--- a/apps/tests/integration/integration_test.go
+++ b/apps/tests/integration/integration_test.go
@@ -205,7 +205,7 @@ func TestUsernamePassword(t *testing.T) {
 			t.Fatalf("TestUsernamePassword(%s): on AcquireTokenByUsernamePassword(): got err == %s, want err == nil", test.desc, errors.Verbose(err))
 		}
 		if result.AccessToken == "" {
-			t.Fatalf("TestUsernamePassword(%s): got AccessToken == '', want AccessToken == non-empty string", test.desc)
+			t.Fatalf("TestUsernamePassword(%s): got AccessToken == '', want AccessToken != ''", test.desc)
 		}
 		if result.IDToken.IsZero() {
 			t.Fatalf("TestUsernamePassword(%s): got IDToken == empty, want IDToken == non-empty struct", test.desc)
@@ -237,14 +237,14 @@ func TestConfidentialClientwithSecret(t *testing.T) {
 		t.Fatalf("TestConfidentialClientwithSecret: on AcquireTokenByCredential(): got err == %s, want err == nil", errors.Verbose(err))
 	}
 	if result.AccessToken == "" {
-		t.Fatal("TestConfidentialClientwithSecret: on AcquireTokenByCredential(): got AccessToken == '', want AccessToken == non-empty string")
+		t.Fatal("TestConfidentialClientwithSecret: on AcquireTokenByCredential(): got AccessToken == '', want AccessToken != ''")
 	}
 	silentResult, err := app.AcquireTokenSilent(context.Background(), scopes)
 	if err != nil {
 		t.Fatalf("TestConfidentialClientwithSecret: on AcquireTokenSilent(): got err == %s, want err == nil", errors.Verbose(err))
 	}
 	if silentResult.AccessToken == "" {
-		t.Fatal("TestConfidentialClientwithSecret: on AcquireTokenSilent(): got AccessToken == '', want AccessToken == non-empty string")
+		t.Fatal("TestConfidentialClientwithSecret: on AcquireTokenSilent(): got AccessToken == '', want AccessToken != ''")
 	}
 
 }

--- a/apps/tests/integration/integration_test.go
+++ b/apps/tests/integration/integration_test.go
@@ -215,3 +215,36 @@ func TestUsernamePassword(t *testing.T) {
 		}
 	}
 }
+
+func TestConfidentialClientwithSecret(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	clientID := os.Getenv("clientId")
+	secret := os.Getenv("clientSecret")
+	cred, err := confidential.NewCredFromSecret(secret)
+	if err != nil {
+		panic(errors.Verbose(err))
+	}
+
+	app, err := confidential.New(clientID, cred, confidential.WithAuthority(microsoftAuthority))
+	if err != nil {
+		panic(errors.Verbose(err))
+	}
+	scopes := []string{msIDlabDefaultScope}
+	result, err := app.AcquireTokenByCredential(context.Background(), scopes)
+	if err != nil {
+		t.Fatalf("TestConfidentialClientwithSecret: on AcquireTokenByCredential(): got err == %s, want err == nil", errors.Verbose(err))
+	}
+	if result.AccessToken == "" {
+		t.Fatal("TestConfidentialClientwithSecret: on AcquireTokenByCredential(): got AccessToken == '', want AccessToken == non-empty string")
+	}
+	silentResult, err := app.AcquireTokenSilent(context.Background(), scopes)
+	if err != nil {
+		t.Fatalf("TestConfidentialClientwithSecret: on AcquireTokenSilent(): got err == %s, want err == nil", errors.Verbose(err))
+	}
+	if silentResult.AccessToken == "" {
+		t.Fatal("TestConfidentialClientwithSecret: on AcquireTokenSilent(): got AccessToken == '', want AccessToken == non-empty string")
+	}
+
+}


### PR DESCRIPTION
Resolves #106 

This changes the way we do cache lookups when confidential client apps with no account are performing acquire token silent. 

Before this change, we would ALWAYS look for an access token, refresh token, id token and account in the cache. Meaning even if one of them is not found we return an error which mean silent call failed. This works for public client applications with an user identity meaning an account present, 

However, for confidential client scenarios with no user identity (no account), the only thing that gets populated in the cache is the access token. 
There is no ID token or account because there is no user identity. There is no refresh token as well, as the service does not send one for this use case. Reasoning is in this stackoverflow answer by @rayluo :  https://stackoverflow.com/a/43150260/728675