### PR TITLE
Jwt assertion expiry time change

### DIFF
--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -110,10 +110,11 @@ func (c *Credential) JWT(authParams authority.AuthParams) (string, error) {
 	if c.Expires.Before(time.Now()) && c.Assertion != "" {
 		return c.Assertion, nil
 	}
-	// TODO(msal): The reasoning for this needs to be documented somewhere.
-	// I don't have any logical reason that the JWT should expire at any certain time.
-	// Why ask for only 5 minutes, why not 10, 20, 30, 1hour...
-	expires := time.Now().Add(5 * time.Minute)
+	// There is no hard requirement on what the expiry time should be.
+	// https://tools.ietf.org/html/rfc7519#section-4.1.4
+	// This just sets a default of 10 mins which means a cached JWT assertion
+	// can be used if it is less that 10 mins old after which we regenerate the assertion.
+	expires := time.Now().Add(10 * time.Minute)
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"aud": authParams.Endpoints.TokenEndpoint,


### PR DESCRIPTION
Changed the default time from 5 mins to 10 mins as that is the default [MSAL .Net](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/28e5f6d1b4893e0ff530f7441038fe930a3164ce/src/client/Microsoft.Identity.Client/Internal/JsonWebTokenConstants.cs#L8), [MSAL Java](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/dev/src/main/java/com/microsoft/aad/msal4j/Constants.java#L12) and [MSAL Python](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/dev/msal/oauth2cli/assertion.py#L27) use.

I could not find any documentation or reasoning around why it is 10 mins and not 20, 30 etc. It looks like a good enough default which makes sure we do not have to regenerate it often but is also secure. 

Quoting @bgavrilMS and @rayluo.
Resolves #171 