### PR TITLE
Adding support for SubjectName/Issuer (SNI) authentication

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -187,7 +187,7 @@ type Options struct {
 	// It defaults to a shared http.Client.
 	HTTPClient ops.HTTPClient
 
-	// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS
+	// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS.
 	SendX5C bool
 }
 
@@ -227,7 +227,7 @@ func WithHTTPClient(httpClient ops.HTTPClient) Option {
 	}
 }
 
-// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication
+// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication.
 func SendX5C() Option {
 	return func(o *Options) {
 		o.SendX5C = true

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -227,8 +227,8 @@ func WithHTTPClient(httpClient ops.HTTPClient) Option {
 	}
 }
 
-// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication.
-func SendX5C() Option {
+// WithX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication.
+func WithX5C() Option {
 	return func(o *Options) {
 		o.SendX5C = true
 	}
@@ -250,7 +250,7 @@ func New(clientID string, cred Credential, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.SendX5C(opts.SendX5C), base.WithCacheAccessor(opts.Accessor))
+	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithX5C(opts.SendX5C), base.WithCacheAccessor(opts.Accessor))
 	if err != nil {
 		return Client{}, err
 	}

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -227,7 +227,7 @@ func WithHTTPClient(httpClient ops.HTTPClient) Option {
 	}
 }
 
-// SendX5c allows to send X5C value
+// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication
 func SendX5C() Option {
 	return func(o *Options) {
 		o.SendX5C = true

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -140,8 +140,8 @@ type Credential struct {
 // code requires that client.go, requests.go and confidential.go share a credential type without
 // having import recursion. That requires the type used between is in a shared package. Therefore
 // we have this.
-func (c Credential) toInternal(sendX5C bool) *accesstokens.Credential {
-	return &accesstokens.Credential{Secret: c.secret, Cert: c.cert, Key: c.key, SendX5C: sendX5C}
+func (c Credential) toInternal() *accesstokens.Credential {
+	return &accesstokens.Credential{Secret: c.secret, Cert: c.cert, Key: c.key}
 }
 
 // NewCredFromSecret creates a Credential from a secret.
@@ -250,14 +250,14 @@ func New(clientID string, cred Credential, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithCacheAccessor(opts.Accessor))
+	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.SendX5C(opts.SendX5C), base.WithCacheAccessor(opts.Accessor))
 	if err != nil {
 		return Client{}, err
 	}
 
 	return Client{
 		base: base,
-		cred: cred.toInternal(opts.SendX5C),
+		cred: cred.toInternal(),
 	}, nil
 }
 

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -130,6 +130,13 @@ func WithCacheAccessor(ca cache.ExportReplace) Option {
 	}
 }
 
+// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication
+func SendX5C(sendX5C bool) Option {
+	return func(c *Client) {
+		c.AuthParams.SendX5C = sendX5C
+	}
+}
+
 // New is the constructor for Base.
 func New(clientID string, authorityURI string, token *oauth.Client, options ...Option) (Client, error) {
 	authInfo, err := authority.NewInfoFromAuthorityURI(authorityURI, true)

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -130,8 +130,8 @@ func WithCacheAccessor(ca cache.ExportReplace) Option {
 	}
 }
 
-// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication
-func SendX5C(sendX5C bool) Option {
+// WithX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication.
+func WithX5C(sendX5C bool) Option {
 	return func(c *Client) {
 		c.AuthParams.SendX5C = sendX5C
 	}

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -92,6 +92,9 @@ type Credential struct {
 	// Key is the private key for signing if we are doing any auth other than secret.
 	Key crypto.PrivateKey
 
+	// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS
+	SendX5C bool
+
 	// mu protects everything below.
 	mu sync.Mutex
 	// Assertion is the JWT assertion if we have retrieved it. Public to allow faking in tests.
@@ -130,6 +133,9 @@ func (c *Credential) JWT(authParams authority.AuthParams) (string, error) {
 		"x5t": base64.StdEncoding.EncodeToString(thumbprint(c.Cert)),
 	}
 
+	if c.SendX5C {
+		token.Header["x5c"] = []string{base64.StdEncoding.EncodeToString(c.Cert.Raw)}
+	}
 	var err error
 	c.Assertion, err = token.SignedString(c.Key)
 	if err != nil {

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -92,9 +92,6 @@ type Credential struct {
 	// Key is the private key for signing if we are doing any auth other than secret.
 	Key crypto.PrivateKey
 
-	// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS
-	SendX5C bool
-
 	// mu protects everything below.
 	mu sync.Mutex
 	// Assertion is the JWT assertion if we have retrieved it. Public to allow faking in tests.
@@ -133,7 +130,7 @@ func (c *Credential) JWT(authParams authority.AuthParams) (string, error) {
 		"x5t": base64.StdEncoding.EncodeToString(thumbprint(c.Cert)),
 	}
 
-	if c.SendX5C {
+	if authParams.SendX5C {
 		token.Header["x5c"] = []string{base64.StdEncoding.EncodeToString(c.Cert.Raw)}
 	}
 	var err error

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -140,9 +140,9 @@ type AuthParams struct {
 	CodeChallengeMethod string
 	// Prompt specifies the user prompt type during interactive auth.
 	Prompt string
-	// IsConfidentialClient specifies if it is a confidential client
+	// IsConfidentialClient specifies if it is a confidential client.
 	IsConfidentialClient bool
-	// SendX5C does some things
+	// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS.
 	SendX5C bool
 }
 

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -142,6 +142,8 @@ type AuthParams struct {
 	Prompt string
 	// IsConfidentialClient specifies if it is a confidential client
 	IsConfidentialClient bool
+	// SendX5C does some things
+	SendX5C bool
 }
 
 // NewAuthParams creates an authorization parameters object.


### PR DESCRIPTION
This PR resolves #190.

This feature can be enabled by setting WithX5C() option to true when initializing the confidential client application something like this:
``` Go
confidential.New("client_id", credential, confidential.WithAuthority("authority"), confidential.WithX5C())
```

Alternate way to expose this can be by providing this as option to the Credential object here: https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/dev/apps/confidential/confidential.go#L132

Also, I was able to test this e2e using an MSIT cert and configuring the tenant to have MSIT as a Trusted Certificate Authority.

RFC : https://tools.ietf.org/html/rfc7515#section-4.1.6