### PR TITLE
[Feature Request] ValidateAuthority parameter not exposed causing the library not to be used in ADFS deployment. #289

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -249,6 +249,10 @@ func WithX5C() Option {
 // will store credentials for (a Client is per user). clientID is the Azure clientID and cred is
 // the type of credential to use.
 func New(clientID string, cred Credential, options ...Option) (Client, error) {
+	return NewClient(clientID, true, cred, options...)
+}
+
+func NewClient(clientID string, validateAuthority bool, cred Credential, options ...Option) (Client, error) {
 	opts := Options{
 		Authority:  base.AuthorityPublicCloud,
 		HTTPClient: shared.DefaultClient,
@@ -261,7 +265,7 @@ func New(clientID string, cred Credential, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithX5C(opts.SendX5C), base.WithCacheAccessor(opts.Accessor))
+	base, err := base.NewClient(clientID, opts.Authority, validateAuthority, oauth.New(opts.HTTPClient), base.WithX5C(opts.SendX5C), base.WithCacheAccessor(opts.Accessor))
 	if err != nil {
 		return Client{}, err
 	}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -156,7 +156,12 @@ func WithX5C(sendX5C bool) Option {
 
 // New is the constructor for Base.
 func New(clientID string, authorityURI string, token *oauth.Client, options ...Option) (Client, error) {
-	authInfo, err := authority.NewInfoFromAuthorityURI(authorityURI, true)
+	return NewClient(clientID, authorityURI, true, token, options...)
+}
+
+// New is the constructor for Base.
+func NewClient(clientID string, authorityURI string, validateAuthority bool, token *oauth.Client, options ...Option) (Client, error) {
+	authInfo, err := authority.NewInfoFromAuthorityURI(authorityURI, validateAuthority)
 	if err != nil {
 		return Client{}, err
 	}

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -104,6 +104,11 @@ type Client struct {
 
 // New is the constructor for Client.
 func New(clientID string, options ...Option) (Client, error) {
+	return NewClient(clientID, true, options...)
+}
+
+// New is the constructor for Client.
+func NewClient(clientID string, validateAuthority bool, options ...Option) (Client, error) {
 	opts := Options{
 		Authority:  base.AuthorityPublicCloud,
 		HTTPClient: shared.DefaultClient,
@@ -116,7 +121,7 @@ func New(clientID string, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithCacheAccessor(opts.Accessor))
+	base, err := base.NewClient(clientID, opts.Authority, validateAuthority, oauth.New(opts.HTTPClient), base.WithCacheAccessor(opts.Accessor))
 	if err != nil {
 		return Client{}, err
 	}


### PR DESCRIPTION
[Feature Request] ValidateAuthority parameter not exposed causing the library not to be used in ADFS deployment. #289