### PR TITLE
Honor the reply url in the redirectURI if specified

### DIFF
--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -372,7 +372,11 @@ func (pca Client) browserLogin(ctx context.Context, redirectURI *url.URL, params
 		return interactiveAuthResult{}, err
 	}
 	defer srv.Shutdown()
-	authURL, err := pca.base.AuthCodeURL(ctx, params.ClientID, srv.Addr, params.Scopes, params)
+	replyUrl := srv.Addr
+	if redirectURI != nil {
+		replyUrl = redirectURI.String()
+	}
+	authURL, err := pca.base.AuthCodeURL(ctx, params.ClientID, replyUrl, params.Scopes, params)
 	if err != nil {
 		return interactiveAuthResult{}, err
 	}
@@ -387,7 +391,7 @@ func (pca Client) browserLogin(ctx context.Context, redirectURI *url.URL, params
 	}
 	return interactiveAuthResult{
 		authCode:    res.Code,
-		redirectURI: srv.Addr,
+		redirectURI: replyUrl,
 	}, nil
 }
 


### PR DESCRIPTION
The interactive login process should honor the Redirect URI if specified.

Had an issue with this trying to leverage the AZ CLI client-id & application and it seems that only localhost is an authorized URL, not 127.0.0.1.

Seems to be because `net.Listener`'s  Addr() function returns 127.0.0.1 as opposed to localhost -- not sure if that is desired or not.

https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/696213fb452a5c21c892c7f87f3dda19f0cc1313/apps/internal/local/server.go#L80



In case you are curious what I am trying to do, I'd like to get rid of the need for Python Azure CLI completely for `az login` functionality.  I have an internal platform CLI tool which performs this function for AWS.  I'd like to add similar functionality for Azure.  Right now the tool just shells out to the Azure CLI, but I'd like to get rid of that dependency.

It would also help slim down Terraform containers for Azure deployments, as Terraform also has a dependency on the Azure CLI, which my understanding is purely for sourcing credentials.