### PR TITLE
Add method to get all accounts in confidential client cache

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -369,6 +369,12 @@ func (cca Client) AcquireTokenByCredential(ctx context.Context, scopes []string)
 	return cca.base.AuthResultFromToken(ctx, authParams, token, true)
 }
 
+// Accounts gets all the accounts in the token cache.
+// If there are no accounts in the cache the returned slice is empty.
+func (cca Client) Accounts() []Account {
+	return cca.base.AllAccounts()
+}
+
 // Account gets the account in the token cache with the specified homeAccountID.
 func (cca Client) Account(homeAccountID string) Account {
 	return cca.base.Account(homeAccountID)

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -221,4 +221,9 @@ func TestAcquireTokenByAuthCode(t *testing.T) {
 	if tk.AccessToken != token {
 		t.Fatalf("unexpected access token %s", tk.AccessToken)
 	}
+
+	accounts := client.Accounts()
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
 }


### PR DESCRIPTION
This is analogous to `public.Client.Accounts`, and exposes the same functionality as the [msal.ClientApplication.get_accounts](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/da5baf3c72271ac8c68c4dbbcf12cc39fe54594a/msal/application.py#L457) python equivalent.