### PR TITLE
Leaf Certificate detection

### DIFF
--- a/apps/confidential/examples_test.go
+++ b/apps/confidential/examples_test.go
@@ -29,6 +29,11 @@ func ExampleNewCredFromCert_pem() {
 		log.Fatal("too many certificates in PEM file")
 	}
 
-	cred := NewCredFromCert(certs[0], priv)
+	leaf, err := LeafCertificate(certs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cred := NewCredFromCert(leaf, priv)
 	fmt.Println(cred) // Simply here so cred is used, otherwise won't compile.
 }

--- a/apps/tests/devapps/client_certificate_sample.go
+++ b/apps/tests/devapps/client_certificate_sample.go
@@ -34,10 +34,12 @@ func acquireTokenClientCertificate() {
 		log.Fatal("too many certificates in PEM file")
 	}
 
-	cred := confidential.NewCredFromCert(certs[0], privateKey)
+	leaf, err := confidential.LeafCertificate(certs)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	cred := confidential.NewCredFromCert(leaf, privateKey)
 	app, err := confidential.New(config.ClientID, cred, confidential.WithAuthority(config.Authority), confidential.WithAccessor(cacheAccessor))
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This PR adds leaf certificate detection. We currently are only reading the first item in a pool of certificates and making the assumption that the first item will always be the leaf certificate. The easier and more predictable approach would be to check if the certificate is marked IsCA or not. Root and Intermediary Certificates are marked IsCA as TRUE because these are certificates that generate/issue other certificates. A leaf certificate has IsCA marked as false because its an end entity certificate. 

The PR also renames `base` variable to `baseClient` to avoid collision with the imported package `github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/base`

Resources:
RFC 5280, x509 package