### PR TITLE
Fixing JSON marshal bug on empty map values

### DIFF
--- a/apps/internal/base/internal/storage/items.go
+++ b/apps/internal/base/internal/storage/items.go
@@ -19,11 +19,11 @@ import (
 // the internal cache. This design is shared between MSAL versions in many languages.
 // This cannot be changed without design that includes other SDKs.
 type Contract struct {
-	AccessTokens  map[string]AccessToken               `json:"AccessToken"`
-	RefreshTokens map[string]accesstokens.RefreshToken `json:"RefreshToken"`
-	IDTokens      map[string]IDToken                   `json:"IdToken"`
-	Accounts      map[string]shared.Account            `json:"Account"`
-	AppMetaData   map[string]AppMetaData               `json:"AppMetadata"`
+	AccessTokens  map[string]AccessToken               `json:"AccessToken,omitempty"`
+	RefreshTokens map[string]accesstokens.RefreshToken `json:"RefreshToken,omitempty"`
+	IDTokens      map[string]IDToken                   `json:"IdToken,omitempty"`
+	Accounts      map[string]shared.Account            `json:"Account,omitempty"`
+	AppMetaData   map[string]AppMetaData               `json:"AppMetadata,omitempty"`
 
 	AdditionalFields map[string]interface{}
 }

--- a/apps/internal/base/internal/storage/items_test.go
+++ b/apps/internal/base/internal/storage/items_test.go
@@ -550,3 +550,46 @@ func TestRefreshTokenMarshal(t *testing.T) {
 		t.Errorf("TestRefreshTokenMarshal: -want/+got:\n%s", diff)
 	}
 }
+
+func TestRegression196(t *testing.T) {
+	// https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/196
+
+	// Note: all values here look real, but they have been altered to prevent any exposure
+	// of even a temporary security value.
+	contract := &Contract{
+		AccessTokens: map[string]AccessToken{
+			"-login.microsoftonline.com-AccessToken-5b0c5134eacb-https://graph.microsoft.com/.default": AccessToken{
+				HomeAccountID:     "",
+				Environment:       "login.microsoftonline.com",
+				Realm:             "2cce-489d-4002-8293-5b0eacb",
+				CredentialType:    "AccessToken",
+				ClientID:          "841-b1d2-460b-bc46-11cfb",
+				Secret:            "secret",
+				Scopes:            "https://graph.microsoft.com/.default",
+				ExpiresOn:         internalTime.Unix{expiresOn},
+				ExtendedExpiresOn: internalTime.Unix{extExpiresOn},
+				CachedAt:          internalTime.Unix{cachedAt},
+			},
+		},
+		AppMetaData: map[string]AppMetaData{
+			"AppMetaData-login.microsoftonline.com-84a31-b1d2-460b-bc46-1158fb": AppMetaData{
+				ClientID:    "8431-bd2-460b-bc46-11c4c8fb",
+				Environment: "login.microsoftonline.com",
+			},
+		},
+	}
+
+	b, err := json.Marshal(contract)
+	if err != nil {
+		t.Fatalf("TestRegression196: Marshal had unexpected error: %v", err)
+	}
+
+	got := &Contract{}
+	if err := json.Unmarshal(b, got); err != nil {
+		t.Fatalf("TestRegression196: Unmarshal had unexpected error: %v, json was:\n%s", err, string(b))
+	}
+
+	if diff := pretty.Compare(contract, got); diff != "" {
+		t.Fatalf("TestRegression196: -want/+got:\n%s", diff)
+	}
+}

--- a/apps/internal/base/internal/storage/items_test.go
+++ b/apps/internal/base/internal/storage/items_test.go
@@ -566,9 +566,9 @@ func TestRegression196(t *testing.T) {
 				ClientID:          "841-b1d2-460b-bc46-11cfb",
 				Secret:            "secret",
 				Scopes:            "https://graph.microsoft.com/.default",
-				ExpiresOn:         internalTime.Unix{expiresOn},
-				ExtendedExpiresOn: internalTime.Unix{extExpiresOn},
-				CachedAt:          internalTime.Unix{cachedAt},
+				ExpiresOn:         internalTime.Unix{T: expiresOn},
+				ExtendedExpiresOn: internalTime.Unix{T: extExpiresOn},
+				CachedAt:          internalTime.Unix{T: cachedAt},
 			},
 		},
 		AppMetaData: map[string]AppMetaData{

--- a/apps/internal/json/marshal.go
+++ b/apps/internal/json/marshal.go
@@ -126,6 +126,11 @@ func marshalMap(v reflect.Value, buff *bytes.Buffer, enc *json.Encoder) error {
 	if v.Kind() != reflect.Map {
 		return fmt.Errorf("bug: marshalMap() called on %T", v.Interface())
 	}
+	if v.Len() == 0 {
+		buff.WriteByte(leftBrace)
+		buff.WriteByte(rightBrace)
+		return nil
+	}
 	encoder := mapEncode{m: v, buff: buff, enc: enc}
 	return encoder.run()
 }
@@ -224,6 +229,11 @@ func (m *mapEncode) encode() (stateFn, error) {
 func marshalSlice(v reflect.Value, buff *bytes.Buffer, enc *json.Encoder) error {
 	if v.Kind() != reflect.Slice {
 		return fmt.Errorf("bug: marshalSlice() called on %T", v.Interface())
+	}
+	if v.Len() == 0 {
+		buff.WriteByte(leftParen)
+		buff.WriteByte(rightParen)
+		return nil
 	}
 	encoder := sliceEncode{s: v, buff: buff, enc: enc}
 	return encoder.run()

--- a/apps/internal/json/marshal_test.go
+++ b/apps/internal/json/marshal_test.go
@@ -212,3 +212,36 @@ func TestMarshalStruct(t *testing.T) {
 		}
 	}
 }
+
+func TestEmptyTypes(t *testing.T) {
+	type structA struct {
+		EmptyMap   map[string]bool
+		EmptySlice []string
+		Slice      []string
+		EmptyInt   int
+		Int        int
+
+		AdditionalFields map[string]interface{}
+	}
+
+	val := structA{
+		EmptyMap: map[string]bool{},
+		Slice:    []string{"hello"},
+		Int:      1,
+	}
+
+	b, err := Marshal(val)
+	if err != nil {
+		t.Fatalf("TestEmptyTypes: unexpected error on Marshal: %v", err)
+	}
+
+	got := structA{}
+
+	if err := Unmarshal(b, &got); err != nil {
+		t.Fatalf("TestEmptyTypes: unexpected error when Umarshalling: %v", err)
+	}
+
+	if diff := pretty.Compare(got, val); diff != "" {
+		t.Fatalf("TestEmptyTypes: -want/+got:\n%s", diff)
+	}
+}


### PR DESCRIPTION
Fixes a bug where the JSON marshaller would write bad JSON when encountering an empty map and the field did not have omitempty in the tag.