### PR TITLE
Compare scopes case insensitive

### DIFF
--- a/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
@@ -901,6 +901,30 @@ func TestComputeScopes(t *testing.T) {
 				scopesComputed: true,
 			},
 		},
+		{
+			desc: "no declined scopes case insensitive",
+			authParams: authority.AuthParams{
+				Scopes: []string{
+					"scope0",
+					"scope1",
+				},
+			},
+			input: TokenResponse{
+				GrantedScopes: Scopes{
+					Slice: []string{
+						"Scope0",
+						"Scope1",
+					},
+				},
+			},
+			want: TokenResponse{
+				GrantedScopes: Scopes{
+					Slice: []string{"Scope0", "Scope1"},
+				},
+				DeclinedScopes: nil,
+				scopesComputed: true,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -165,7 +165,7 @@ func (s *Scopes) UnmarshalJSON(b []byte) error {
 	if len(str) == 0 {
 		return nil
 	}
-	sl := strings.Split(strings.ToLower(str), " ")
+	sl := strings.Split(str, " ")
 	s.Slice = sl
 	return nil
 }
@@ -234,11 +234,11 @@ func findDeclinedScopes(requestedScopes []string, grantedScopes []string) []stri
 	declined := []string{}
 	grantedMap := map[string]bool{}
 	for _, s := range grantedScopes {
-		grantedMap[s] = true
+		grantedMap[strings.ToLower(s)] = true
 	}
 	// Comparing the requested scopes with the granted scopes to see if there are any scopes that have been declined.
 	for _, r := range requestedScopes {
-		if !grantedMap[r] {
+		if !grantedMap[strings.ToLower(r)] {
 			declined = append(declined, r)
 		}
 	}


### PR DESCRIPTION
Resolves #214.

MSAL Go was converting scopes received from AAD into lowercase. So if the customer Requested `User.Read` and AAD sent `User.Read`, MSAL go would make the granted scopes as `user.read` and fail on comparing granted scopes with requested scopes because of case difference.

This change does 2 things :

1. We do not alter the scopes received from AAD. Meaning we do not convert it to lower case. 
2. The comparison of granted scopes with requested scopes is insensitive. Because AAD behavior is to send back the scopes in corrected case. So if user asked for `user.read`, AAD grants corrected case -> `User.Read ` which should not fail.