### PR TITLE
Exposing suggestedCacheKey in the cache interface for custom token cache

### DIFF
--- a/apps/cache/cache.go
+++ b/apps/cache/cache.go
@@ -30,8 +30,8 @@ type Serializer interface {
 // ExportReplace is used export or replace what is in the cache.
 type ExportReplace interface {
 	// Replace replaces the cache with what is in external storage.
-	Replace(cache Unmarshaler)
+	Replace(cache Unmarshaler, key string)
 	// Export writes the binary representation of the cache (cache.Marshal()) to
 	// external storage. This is considered opaque.
-	Export(cache Marshaler)
+	Export(cache Marshaler, key string)
 }

--- a/apps/cache/cache.go
+++ b/apps/cache/cache.go
@@ -30,8 +30,10 @@ type Serializer interface {
 // ExportReplace is used export or replace what is in the cache.
 type ExportReplace interface {
 	// Replace replaces the cache with what is in external storage.
+	// key is the suggested key which can be used for partioning the cache
 	Replace(cache Unmarshaler, key string)
 	// Export writes the binary representation of the cache (cache.Marshal()) to
 	// external storage. This is considered opaque.
+	// key is the suggested key which can be used for partioning the cache
 	Export(cache Marshaler, key string)
 }

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -341,12 +341,7 @@ func (cca Client) AcquireTokenByCredential(ctx context.Context, scopes []string)
 	return cca.base.AuthResultFromToken(ctx, authParams, token, true)
 }
 
-// Accounts gets all the accounts in the token cache.
-func (cca Client) Accounts() []Account {
-	return cca.base.AllAccounts()
-}
-
-// AccountsByHomeAccountID gets all the accounts in the token cache with the specified homeAccountID
-func (cca Client) AccountsByHomeAccountID(homeAccountID string) []Account {
-	return cca.base.Accounts(homeAccountID)
+// Account gets the account in the token cache with the specified homeAccountID
+func (cca Client) Account(homeAccountID string) Account {
+	return cca.base.Account(homeAccountID)
 }

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -343,5 +343,10 @@ func (cca Client) AcquireTokenByCredential(ctx context.Context, scopes []string)
 
 // Accounts gets all the accounts in the token cache.
 func (cca Client) Accounts() []Account {
-	return cca.base.Accounts()
+	return cca.base.AllAccounts()
+}
+
+// AccountsByHomeAccountID gets all the accounts in the token cache with the specified homeAccountID
+func (cca Client) AccountsByHomeAccountID(homeAccountID string) []Account {
+	return cca.base.Accounts(homeAccountID)
 }

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -284,12 +284,17 @@ func (cca Client) AcquireTokenSilent(ctx context.Context, scopes []string, optio
 	for _, o := range options {
 		o(&opts)
 	}
+	var isAppCache bool
+	if opts.Account.IsZero() {
+		isAppCache = true
+	}
 
 	silentParameters := base.AcquireTokenSilentParameters{
 		Scopes:      scopes,
 		Account:     opts.Account,
 		RequestType: accesstokens.ATConfidential,
 		Credential:  cca.cred,
+		IsAppCache:  isAppCache,
 	}
 
 	return cca.base.AcquireTokenSilent(ctx, silentParameters)

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -196,9 +196,9 @@ func TestAcquireTokenByAuthCode(t *testing.T) {
 	if tk.AccessToken != token {
 		t.Fatalf("unexpected access token %s", tk.AccessToken)
 	}
-	accounts := client.Accounts()
+	account := client.Account(tk.Account.HomeAccountID)
 	// second attempt should return the cached token
-	tk, err = client.AcquireTokenSilent(context.Background(), tokenScope, WithSilentAccount(accounts[0]))
+	tk, err = client.AcquireTokenSilent(context.Background(), tokenScope, WithSilentAccount(account))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -203,11 +203,11 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 	authParams.HomeaccountID = silent.Account.HomeAccountID
 
 	if s, ok := b.manager.(cache.Serializer); ok {
-		var isApp bool
+		var isAppCache bool
 		if silent.Account.IsZero() {
-			isApp = true
+			isAppCache = true
 		}
-		suggestedCacheKey := authParams.CacheKey(isApp)
+		suggestedCacheKey := authParams.CacheKey(isAppCache)
 		b.cacheAccessor.Replace(s, suggestedCacheKey)
 		defer b.cacheAccessor.Export(s, suggestedCacheKey)
 	}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -33,7 +33,7 @@ type manager interface {
 	Read(ctx context.Context, authParameters authority.AuthParams, account shared.Account) (storage.TokenResponse, error)
 	Write(authParameters authority.AuthParams, tokenResponse accesstokens.TokenResponse) (shared.Account, error)
 	AllAccounts() []shared.Account
-	Accounts(homeAccountID string) []shared.Account
+	Account(homeAccountID string) shared.Account
 }
 
 type noopCacheAccessor struct{}
@@ -292,7 +292,7 @@ func (b Client) AllAccounts() []shared.Account {
 	return accounts
 }
 
-func (b Client) Accounts(homeAccountID string) []shared.Account {
+func (b Client) Account(homeAccountID string) shared.Account {
 	authParams := b.AuthParams // This is a copy, as we dont' have a pointer receiver and .AuthParams is not a pointer.
 	authParams.AuthorizationType = authority.AccountByID
 	authParams.HomeaccountID = homeAccountID
@@ -301,8 +301,8 @@ func (b Client) Accounts(homeAccountID string) []shared.Account {
 		b.cacheAccessor.Replace(s, suggestedCacheKey)
 		defer b.cacheAccessor.Export(s, suggestedCacheKey)
 	}
-	accounts := b.manager.Accounts(homeAccountID)
-	return accounts
+	account := b.manager.Account(homeAccountID)
+	return account
 }
 
 // toLower makes all slice entries lowercase in-place. Returns the same slice that was put in.

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -47,6 +47,7 @@ type AcquireTokenSilentParameters struct {
 	Account     shared.Account
 	RequestType accesstokens.AppType
 	Credential  *accesstokens.Credential
+	IsAppCache  bool
 }
 
 // AcquireTokenAuthCodeParameters contains the parameters required to acquire an access token using the auth code flow.
@@ -203,11 +204,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 	authParams.HomeaccountID = silent.Account.HomeAccountID
 
 	if s, ok := b.manager.(cache.Serializer); ok {
-		var isAppCache bool
-		if silent.Account.IsZero() {
-			isAppCache = true
-		}
-		suggestedCacheKey := authParams.CacheKey(isAppCache)
+		suggestedCacheKey := authParams.CacheKey(silent.IsAppCache)
 		b.cacheAccessor.Replace(s, suggestedCacheKey)
 		defer b.cacheAccessor.Export(s, suggestedCacheKey)
 	}

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -374,17 +374,16 @@ func (m *Manager) AllAccounts() []shared.Account {
 	return accounts
 }
 
-func (m *Manager) Accounts(homeAccountID string) []shared.Account {
+func (m *Manager) Account(homeAccountID string) shared.Account {
 	cache := m.Contract()
 
-	var accounts []shared.Account
 	for _, v := range cache.Accounts {
 		if v.HomeAccountID == homeAccountID {
-			accounts = append(accounts, v)
+			return v
 		}
 	}
 
-	return accounts
+	return shared.Account{}
 }
 
 func (m *Manager) readAccount(homeAccountID string, envAliases []string, realm string) (shared.Account, error) {

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -363,7 +363,7 @@ func (m *Manager) writeIDToken(idToken IDToken) error {
 	return nil
 }
 
-func (m *Manager) AllAccounts() ([]shared.Account, error) {
+func (m *Manager) AllAccounts() []shared.Account {
 	cache := m.Contract()
 
 	var accounts []shared.Account
@@ -371,7 +371,20 @@ func (m *Manager) AllAccounts() ([]shared.Account, error) {
 		accounts = append(accounts, v)
 	}
 
-	return accounts, nil
+	return accounts
+}
+
+func (m *Manager) Accounts(homeAccountID string) []shared.Account {
+	cache := m.Contract()
+
+	var accounts []shared.Account
+	for _, v := range cache.Accounts {
+		if v.HomeAccountID == homeAccountID {
+			accounts = append(accounts, v)
+		}
+	}
+
+	return accounts
 }
 
 func (m *Manager) readAccount(homeAccountID string, envAliases []string, realm string) (shared.Account, error) {

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -95,10 +95,7 @@ func TestAllAccounts(t *testing.T) {
 	storageManager := Manager{}
 	storageManager.update(cache)
 
-	actualAccounts, err := storageManager.AllAccounts()
-	if err != nil {
-		panic(err)
-	}
+	actualAccounts := storageManager.AllAccounts()
 	// AllAccounts() is unstable in that the order can be reversed between calls.
 	// This fixes that.
 	sort.Slice(

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -220,6 +220,16 @@ func (tr *TokenResponse) Validate() error {
 	return nil
 }
 
+func (tr *TokenResponse) CacheKey(authParams authority.AuthParams) string {
+	if authParams.AuthorizationType == authority.ATClientCredentials {
+		return authParams.AppKey()
+	}
+	if authParams.IsConfidentialClient || authParams.AuthorizationType == authority.ATRefreshToken {
+		return tr.ClientInfo.HomeAccountID()
+	}
+	return ""
+}
+
 func findDeclinedScopes(requestedScopes []string, grantedScopes []string) []string {
 	declined := []string{}
 	grantedMap := map[string]bool{}

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -355,8 +355,8 @@ func (c Client) AADInstanceDiscovery(ctx context.Context, authorityInfo Info) (I
 	return resp, err
 }
 
-func (a *AuthParams) CacheKey(isApp bool) string {
-	if a.AuthorizationType == ATClientCredentials || isApp {
+func (a *AuthParams) CacheKey(isAppCache bool) string {
+	if a.AuthorizationType == ATClientCredentials || isAppCache {
 		return a.AppKey()
 	}
 	if a.AuthorizationType == ATRefreshToken || a.AuthorizationType == AccountByID {

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -133,6 +133,8 @@ type AuthParams struct {
 	CodeChallengeMethod string
 	// Prompt specifies the user prompt type during interactive auth.
 	Prompt string
+	// IsConfidentialClient specifies if it is a confidential client
+	IsConfidentialClient bool
 }
 
 // NewAuthParams creates an authorization parameters object.

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -106,6 +106,7 @@ const (
 	ATClientCredentials
 	ATDeviceCode
 	ATRefreshToken
+	AccountByID
 )
 
 // AuthParams represents the parameters used for authorization for token acquisition.
@@ -352,4 +353,21 @@ func (c Client) AADInstanceDiscovery(ctx context.Context, authorityInfo Info) (I
 	resp := InstanceDiscoveryResponse{}
 	err := c.Comm.JSONCall(ctx, endpoint, http.Header{}, qv, nil, &resp)
 	return resp, err
+}
+
+func (a *AuthParams) CacheKey(isApp bool) string {
+	if a.AuthorizationType == ATClientCredentials || isApp {
+		return a.AppKey()
+	}
+	if a.AuthorizationType == ATRefreshToken || a.AuthorizationType == AccountByID {
+		return a.HomeaccountID
+	}
+	return ""
+}
+
+func (a *AuthParams) AppKey() string {
+	if a.AuthorityInfo.Tenant != "" {
+		return fmt.Sprintf("%s_%s_AppTokenCache", a.ClientID, a.AuthorityInfo.Tenant)
+	}
+	return fmt.Sprintf("%s__AppTokenCache", a.ClientID)
 }

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -271,7 +271,7 @@ func (pca Client) AcquireTokenByAuthCode(ctx context.Context, scopes []string, o
 // Accounts gets all the accounts in the token cache.
 // If there are no accounts in the cache the returned slice is empty.
 func (pca Client) Accounts() []Account {
-	return pca.base.Accounts()
+	return pca.base.AllAccounts()
 }
 
 // InteractiveAuthOptions contains the optional parameters used to acquire an access token for interactive auth code flow.

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -156,6 +156,7 @@ func (pca Client) AcquireTokenSilent(ctx context.Context, scopes []string, optio
 		Scopes:      scopes,
 		Account:     opts.Account,
 		RequestType: accesstokens.ATPublic,
+		IsAppCache:  false,
 	}
 
 	return pca.base.AcquireTokenSilent(ctx, silentParameters)

--- a/apps/tests/devapps/sample_cache_accessor.go
+++ b/apps/tests/devapps/sample_cache_accessor.go
@@ -22,7 +22,6 @@ func (t *TokenCache) Replace(cache cache.Unmarshaler, key string) {
 	}
 	defer jsonFile.Close()
 	data, err := ioutil.ReadAll(jsonFile)
-
 	if err != nil {
 		log.Println(err)
 	}

--- a/apps/tests/devapps/sample_cache_accessor.go
+++ b/apps/tests/devapps/sample_cache_accessor.go
@@ -15,13 +15,14 @@ type TokenCache struct {
 	file string
 }
 
-func (t *TokenCache) Replace(cache cache.Unmarshaler) {
+func (t *TokenCache) Replace(cache cache.Unmarshaler, key string) {
 	jsonFile, err := os.Open(t.file)
 	if err != nil {
 		log.Println(err)
 	}
 	defer jsonFile.Close()
 	data, err := ioutil.ReadAll(jsonFile)
+
 	if err != nil {
 		log.Println(err)
 	}
@@ -31,7 +32,7 @@ func (t *TokenCache) Replace(cache cache.Unmarshaler) {
 	}
 }
 
-func (t *TokenCache) Export(cache cache.Marshaler) {
+func (t *TokenCache) Export(cache cache.Marshaler, key string) {
 	data, err := cache.Marshal()
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
The PR adds a parameter named key to the cache interaface. This key can be used to partition the cache for better performance. 

After discussions, this PR also removed GetAccounts() API from confidential clients. 

We instead expose GetAccount(homeAccountId) which returns an Account assosciated with the corresponding homeAccountID

Wiki page : https://github.com/AzureAD/microsoft-authentication-library-for-go/wiki/Using-cache-key-to-partition-the-cache

CC: @jmprieur @jennyf19  