### PR TITLE
This branch adds readtimeout and writetimeout to the server. It also adds ssytem shutdown signal, allowing us to gracefully shutdown

### DIFF
--- a/apps/internal/local/server.go
+++ b/apps/internal/local/server.go
@@ -162,7 +162,6 @@ func (s *Server) Shutdown() {
 	}
 	if err != nil {
 		//We failed to shutdown completely.
-		//TODO we should pass a logger into this function
 		log.Fatalf("Shutdown: could not stop the server gracefully: %v", err)
 	}
 


### PR DESCRIPTION
This PR makes the following changes:
1. Handle the critical Http Server errors that we are swallowing

2. Add os syscall shutdown and interrupt alert handling

3. We are just calling Http Server Shutdown with a context that does not have a timeout. What if the shutdown fails or hangs forever?

4. We should also call shutdown and handle the error incase the shutdown fails. If it fails, then we should call Close( ). This will force the shutdown. If forced shutdown fails then thats a fatal error