### PR TITLE
Trying to fix formatting

### DIFF
--- a/apps/internal/base/internal/storage/items_test.go
+++ b/apps/internal/base/internal/storage/items_test.go
@@ -558,7 +558,7 @@ func TestRegression196(t *testing.T) {
 	// of even a temporary security value.
 	contract := &Contract{
 		AccessTokens: map[string]AccessToken{
-			"-login.microsoftonline.com-AccessToken-5b0c5134eacb-https://graph.microsoft.com/.default": AccessToken{
+			"-login.microsoftonline.com-AccessToken-5b0c5134eacb-https://graph.microsoft.com/.default": {
 				HomeAccountID:     "",
 				Environment:       "login.microsoftonline.com",
 				Realm:             "2cce-489d-4002-8293-5b0eacb",
@@ -572,7 +572,7 @@ func TestRegression196(t *testing.T) {
 			},
 		},
 		AppMetaData: map[string]AppMetaData{
-			"AppMetaData-login.microsoftonline.com-84a31-b1d2-460b-bc46-1158fb": AppMetaData{
+			"AppMetaData-login.microsoftonline.com-84a31-b1d2-460b-bc46-1158fb": {
 				ClientID:    "8431-bd2-460b-bc46-11c4c8fb",
 				Environment: "login.microsoftonline.com",
 			},


### PR DESCRIPTION
This is to fix the failing build. https://github.com/AzureAD/microsoft-authentication-library-for-go/runs/2188167269.

I tried running the failing command on the local machine and this was the output
```
apps\internal\base\internal\storage\items_test.go
apps\tests\benchmarks\confidential.go
apps\tests\devapps\authorization_code_sample.go
apps\tests\devapps\client_certificate_sample.go
apps\tests\devapps\device_code_flow_sample.go
apps\tests\devapps\main.go
apps\tests\devapps\sample_cache_accessor.go
apps\tests\devapps\sample_utils.go
apps\tests\devapps\username_password_sample.go
apps\tests\integration\integration_test.go
```

VS code was showing some problems in the `apps\internal\base\internal\storage\items_test.go` which are fixed below and the build is now green.
