### PR TITLE
Only trigger CI/CD when a PR is labelled 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,9 @@ on:
     branches: [dev]
   pull_request:
     branches: [dev]
+    # This guards against unknown PR until a community member vet it and label it.
+    types: [ labeled ]
+
 
 jobs:
   build:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,6 +8,9 @@ on:
       - main
       - dev
   pull_request:
+    # This guards against unknown PR until a community member vet it and label it.
+      types: [ labeled ]
+
 jobs:
   golangci:
     name: lint


### PR DESCRIPTION
This branch changes the PR to be built only when a label has been added.
Verified this works as expected.