### PR TITLE
remove false error handling

### DIFF
--- a/apps/confidential/examples_test.go
+++ b/apps/confidential/examples_test.go
@@ -30,8 +30,5 @@ func ExampleNewCredFromCert_pem() {
 	}
 
 	cred := NewCredFromCert(certs[0], priv)
-	if err != nil {
-		log.Fatal(err)
-	}
 	fmt.Println(cred) // Simply here so cred is used, otherwise won't compile.
 }


### PR DESCRIPTION
`NewCredFromCert ` does not return an error, yet we are wrongly handling the error:

```
cred := NewCredFromCert(certs[0], priv)
	if err != nil {
		log.Fatal(err)
	}
```

