### PR TITLE
Modifying confidential client secret sample to use the latest API

### DIFF
--- a/apps/tests/devapps/client_secret_sample.go
+++ b/apps/tests/devapps/client_secret_sample.go
@@ -3,34 +3,31 @@
 
 package main
 
-/*
-func tryClientSecretFlow(app confidential.Client) {
-	result, err := app.AcquireTokenByCredential(context.Background(), confidentialConfig.Scopes)
-	if err != nil {
-		log.Fatal(err)
-	}
-	accessToken := result.GetAccessToken()
-	log.Println("Access token is: " + accessToken)
-}
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+)
 
 func acquireTokenClientSecret() {
-	cred, err := confidential.NewCredFromSecret(confidentialConfig.ClientSecret)
+	config := CreateConfig("confidential_config.json")
+	cred, err := confidential.NewCredFromSecret(config.ClientSecret)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	app, err := confidential.New("myUser", confidentialConfig.ClientID, cred, confidential.Accessor(cacheAccessor), confidential.Authority(confidentialConfig.Authority))
+	app, err := confidential.New(config.ClientID, cred, confidential.WithAuthority(config.Authority), confidential.WithAccessor(cacheAccessor))
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	result, err := app.AcquireTokenSilent(context.Background(), confidentialConfig.Scopes, nil)
+	result, err := app.AcquireTokenSilent(context.Background(), config.Scopes)
 	if err != nil {
-		log.Println(err)
-		tryClientSecretFlow(app)
-	} else {
-		accessToken := result.GetAccessToken()
-		log.Println("Access token is: " + accessToken)
+		result, err = app.AcquireTokenByCredential(context.Background(), config.Scopes)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Access Token Is " + result.AccessToken)
 	}
+	fmt.Println("Silently acquired token " + result.AccessToken)
 }
-*/

--- a/apps/tests/devapps/main.go
+++ b/apps/tests/devapps/main.go
@@ -23,7 +23,7 @@ func main() {
 		panic("currently not implemented")
 		//acquireByAuthorizationCodeConfidential()
 	} else if exampleType == "5" {
-		//acquireTokenClientSecret()
+		acquireTokenClientSecret()
 	} else if exampleType == "6" {
 		acquireTokenClientCertificate()
 	}


### PR DESCRIPTION
Removing the commented sample which was using an older unreleased API and adding one which uses the latest API surface.