### PR TITLE
Add `context` to `ExportReplace` interface

### DIFF
--- a/apps/cache/cache.go
+++ b/apps/cache/cache.go
@@ -11,6 +11,8 @@ implementers on the format being passed.
 */
 package cache
 
+import "context"
+
 // Marshaler marshals data from an internal cache to bytes that can be stored.
 type Marshaler interface {
 	Marshal() ([]byte, error)
@@ -31,9 +33,9 @@ type Serializer interface {
 type ExportReplace interface {
 	// Replace replaces the cache with what is in external storage.
 	// key is the suggested key which can be used for partioning the cache
-	Replace(cache Unmarshaler, key string)
+	Replace(ctx context.Context, cache Unmarshaler, key string)
 	// Export writes the binary representation of the cache (cache.Marshal()) to
 	// external storage. This is considered opaque.
 	// key is the suggested key which can be used for partioning the cache
-	Export(cache Marshaler, key string)
+	Export(ctx context.Context, cache Marshaler, key string)
 }

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -381,12 +381,12 @@ func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion stri
 }
 
 // Account gets the account in the token cache with the specified homeAccountID.
-func (cca Client) Account(homeAccountID string) Account {
-	return cca.base.Account(homeAccountID)
+func (cca Client) Account(ctx context.Context, homeAccountID string) Account {
+	return cca.base.Account(ctx, homeAccountID)
 }
 
 // RemoveAccount signs the account out and forgets account from token cache.
-func (cca Client) RemoveAccount(account Account) error {
-	cca.base.RemoveAccount(account)
+func (cca Client) RemoveAccount(ctx context.Context, account Account) error {
+	cca.base.RemoveAccount(ctx, account)
 	return nil
 }

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -254,13 +254,13 @@ func (pca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redir
 
 // Accounts gets all the accounts in the token cache.
 // If there are no accounts in the cache the returned slice is empty.
-func (pca Client) Accounts() []Account {
-	return pca.base.AllAccounts()
+func (pca Client) Accounts(ctx context.Context) []Account {
+	return pca.base.AllAccounts(ctx)
 }
 
 // RemoveAccount signs the account out and forgets account from token cache.
-func (pca Client) RemoveAccount(account Account) error {
-	pca.base.RemoveAccount(account)
+func (pca Client) RemoveAccount(ctx context.Context, account Account) error {
+	pca.base.RemoveAccount(ctx, account)
 	return nil
 }
 

--- a/apps/tests/devapps/sample_cache_accessor.go
+++ b/apps/tests/devapps/sample_cache_accessor.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"os"
@@ -15,7 +16,7 @@ type TokenCache struct {
 	file string
 }
 
-func (t *TokenCache) Replace(cache cache.Unmarshaler, key string) {
+func (t *TokenCache) Replace(ctx context.Context, cache cache.Unmarshaler, key string) {
 	jsonFile, err := os.Open(t.file)
 	if err != nil {
 		log.Println(err)
@@ -31,7 +32,7 @@ func (t *TokenCache) Replace(cache cache.Unmarshaler, key string) {
 	}
 }
 
-func (t *TokenCache) Export(cache cache.Marshaler, key string) {
+func (t *TokenCache) Export(ctx context.Context, cache cache.Marshaler, key string) {
 	data, err := cache.Marshal()
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
We're looking to use this library to replace the support we built ourselves in our app.  However, in order to instrument the usage of the cache, we need a `context` to be passed via the ExportReplace interface.  This changes that interface and adds the underlying plumbing to make sure the context can be passed through.

This would be a breaking API change, so I'm willing to work around that if it's necessary.  Instead of this change, we could allow adding a `CacheAccessorWithContext` or similar, but it would add some complexity and the breaking API changes aren't onerous.  I'd opt for the breaking change given this is still preview, but I'll defer to y'all there if you decide to accept this change.

Thanks for this library!  Let me know if there's anything I need to change so that this can be considered.