### PR TITLE
ESTS-Regional support

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,9 +16,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.32

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -200,6 +200,9 @@ type Options struct {
 
 	// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS.
 	SendX5C bool
+
+	// TODO: write region detection info
+	autoDetectRegion bool
 }
 
 func (o Options) validate() error {
@@ -242,6 +245,12 @@ func WithHTTPClient(httpClient ops.HTTPClient) Option {
 func WithX5C() Option {
 	return func(o *Options) {
 		o.SendX5C = true
+	}
+}
+
+func withRegionDetection() Option {
+	return func(o *Options) {
+		o.autoDetectRegion = true
 	}
 }
 

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -253,7 +253,7 @@ func WithX5C() Option {
 	}
 }
 
-// WithAzureRegionsets the region(preferred) or Confidential.AutoDetectRegion() for auto detecting region.
+// WithAzureRegion sets the region(preferred) or Confidential.AutoDetectRegion() for auto detecting region.
 // Region names as per https://azure.microsoft.com/en-ca/global-infrastructure/geographies/.
 // See https://aka.ms/region-map for more details on region names.
 // The region value should be short region name for the region where the service is deployed.

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -169,6 +169,11 @@ func NewCredFromCert(cert *x509.Certificate, key crypto.PrivateKey) Credential {
 	return Credential{cert: cert, key: key}
 }
 
+// AutoDetectRegion instructs MSAL Go to auto detect region for Azure regional token service.
+func AutoDetectRegion() string {
+	return "TryAutoDetect"
+}
+
 // Client is a representation of authentication client for confidential applications as defined in the
 // package doc. A new Client should be created PER SERVICE USER.
 // For more information, visit https://docs.microsoft.com/azure/active-directory/develop/msal-client-applications
@@ -201,8 +206,8 @@ type Options struct {
 	// SendX5C specifies if x5c claim(public key of the certificate) should be sent to STS.
 	SendX5C bool
 
-	// TODO: write region detection info
-	autoDetectRegion bool
+	// Instructs MSAL Go to use an Azure regional token service with sepcified AzureRegion.
+	AzureRegion string
 }
 
 func (o Options) validate() error {
@@ -248,9 +253,20 @@ func WithX5C() Option {
 	}
 }
 
-func withRegionDetection() Option {
+// WithAzureRegionsets the region(preferred) or Confidential.AutoDetectRegion() for auto detecting region.
+// Region names as per https://azure.microsoft.com/en-ca/global-infrastructure/geographies/.
+// See https://aka.ms/region-map for more details on region names.
+// The region value should be short region name for the region where the service is deployed.
+// For example "centralus" is short name for region Central US.
+// Not all auth flows can use the regional token service.
+// Service To Service (client credential flow) tokens can be obtained from the regional service.
+// Requires configuration at the tenant level.
+// Auto-detection works on a limited number of Azure artifacts (VMs, Azure functions).
+// If auto-detection fails, the non-regional endpoint will be used.
+// If an invalid region name is provided, the non-regional endpoint MIGHT be used or the token request MIGHT fail.
+func WithAzureRegion(val string) Option {
 	return func(o *Options) {
-		o.autoDetectRegion = true
+		o.AzureRegion = val
 	}
 }
 
@@ -270,7 +286,7 @@ func New(clientID string, cred Credential, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithX5C(opts.SendX5C), base.WithCacheAccessor(opts.Accessor))
+	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithX5C(opts.SendX5C), base.WithCacheAccessor(opts.Accessor), base.WithRegionDetection(opts.AzureRegion))
 	if err != nil {
 		return Client{}, err
 	}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -154,6 +154,12 @@ func WithX5C(sendX5C bool) Option {
 	}
 }
 
+func withRegionDetection(region string) Option {
+	return func(c *Client) {
+		c.AuthParams.AuthorityInfo.Region = region
+	}
+}
+
 // New is the constructor for Base.
 func New(clientID string, authorityURI string, token *oauth.Client, options ...Option) (Client, error) {
 	authInfo, err := authority.NewInfoFromAuthorityURI(authorityURI, true)

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -154,7 +154,7 @@ func WithX5C(sendX5C bool) Option {
 	}
 }
 
-func withRegionDetection(region string) Option {
+func WithRegionDetection(region string) Option {
 	return func(c *Client) {
 		c.AuthParams.AuthorityInfo.Region = region
 	}

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -23,7 +23,7 @@ const (
 	instanceDiscoveryEndpointWithRegion = "https://%v.%v/common/discovery/instance"
 	regionName                          = "REGION_NAME"
 	defaultAPIVersion                   = "2020-06-01"
-	imdsEndpoint                        = "https://169.254.169.254/metadata/instance/compute/location"
+	imdsEndpoint                        = "http://169.254.169.254/metadata/instance/compute/location"
 	defaultHost                         = "login.microsoftonline.com"
 	autoDetectRegion                    = "TryAutoDetect"
 )

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -364,12 +364,15 @@ func detectRegion(ctx context.Context) string {
 		return strings.ToLower(region)
 	}
 	// HTTP call to IMDS endpoint to get region
+	// Refer : https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=%2FPinAuthToRegion%2FAAD%20SDK%20Proposal%20to%20Pin%20Auth%20to%20region.md&_a=preview&version=GBdev
+	// Set a 2 second timeout for this http client which only does calls to IMDS endpoint
 	client := http.Client{
 		Timeout: time.Duration(2 * time.Second),
 	}
 	req, _ := http.NewRequest("GET", imdsEndpoint, nil)
 	req.Header.Set("Metadata", "true")
 	resp, err := client.Do(req)
+	// If the request times out or there is an error, it is retried once
 	if err != nil || resp.StatusCode != 200 {
 		resp, err = client.Do(req)
 		if err != nil || resp.StatusCode != 200 {

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -371,6 +371,9 @@ func detectRegion(ctx context.Context) string {
 		return ""
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return ""
+	}
 	response, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return ""

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -360,7 +360,8 @@ func (c Client) AADInstanceDiscovery(ctx context.Context, authorityInfo Info) (I
 func (c Client) detectRegion(ctx context.Context) string {
 	region := os.Getenv(regionName)
 	if region != "" {
-		return region
+		region = strings.ReplaceAll(region, " ", "")
+		return strings.ToLower(region)
 	}
 	qv := url.Values{}
 	qv.Set("api-version", defaultAPIVersion)

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -18,15 +18,14 @@ import (
 )
 
 const (
-	authorizationEndpoint               = "https://%v/%v/oauth2/v2.0/authorize"
-	instanceDiscoveryEndpoint           = "https://%v/common/discovery/instance"
-	instanceDiscoveryEndpointWithRegion = "https://%v.%v/common/discovery/instance"
-	TenantDiscoveryEndpointWithRegion   = "https://%v.r.%v/%v/v2.0/.well-known/openid-configuration"
-	regionName                          = "REGION_NAME"
-	defaultAPIVersion                   = "2020-06-01"
-	imdsEndpoint                        = "http://169.254.169.254/metadata/instance/compute/location"
-	defaultHost                         = "login.microsoftonline.com"
-	autoDetectRegion                    = "TryAutoDetect"
+	authorizationEndpoint             = "https://%v/%v/oauth2/v2.0/authorize"
+	instanceDiscoveryEndpoint         = "https://%v/common/discovery/instance"
+	TenantDiscoveryEndpointWithRegion = "https://%v.r.%v/%v/v2.0/.well-known/openid-configuration"
+	regionName                        = "REGION_NAME"
+	defaultAPIVersion                 = "2020-06-01"
+	imdsEndpoint                      = "http://169.254.169.254/metadata/instance/compute/location"
+	defaultHost                       = "login.microsoftonline.com"
+	autoDetectRegion                  = "TryAutoDetect"
 )
 
 type jsonCaller interface {

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -365,9 +365,8 @@ func (c Client) detectRegion(ctx context.Context) string {
 	qv := url.Values{}
 	qv.Set("api-version", defaultAPIVersion)
 	qv.Set("format", "text")
-
 	resp := ""
-	err := c.Comm.JSONCall(ctx, imdsEndpoint, http.Header{}, nil, nil, &resp)
+	err := c.Comm.JSONCall(ctx, imdsEndpoint, http.Header{}, qv, nil, &resp)
 	if err != nil {
 		return ""
 	}

--- a/apps/internal/oauth/ops/authority/authority_test.go
+++ b/apps/internal/oauth/ops/authority/authority_test.go
@@ -275,7 +275,7 @@ func TestAADInstanceDiscoveryWithRegion(t *testing.T) {
 		t.Errorf("AADInstanceDiscoveryWithRegion failing with %s", err)
 	}
 	expectedTenantDiscoveryEndpoint := fmt.Sprintf(TenantDiscoveryEndpointWithRegion, "eastus", "host", "tenant")
-	expectedPreferredNetwork := fmt.Sprintf("%v.%v", "region", "host")
+	expectedPreferredNetwork := fmt.Sprintf("%v.%v", "eastus", "host")
 	expectedPreferredCache := "host"
 	if resp.TenantDiscoveryEndpoint != expectedTenantDiscoveryEndpoint {
 		t.Errorf("AADInstanceDiscoveryWithRegion incorrect TenantDiscoveryEndpoint: got: %s , want: %s", resp.TenantDiscoveryEndpoint, expectedTenantDiscoveryEndpoint)

--- a/apps/internal/oauth/ops/authority/authority_test.go
+++ b/apps/internal/oauth/ops/authority/authority_test.go
@@ -235,6 +235,21 @@ func TestAADInstanceDiscovery(t *testing.T) {
 			},
 			resp: &InstanceDiscoveryResponse{},
 		},
+		{
+			desc:     "Success with region = eastus returns successfully",
+			endpoint: fmt.Sprintf(instanceDiscoveryEndpointWithRegion, "eastus", defaultHost),
+			authInfo: Info{
+				Host:   "host",
+				Tenant: "tenant",
+				Region: "eastus",
+			},
+
+			qv: url.Values{
+				"api-version":            []string{"1.1"},
+				"authorization_endpoint": []string{fmt.Sprintf(authorizationEndpoint, "host", "tenant")},
+			},
+			resp: &InstanceDiscoveryResponse{},
+		},
 	}
 
 	for _, test := range tests {

--- a/apps/internal/oauth/ops/authority/authority_test.go
+++ b/apps/internal/oauth/ops/authority/authority_test.go
@@ -235,21 +235,6 @@ func TestAADInstanceDiscovery(t *testing.T) {
 			},
 			resp: &InstanceDiscoveryResponse{},
 		},
-		{
-			desc:     "Success with region = eastus returns successfully",
-			endpoint: fmt.Sprintf(instanceDiscoveryEndpointWithRegion, "eastus", defaultHost),
-			authInfo: Info{
-				Host:   "host",
-				Tenant: "tenant",
-				Region: "eastus",
-			},
-
-			qv: url.Values{
-				"api-version":            []string{"1.1"},
-				"authorization_endpoint": []string{fmt.Sprintf(authorizationEndpoint, "host", "tenant")},
-			},
-			resp: &InstanceDiscoveryResponse{},
-		},
 	}
 
 	for _, test := range tests {
@@ -277,6 +262,32 @@ func TestAADInstanceDiscovery(t *testing.T) {
 	}
 }
 
+func TestAADInstanceDiscoveryWithRegion(t *testing.T) {
+	fake := &fakeJSONCaller{}
+	client := Client{fake}
+	authInfo := Info{
+		Host:   "host",
+		Tenant: "tenant",
+		Region: "eastus",
+	}
+	resp, err := client.AADInstanceDiscovery(context.Background(), authInfo)
+	if err != nil {
+		t.Errorf("AADInstanceDiscoveryWithRegion failing with %s", err)
+	}
+	expectedTenantDiscoveryEndpoint := fmt.Sprintf(TenantDiscoveryEndpointWithRegion, "eastus", "host", "tenant")
+	expectedPreferredNetwork := fmt.Sprintf("%v.%v", "region", "host")
+	expectedPreferredCache := "host"
+	if resp.TenantDiscoveryEndpoint != expectedTenantDiscoveryEndpoint {
+		t.Errorf("AADInstanceDiscoveryWithRegion incorrect TenantDiscoveryEndpoint: got: %s , want: %s", resp.TenantDiscoveryEndpoint, expectedTenantDiscoveryEndpoint)
+	}
+	if resp.Metadata[0].PreferredNetwork != expectedPreferredNetwork {
+		t.Errorf("AADInstanceDiscoveryWithRegion incorrect Preferred Network got: %s , want: %s", resp.Metadata[0].PreferredNetwork, expectedPreferredNetwork)
+	}
+	if resp.Metadata[0].PreferredCache != expectedPreferredCache {
+		t.Errorf("AADInstanceDiscoveryWithRegion incorrect Preferred Cache got: %s , want: %s", resp.Metadata[0].PreferredCache, expectedPreferredCache)
+
+	}
+}
 func TestCreateAuthorityInfoFromAuthorityUri(t *testing.T) {
 	const authorityURI = "https://login.microsoftonline.com/common/"
 

--- a/apps/internal/oauth/resolvers.go
+++ b/apps/internal/oauth/resolvers.go
@@ -131,6 +131,13 @@ func (m *authorityEndpoint) openIDConfigurationEndpoint(ctx context.Context, aut
 			return "", err
 		}
 		return resp.TenantDiscoveryEndpoint, nil
+	} else if authorityInfo.Region != "" {
+		resp, err := m.rest.Authority().AADInstanceDiscovery(ctx, authorityInfo)
+		if err != nil {
+			return "", err
+		}
+		return resp.TenantDiscoveryEndpoint, nil
+
 	}
 
 	return authorityInfo.CanonicalAuthorityURI + "v2.0/.well-known/openid-configuration", nil


### PR DESCRIPTION
This resolves #240 

This is the internal design doc: [AAD SDK Proposal to Pin Auth to region](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=%2FPinAuthToRegion%2FAAD%20SDK%20Proposal%20to%20Pin%20Auth%20to%20region.md&_a=preview&version=GBdev)

I was able to E2E test this by specifying an Azure Region using this [sample app](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/2cebdaec10f1991482ed7109a2fa34389a037299/tests/devapps/RegionalTestApp/Program.cs#L81).

Also added a [wiki page](https://github.com/AzureAD/microsoft-authentication-library-for-go/wiki/How-to-use-ests-r-support-in-code) to show usage details.