### PR TITLE
BugFix - Compare scopes insensitive 

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -206,7 +206,6 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 
 func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilentParameters) (AuthResult, error) {
 	authParams := b.AuthParams // This is a copy, as we dont' have a pointer receiver and authParams is not a pointer.
-	toLower(silent.Scopes)
 	authParams.Scopes = silent.Scopes
 	authParams.AuthorizationType = authority.ATRefreshToken
 	authParams.HomeaccountID = silent.Account.HomeAccountID
@@ -318,12 +317,4 @@ func (b Client) RemoveAccount(account shared.Account) {
 		defer b.cacheAccessor.Export(s, suggestedCacheKey)
 	}
 	b.manager.RemoveAccount(account, b.AuthParams.ClientID)
-}
-
-// toLower makes all slice entries lowercase in-place. Returns the same slice that was put in.
-func toLower(s []string) []string {
-	for i := 0; i < len(s); i++ {
-		s[i] = strings.ToLower(s[i])
-	}
-	return s
 }

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -70,8 +70,10 @@ func checkAlias(alias string, aliases []string) bool {
 
 func isMatchingScopes(scopesOne []string, scopesTwo string) bool {
 	newScopesTwo := strings.Split(scopesTwo, scopeSeparator)
+	toLower(newScopesTwo)
 	scopeCounter := 0
 	for _, scope := range scopesOne {
+		scope = strings.ToLower(scope)
 		for _, otherScope := range newScopesTwo {
 			if scope == otherScope {
 				scopeCounter++
@@ -80,6 +82,14 @@ func isMatchingScopes(scopesOne []string, scopesTwo string) bool {
 		}
 	}
 	return scopeCounter == len(scopesOne)
+}
+
+// toLower makes all slice entries lowercase in-place. Returns the same slice that was put in.
+func toLower(s []string) []string {
+	for i := 0; i < len(s); i++ {
+		s[i] = strings.ToLower(s[i])
+	}
+	return s
 }
 
 // Read reads a storage token from the cache if it exists.

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -70,26 +70,16 @@ func checkAlias(alias string, aliases []string) bool {
 
 func isMatchingScopes(scopesOne []string, scopesTwo string) bool {
 	newScopesTwo := strings.Split(scopesTwo, scopeSeparator)
-	toLower(newScopesTwo)
 	scopeCounter := 0
 	for _, scope := range scopesOne {
-		scope = strings.ToLower(scope)
 		for _, otherScope := range newScopesTwo {
-			if scope == otherScope {
+			if strings.EqualFold(scope, otherScope) {
 				scopeCounter++
 				continue
 			}
 		}
 	}
 	return scopeCounter == len(scopesOne)
-}
-
-// toLower makes all slice entries lowercase in-place. Returns the same slice that was put in.
-func toLower(s []string) []string {
-	for i := 0; i < len(s); i++ {
-		s[i] = strings.ToLower(s[i])
-	}
-	return s
 }
 
 // Read reads a storage token from the cache if it exists.

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -76,6 +76,10 @@ func TestIsMatchingScopes(t *testing.T) {
 	if !isMatchingScopes(scopesOne, scopesTwo) {
 		t.Fatalf("Scopes %v and %v are supposed to be the same", scopesOne, scopesTwo)
 	}
+	scopesUpperCase := "openid User.Write User.Read"
+	if !isMatchingScopes(scopesOne, scopesUpperCase) {
+		t.Fatalf("Scopes %v and %v are supposed to be the same as the comparison is case insensitive", scopesOne, scopesUpperCase)
+	}
 	errorScopes := "openid user.read hello"
 	if isMatchingScopes(scopesOne, errorScopes) {
 		t.Fatalf("Scopes %v and %v are not supposed to be the same", scopesOne, errorScopes)


### PR DESCRIPTION
Scenario: 

We write scopes in Access Token Cache object like they are sent by AAD. AAD sends scopes like these:
``` "User.Read User.Write"```
If a user requests `AcquireTokenSilent` with `user.read`, MSAL would not find an accessToken because of scopes not matching.

This PR fixes the above condition by making the scope comparison case insensitive. 