### PR TITLE
Allow Creation of Access Token via RefreshToken

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -264,7 +264,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 			cc = silent.Credential
 		}
 
-		token, err := b.Token.Refresh(ctx, silent.RequestType, b.AuthParams, cc, storageTokenResponse.RefreshToken)
+		token, err := b.Token.Refresh(ctx, silent.RequestType, authParams, cc, storageTokenResponse.RefreshToken)
 		if err != nil {
 			return AuthResult{}, err
 		}

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -96,7 +96,16 @@ func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams,
 
 	accessToken, err := m.readAccessToken(homeAccountID, metadata.Aliases, realm, clientID, scopes)
 	if err != nil {
-		return TokenResponse{}, err
+		appMeta, err := m.readAppMetaData(metadata.Aliases, clientID)
+		if err != nil {
+			return TokenResponse{}, err
+		}
+
+		refreshToken, err := m.readRefreshToken(homeAccountID, metadata.Aliases, appMeta.FamilyID, clientID)
+		if err != nil {
+			return TokenResponse{}, err
+		}
+		return TokenResponse{RefreshToken: refreshToken}, err
 	}
 
 	if account.IsZero() {

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -312,19 +312,16 @@ func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, 
 	if err != nil {
 		return AuthResult{}, err
 	}
-	authParams.Redirecturi = res.redirectURI
 
-	req, err := accesstokens.NewCodeChallengeRequest(authParams, accesstokens.ATPublic, nil, res.authCode, cv)
-	if err != nil {
-		return AuthResult{}, err
+	params := base.AcquireTokenAuthCodeParameters{
+		AppType:     accesstokens.ATPublic,
+		Challenge:   cv,
+		Code:        res.authCode,
+		RedirectURI: res.redirectURI,
+		Scopes:      scopes,
 	}
 
-	token, err := pca.base.Token.AuthCode(ctx, req)
-	if err != nil {
-		return AuthResult{}, err
-	}
-
-	return pca.base.AuthResultFromToken(ctx, authParams, token, true)
+	return pca.base.AcquireTokenByAuthCode(ctx, params)
 }
 
 type interactiveAuthResult struct {


### PR DESCRIPTION
There is probably a cleaner way to do this, but we should fallback to trying to create an accessToken via a refreshToken if available instead of returning an error.

In my case, I try to acquire a token silently before doing an interactive.  Without this, each time something needed a new scope or otherwise different level of access, it would bring up the interactive prompt.  Now, it only does if it is not able to use the refresh token to create a new access token.

This also fixes the empty authParams being passed to Refresh instead of the requested authParams.
