### PR TITLE
Fixing Jwt decoding

### DIFF
--- a/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
@@ -707,8 +707,8 @@ func TestAccessTokenFromSamlGrant(t *testing.T) {
 }
 
 func TestDecodeJWT(t *testing.T) {
-	encodedStr := "aGVsbG8"
-	expectedStr := []byte("hello")
+	encodedStr := "A-z_4ME"
+	expectedStr := []byte{3, 236, 255, 224, 193}
 	actualString, err := decodeJWT(encodedStr)
 	if err != nil {
 		t.Errorf("Error should be nil but it is %v", err)

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -229,8 +229,7 @@ func findDeclinedScopes(requestedScopes []string, grantedScopes []string) []stri
 }
 
 // decodeJWT decodes a JWT and converts it to a byte array representing a JSON object
-// Adapted from MSAL Python and https://stackoverflow.com/a/31971780 .
-// JWT has headers and payload base64url encoded without padding.
+// JWT has headers and payload base64url encoded without padding
 // https://tools.ietf.org/html/rfc7519#section-3 and
 // https://tools.ietf.org/html/rfc7515#section-2
 func decodeJWT(data string) ([]byte, error) {

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -233,15 +233,8 @@ func findDeclinedScopes(requestedScopes []string, grantedScopes []string) []stri
 // https://tools.ietf.org/html/rfc7519#section-3 and
 // https://tools.ietf.org/html/rfc7515#section-2
 func decodeJWT(data string) ([]byte, error) {
-	// The following code adds padding based on
 	// https://tools.ietf.org/html/rfc7515#appendix-C
-	if i := len(data) % 4; i != 0 {
-		if i == 1 {
-			return nil, errors.New("Illegal base64url string")
-		}
-		data += strings.Repeat("=", 4-i)
-	}
-	return base64.URLEncoding.DecodeString(data)
+	return base64.RawURLEncoding.DecodeString(data)
 }
 
 // RefreshToken is the JSON representation of a MSAL refresh token for encoding to storage.


### PR DESCRIPTION
Looked up the spec of JWT. It mentions this [here](https://tools.ietf.org/html/rfc7519#section-3):
``` 
A JWT is represented as a sequence of URL-safe parts separated by
period ('.') characters.  Each part contains a base64url-encoded
value.
```
The definition of base64url-encoded is borrowed by the JWT spec from this [spec](https://www.rfc-editor.org/rfc/rfc7515.html#section-2):
```
Base64 encoding using the URL- and filename-safe character set
defined in Section 5 of RFC 4648 [RFC4648], with all trailing '='
characters omitted (as permitted by Section 3.2) and without the
inclusion of any line breaks, whitespace, or other additional
characters.  Note that the base64url encoding of the empty octet
sequence is the empty string.  (See Appendix C for notes on
implementing base64url encoding without padding.)
```

Finally this [Appendix](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-C) mentions how to decode the JWT.

Looks like the implementation is a little bit different from what we adopted from the stackoverflow answer and MSAL Python.
Also changed the encoding from `StdEncoding` to `URLEncoding` based on the above spec.

Resolves #170 