### PR TITLE
MSAL Go 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft Authentication Library (MSAL) for Go
 
-**MSAL Go is a new addition to the MSAL family of libraries, has been made available in production ready preview to gauge customer interest and to gather feedback from the community. We welcome all contributors (see [CONTRIBUTING.md](https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/dev/CONTRIBUTING.md)) to help us grow our list of supported MSAL SDKs.**
+**MSAL for Go is a new addition to the MSAL family of libraries, has been made available in production ready preview to gauge customer interest and to gather feedback from the community. We welcome all contributors (see [CONTRIBUTING.md](https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/dev/CONTRIBUTING.md)) to help us grow our list of supported MSAL SDKs.**
 
 The Microsoft Authentication Library (MSAL) for Go is part of the [Microsoft identity platform for developers](https://aka.ms/aaddevv2) (formerly named Azure AD) v2.0. It allows you to sign in users or apps with Microsoft identities ([Azure AD](https://azure.microsoft.com/services/active-directory/) and [Microsoft Accounts](https://account.microsoft.com)) and obtain tokens to call Microsoft APIs such as [Microsoft Graph](https://graph.microsoft.io/) or your own APIs registered with the Microsoft identity platform. It is built using industry standard OAuth2 and OpenID Connect protocols.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Microsoft Authentication Library (MSAL) for Go
 
-**MSAL Go is a new addition to the MSAL family of libraries, not yet in public preview, that has been made available to gauge customer interest and to gather early feedback from the community. We welcome all contributors (see [CONTRIBUTING.md](https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/dev/CONTRIBUTING.md)) to help us grow our list of supported MSAL SDKs.**
+**MSAL Go is a new addition to the MSAL family of libraries, has been made available in production ready preview to gauge customer interest and to gather feedback from the community. We welcome all contributors (see [CONTRIBUTING.md](https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/dev/CONTRIBUTING.md)) to help us grow our list of supported MSAL SDKs.**
 
 The Microsoft Authentication Library (MSAL) for Go is part of the [Microsoft identity platform for developers](https://aka.ms/aaddevv2) (formerly named Azure AD) v2.0. It allows you to sign in users or apps with Microsoft identities ([Azure AD](https://azure.microsoft.com/services/active-directory/) and [Microsoft Accounts](https://account.microsoft.com)) and obtain tokens to call Microsoft APIs such as [Microsoft Graph](https://graph.microsoft.io/) or your own APIs registered with the Microsoft identity platform. It is built using industry standard OAuth2 and OpenID Connect protocols.
 
-The first public preview of this library is yet to be released, until then, the latest code resides in the `dev` branch.
+The latest code resides in the `dev` branch.
 
 Quick links:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ Acquiring tokens with MSAL Go follows this general three step pattern. There mig
 
 You can view the [dev apps](https://github.com/AzureAD/microsoft-authentication-library-for-go/tree/dev/apps/tests/devapps) on how to use MSAL Go with various application types in various scenarios. For more detailed information, please refer to the [wiki](https://github.com/AzureAD/microsoft-authentication-library-for-go/wiki).
 
-## Road map
+# Releases
+The list of [releases](https://github.com/AzureAD/microsoft-authentication-library-for-go/releases)
+
+## Roadmap
 
 This is a preview library. Details of the roadmap will come soon in the [wiki pages](https://github.com/AzureAD/microsoft-authentication-library-for-go/wiki), along with release notes.
 

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -51,7 +51,7 @@ put a PEM decoder into here.
 */
 
 // TODO(msal): This should have example code for each method on client using Go's example doc framework.
-// base usage details should be includee in the package documentation.
+// base usage details should be include in the package documentation.
 
 // AuthResult contains the results of one token acquisition operation.
 // For details see https://aka.ms/msal-net-authenticationresult

--- a/apps/confidential/examples_test.go
+++ b/apps/confidential/examples_test.go
@@ -30,8 +30,5 @@ func ExampleNewCredFromCert_pem() {
 	}
 
 	cred := NewCredFromCert(certs[0], priv)
-	if err != nil {
-		log.Fatal(err)
-	}
 	fmt.Println(cred) // Simply here so cred is used, otherwise won't compile.
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -206,7 +206,6 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 
 func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilentParameters) (AuthResult, error) {
 	authParams := b.AuthParams // This is a copy, as we dont' have a pointer receiver and authParams is not a pointer.
-	toLower(silent.Scopes)
 	authParams.Scopes = silent.Scopes
 	authParams.AuthorizationType = authority.ATRefreshToken
 	authParams.HomeaccountID = silent.Account.HomeAccountID
@@ -318,12 +317,4 @@ func (b Client) RemoveAccount(account shared.Account) {
 		defer b.cacheAccessor.Export(s, suggestedCacheKey)
 	}
 	b.manager.RemoveAccount(account, b.AuthParams.ClientID)
-}
-
-// toLower makes all slice entries lowercase in-place. Returns the same slice that was put in.
-func toLower(s []string) []string {
-	for i := 0; i < len(s); i++ {
-		s[i] = strings.ToLower(s[i])
-	}
-	return s
 }

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -73,7 +73,7 @@ func isMatchingScopes(scopesOne []string, scopesTwo string) bool {
 	scopeCounter := 0
 	for _, scope := range scopesOne {
 		for _, otherScope := range newScopesTwo {
-			if scope == otherScope {
+			if strings.EqualFold(scope, otherScope) {
 				scopeCounter++
 				continue
 			}

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -76,6 +76,10 @@ func TestIsMatchingScopes(t *testing.T) {
 	if !isMatchingScopes(scopesOne, scopesTwo) {
 		t.Fatalf("Scopes %v and %v are supposed to be the same", scopesOne, scopesTwo)
 	}
+	scopesUpperCase := "openid User.Write User.Read"
+	if !isMatchingScopes(scopesOne, scopesUpperCase) {
+		t.Fatalf("Scopes %v and %v are supposed to be the same as the comparison is case insensitive", scopesOne, scopesUpperCase)
+	}
 	errorScopes := "openid user.read hello"
 	if isMatchingScopes(scopesOne, errorScopes) {
 		t.Fatalf("Scopes %v and %v are not supposed to be the same", scopesOne, errorScopes)

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -29,7 +29,7 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/internal/grant"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 )
 

--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -5,4 +5,4 @@
 package version
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "0.3.0"
+const Version = "0.3.1"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/AzureAD/microsoft-authentication-library-for-go
 go 1.14
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
Bugfix: `AcquireTokenSilent()` does case insensitive comparison to avoid cache misses (#264 )
Change: Replacing use of archived dependency `dgrijalva/jwt-go` to `golang-jwt/jwt` (#244, #265 )