### PR TITLE
Adding default scopes to the request sent to authorize endpoint

### DIFF
--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -394,7 +394,7 @@ var detectDefaultScopes = map[string]bool{
 
 var defaultScopes = []string{"openid", "offline_access", "profile"}
 
-func addScopeQueryParam(queryParams url.Values, authParameters authority.AuthParams) {
+func AppendDefaultScopes(authParameters authority.AuthParams) []string {
 	scopes := make([]string, 0, len(authParameters.Scopes)+len(defaultScopes))
 	for _, scope := range authParameters.Scopes {
 		s := strings.TrimSpace(scope)
@@ -407,6 +407,10 @@ func addScopeQueryParam(queryParams url.Values, authParameters authority.AuthPar
 		scopes = append(scopes, scope)
 	}
 	scopes = append(scopes, defaultScopes...)
+	return scopes
+}
 
+func addScopeQueryParam(queryParams url.Values, authParameters authority.AuthParams) {
+	scopes := AppendDefaultScopes(authParameters)
 	queryParams.Set("scope", strings.Join(scopes, " "))
 }

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -362,6 +362,7 @@ func (pca Client) browserLogin(ctx context.Context, redirectURI *url.URL, params
 		return interactiveAuthResult{}, err
 	}
 	defer srv.Shutdown()
+	params.Scopes = accesstokens.AppendDefaultScopes(params)
 	authURL, err := pca.base.AuthCodeURL(ctx, params.ClientID, srv.Addr, params.Scopes, params)
 	if err != nil {
 		return interactiveAuthResult{}, err


### PR DESCRIPTION
This fix enables the interactive auth code flow login for MSA users. 
MSA user login was failing as the default scopes would not get appended in the request to the authorize endpoint. 