### PR TITLE
Updating dgrijalva/jwt-go to golang-jwt/jwt

### DIFF
--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -29,7 +29,7 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/internal/grant"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/AzureAD/microsoft-authentication-library-for-go
 go 1.14
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
[dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) was cloned to [golang-jwt/jwt](https://github.com/golang-jwt/jwt/tree/v3.2.1) as the maintenance of this project was taken over from the original author. 

Refer this - [Migrating Maintenance](https://github.com/dgrijalva/jwt-go/issues/462) for more details