### PR TITLE
Fixes #298 - Use Major version XML attribute to detect the version

### DIFF
--- a/apps/internal/oauth/ops/wstrust/defs/saml_assertion_definitions.go
+++ b/apps/internal/oauth/ops/wstrust/defs/saml_assertion_definitions.go
@@ -108,6 +108,7 @@ type Assertion struct {
 	Issuer                  string                  `xml:"Issuer,attr"`
 	IssueInstant            string                  `xml:"IssueInstant,attr"`
 	Saml                    string                  `xml:"saml,attr"`
+	Saml1                   string                  `xml:"saml1,attr"`
 	Conditions              Conditions              `xml:"Conditions"`
 	AttributeStatement      AttributeStatement      `xml:"AttributeStatement"`
 	AuthenticationStatement AuthenticationStatement `xml:"AuthenticationStatement"`

--- a/apps/internal/oauth/ops/wstrust/wstrust.go
+++ b/apps/internal/oauth/ops/wstrust/wstrust.go
@@ -112,8 +112,10 @@ func (c Client) SAMLTokenInfo(ctx context.Context, authParameters authority.Auth
 }
 
 const (
-	samlv1Assertion = "urn:oasis:names:tc:SAML:1.0:assertion"
-	samlv2Assertion = "urn:oasis:names:tc:SAML:2.0:assertion"
+	samlv2MajorVersion = "2"
+	samlv1MajorVersion = "1"
+	samlv1Assertion    = "urn:oasis:names:tc:SAML:1.0:assertion"
+	samlv2Assertion    = "urn:oasis:names:tc:SAML:2.0:assertion"
 )
 
 func (c Client) samlAssertion(def defs.SAMLDefinitions) (SamlTokenInfo, error) {
@@ -121,15 +123,13 @@ func (c Client) samlAssertion(def defs.SAMLDefinitions) (SamlTokenInfo, error) {
 		token := tokenResponse.RequestedSecurityToken
 		if token.Assertion.XMLName.Local != "" {
 			assertion := token.AssertionRawXML
-
-			samlVersion := token.Assertion.Saml
-			switch samlVersion {
-			case samlv1Assertion:
+			switch token.Assertion.MajorVersion {
+			case samlv1MajorVersion:
 				return SamlTokenInfo{AssertionType: grant.SAMLV1, Assertion: assertion}, nil
-			case samlv2Assertion:
+			case samlv2MajorVersion:
 				return SamlTokenInfo{AssertionType: grant.SAMLV2, Assertion: assertion}, nil
 			}
-			return SamlTokenInfo{}, fmt.Errorf("couldn't parse SAML assertion, version unknown: %q", samlVersion)
+			return SamlTokenInfo{}, fmt.Errorf("couldn't parse SAML assertion, version unknown: %q", token.Assertion.MajorVersion)
 		}
 	}
 	return SamlTokenInfo{}, errors.New("unknown WS-Trust version")

--- a/apps/internal/oauth/ops/wstrust/wstrust_test.go
+++ b/apps/internal/oauth/ops/wstrust/wstrust_test.go
@@ -232,7 +232,8 @@ func TestSAMLTokenInfo(t *testing.T) {
 										XMLName: xml.Name{
 											Local: "Assertion",
 										},
-										Saml: samlv1Assertion,
+										Saml:         samlv1Assertion,
+										MajorVersion: samlv1MajorVersion,
 									},
 								},
 							},
@@ -259,7 +260,8 @@ func TestSAMLTokenInfo(t *testing.T) {
 										XMLName: xml.Name{
 											Local: "Assertion",
 										},
-										Saml: samlv1Assertion,
+										Saml:         samlv1Assertion,
+										MajorVersion: samlv1MajorVersion,
 									},
 								},
 							},
@@ -285,7 +287,8 @@ func TestSAMLTokenInfo(t *testing.T) {
 										XMLName: xml.Name{
 											Local: "Assertion",
 										},
-										Saml: samlv1Assertion,
+										Saml:         samlv1Assertion,
+										MajorVersion: samlv1MajorVersion,
 									},
 								},
 							},
@@ -311,7 +314,8 @@ func TestSAMLTokenInfo(t *testing.T) {
 										XMLName: xml.Name{
 											Local: "Assertion",
 										},
-										Saml: samlv2Assertion,
+										Saml:         samlv2Assertion,
+										MajorVersion: samlv2MajorVersion,
 									},
 								},
 							},


### PR DESCRIPTION
instead  of matching on field that doesn't exist in SAML1 assertions.