### PR TITLE
fix: set clientID as part of signed assertions flow

### DIFF
--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -266,6 +266,7 @@ func (c Client) FromAssertion(ctx context.Context, authParameters authority.Auth
 	qv.Set(grantType, grant.ClientCredential)
 	qv.Set("client_assertion_type", grant.ClientAssertion)
 	qv.Set("client_assertion", assertion)
+	qv.Set(clientID, authParameters.ClientID)
 	qv.Set(clientInfo, clientInfoVal)
 	addScopeQueryParam(qv, authParameters)
 

--- a/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
@@ -405,6 +405,7 @@ func TestAccessTokenWithAssertion(t *testing.T) {
 				"client_assertion":      []string{"assertion"},
 				grantType:               []string{grant.ClientCredential},
 				clientInfo:              []string{clientInfoVal},
+				clientID:                []string{authParams.ClientID},
 			},
 		},
 		{
@@ -415,6 +416,7 @@ func TestAccessTokenWithAssertion(t *testing.T) {
 				"client_assertion":      []string{"assertion"},
 				grantType:               []string{grant.ClientCredential},
 				clientInfo:              []string{clientInfoVal},
+				clientID:                []string{authParams.ClientID},
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Sets `clientID` for signed assertions token request flow.

Fixes #225 