### PR TITLE
Enable updating client assertions via callback

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -136,7 +136,7 @@ type Credential struct {
 	cert *x509.Certificate
 	key  crypto.PrivateKey
 
-	assertion string
+	assertionCallback func(context.Context) (string, error)
 }
 
 // toInternal returns the accesstokens.Credential that is used internally. The current structure of the
@@ -144,7 +144,7 @@ type Credential struct {
 // having import recursion. That requires the type used between is in a shared package. Therefore
 // we have this.
 func (c Credential) toInternal() *accesstokens.Credential {
-	return &accesstokens.Credential{Secret: c.secret, Cert: c.cert, Key: c.key, Assertion: c.assertion}
+	return &accesstokens.Credential{Secret: c.secret, Cert: c.cert, Key: c.key, AssertionCallback: c.assertionCallback}
 }
 
 // NewCredFromSecret creates a Credential from a secret.
@@ -156,11 +156,20 @@ func NewCredFromSecret(secret string) (Credential, error) {
 }
 
 // NewCredFromAssertion creates a Credential from a signed assertion.
+//
+// Deprecated: a Credential created by this function can't refresh the
+// assertion when it expires. Use NewCredFromAssertionCallback instead.
 func NewCredFromAssertion(assertion string) (Credential, error) {
 	if assertion == "" {
 		return Credential{}, errors.New("assertion can't be empty string")
 	}
-	return Credential{assertion: assertion}, nil
+	return NewCredFromAssertionCallback(func(context.Context) (string, error) { return assertion, nil }), nil
+}
+
+// NewCredFromAssertionCallback creates a Credential that invokes a callback to get assertions
+// authenticating the application.
+func NewCredFromAssertionCallback(callback func(context.Context) (string, error)) Credential {
+	return Credential{assertionCallback: callback}
 }
 
 // NewCredFromCert creates a Credential from an x509.Certificate and a PKCS8 DER encoded private key.

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -167,7 +167,7 @@ func NewCredFromAssertion(assertion string) (Credential, error) {
 }
 
 // NewCredFromAssertionCallback creates a Credential that invokes a callback to get assertions
-// authenticating the application.
+// authenticating the application. The callback must be thread safe.
 func NewCredFromAssertionCallback(callback func(context.Context) (string, error)) Credential {
 	return Credential{assertionCallback: callback}
 }

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/base"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/exported"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens"
@@ -129,6 +130,9 @@ func parsePrivateKey(der []byte) (crypto.PrivateKey, error) {
 	return key, nil
 }
 
+// AssertionRequestOptions has required information for client assertion claims
+type AssertionRequestOptions = exported.AssertionRequestOptions
+
 // Credential represents the credential used in confidential client flows.
 type Credential struct {
 	secret string
@@ -136,7 +140,7 @@ type Credential struct {
 	cert *x509.Certificate
 	key  crypto.PrivateKey
 
-	assertionCallback func(context.Context) (string, error)
+	assertionCallback func(context.Context, AssertionRequestOptions) (string, error)
 }
 
 // toInternal returns the accesstokens.Credential that is used internally. The current structure of the
@@ -163,12 +167,12 @@ func NewCredFromAssertion(assertion string) (Credential, error) {
 	if assertion == "" {
 		return Credential{}, errors.New("assertion can't be empty string")
 	}
-	return NewCredFromAssertionCallback(func(context.Context) (string, error) { return assertion, nil }), nil
+	return NewCredFromAssertionCallback(func(context.Context, AssertionRequestOptions) (string, error) { return assertion, nil }), nil
 }
 
 // NewCredFromAssertionCallback creates a Credential that invokes a callback to get assertions
 // authenticating the application. The callback must be thread safe.
-func NewCredFromAssertionCallback(callback func(context.Context) (string, error)) Credential {
+func NewCredFromAssertionCallback(callback func(context.Context, AssertionRequestOptions) (string, error)) Credential {
 	return Credential{assertionCallback: callback}
 }
 

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -136,9 +136,10 @@ func TestAcquireTokenByCredential(t *testing.T) {
 
 func TestAcquireTokenByAssertionCallback(t *testing.T) {
 	calls := 0
-	ctx := context.WithValue(context.Background(), "test", true)
+	type key string
+	ctx := context.WithValue(context.Background(), key("test"), true)
 	getAssertion := func(c context.Context) (string, error) {
-		if !c.Value("test").(bool) {
+		if !c.Value(key("test")).(bool) {
 			t.Fatal("callback received unexpected context")
 		}
 		calls++
@@ -149,6 +150,9 @@ func TestAcquireTokenByAssertionCallback(t *testing.T) {
 	}
 	cred := NewCredFromAssertionCallback(getAssertion)
 	client, err := fakeClient(accesstokens.TokenResponse{}, cred)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < 3; i++ {
 		if calls != i {
 			t.Fatalf("expected %d calls, got %d", i, calls)

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -136,10 +136,10 @@ func TestAcquireTokenByCredential(t *testing.T) {
 
 func TestAcquireTokenByAssertionCallback(t *testing.T) {
 	calls := 0
-	type key string
-	ctx := context.WithValue(context.Background(), key("test"), true)
+	key := struct{}{}
+	ctx := context.WithValue(context.Background(), key, true)
 	getAssertion := func(c context.Context) (string, error) {
-		if !c.Value(key("test")).(bool) {
+		if v := c.Value(key); v == nil || !v.(bool) {
 			t.Fatal("callback received unexpected context")
 		}
 		calls++

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -5,6 +5,7 @@ package confidential
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -46,12 +47,8 @@ const (
 
 var tokenScope = []string{"the_scope"}
 
-func fakeClient(tk accesstokens.TokenResponse, credential string) (Client, error) {
-	cred, err := NewCredFromSecret(credential)
-	if err != nil {
-		return Client{}, err
-	}
-	client, err := New("fake_client_id", cred, WithAuthority("https://fake_authority/fake"))
+func fakeClient(tk accesstokens.TokenResponse, credential Credential) (Client, error) {
+	client, err := New("fake_client_id", credential, WithAuthority("https://fake_authority/fake"))
 	if err != nil {
 		return Client{}, err
 	}
@@ -101,12 +98,16 @@ func TestAcquireTokenByCredential(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		cred, err := NewCredFromSecret(test.cred)
+		if err != nil {
+			t.Fatal(err)
+		}
 		client, err := fakeClient(accesstokens.TokenResponse{
 			AccessToken:   token,
 			ExpiresOn:     internalTime.DurationTime{T: time.Now().Add(1 * time.Hour)},
 			ExtExpiresOn:  internalTime.DurationTime{T: time.Now().Add(1 * time.Hour)},
 			GrantedScopes: accesstokens.Scopes{Slice: tokenScope},
-		}, test.cred)
+		}, cred)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -133,7 +134,41 @@ func TestAcquireTokenByCredential(t *testing.T) {
 	}
 }
 
+func TestAcquireTokenByAssertionCallback(t *testing.T) {
+	calls := 0
+	ctx := context.WithValue(context.Background(), "test", true)
+	getAssertion := func(c context.Context) (string, error) {
+		if !c.Value("test").(bool) {
+			t.Fatal("callback received unexpected context")
+		}
+		calls++
+		if calls < 4 {
+			return "assertion", nil
+		}
+		return "", errors.New("expected error")
+	}
+	cred := NewCredFromAssertionCallback(getAssertion)
+	client, err := fakeClient(accesstokens.TokenResponse{}, cred)
+	for i := 0; i < 3; i++ {
+		if calls != i {
+			t.Fatalf("expected %d calls, got %d", i, calls)
+		}
+		_, err = client.AcquireTokenByCredential(ctx, tokenScope)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err = client.AcquireTokenByCredential(ctx, tokenScope)
+	if err == nil || err.Error() != "expected error" {
+		t.Fatalf("expected an error from the callback, got %v", err)
+	}
+}
+
 func TestAcquireTokenByAuthCode(t *testing.T) {
+	cred, err := NewCredFromSecret("fake_secret")
+	if err != nil {
+		t.Fatal(err)
+	}
 	client, err := fakeClient(accesstokens.TokenResponse{
 		AccessToken:   token,
 		RefreshToken:  refresh,
@@ -159,7 +194,7 @@ func TestAcquireTokenByAuthCode(t *testing.T) {
 			UID:  "123-456",
 			UTID: "fake",
 		},
-	}, "fake_secret")
+	}, cred)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apps/internal/exported/exported.go
+++ b/apps/internal/exported/exported.go
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// package exported contains internal types that are re-exported from a public package
+package exported
+
+// AssertionRequestOptions has information required to generate a client assertion
+type AssertionRequestOptions struct {
+	// ClientID identifies the application for which an assertion is requested. Used as the assertion's "iss" and "sub" claims.
+	ClientID string
+
+	// TokenEndpoint is the intended token endpoint. Used as the assertion's "aud" claim.
+	TokenEndpoint string
+}

--- a/apps/internal/oauth/oauth.go
+++ b/apps/internal/oauth/oauth.go
@@ -99,7 +99,7 @@ func (t *Client) Credential(ctx context.Context, authParams authority.AuthParams
 	if cred.Secret != "" {
 		return t.AccessTokens.FromClientSecret(ctx, authParams, cred.Secret)
 	}
-	jwt, err := cred.JWT(authParams)
+	jwt, err := cred.JWT(ctx, authParams)
 	if err != nil {
 		return accesstokens.TokenResponse{}, err
 	}
@@ -116,7 +116,7 @@ func (t *Client) OnBehalfOf(ctx context.Context, authParams authority.AuthParams
 		return t.AccessTokens.FromUserAssertionClientSecret(ctx, authParams, authParams.UserAssertion, cred.Secret)
 
 	}
-	jwt, err := cred.JWT(authParams)
+	jwt, err := cred.JWT(ctx, authParams)
 	if err != nil {
 		return accesstokens.TokenResponse{}, err
 	}

--- a/apps/internal/oauth/oauth_test.go
+++ b/apps/internal/oauth/oauth_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/exported"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/fake"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
@@ -66,7 +67,7 @@ func TestAuthCode(t *testing.T) {
 }
 
 func TestCredential(t *testing.T) {
-	callback := func(context.Context) (string, error) {
+	callback := func(context.Context, exported.AssertionRequestOptions) (string, error) {
 		return "assertion", nil
 	}
 	tests := []struct {

--- a/apps/internal/oauth/oauth_test.go
+++ b/apps/internal/oauth/oauth_test.go
@@ -66,6 +66,9 @@ func TestAuthCode(t *testing.T) {
 }
 
 func TestCredential(t *testing.T) {
+	callback := func(context.Context) (string, error) {
+		return "assertion", nil
+	}
 	tests := []struct {
 		desc       string
 		re         fake.ResolveEndpoints
@@ -79,8 +82,7 @@ func TestCredential(t *testing.T) {
 			re:   fake.ResolveEndpoints{Err: true},
 			at:   &fake.AccessTokens{},
 			cred: &accesstokens.Credential{
-				Assertion: "assertion",
-				Expires:   time.Now().Add(-5 * time.Minute),
+				AssertionCallback: callback,
 			},
 			err: true,
 		},
@@ -89,8 +91,7 @@ func TestCredential(t *testing.T) {
 			re:   fake.ResolveEndpoints{},
 			at:   &fake.AccessTokens{Err: true},
 			cred: &accesstokens.Credential{
-				Assertion: "assertion",
-				Expires:   time.Now().Add(-5 * time.Minute),
+				AssertionCallback: callback,
 			},
 			err: true,
 		},
@@ -99,9 +100,8 @@ func TestCredential(t *testing.T) {
 			re:   fake.ResolveEndpoints{},
 			at:   &fake.AccessTokens{Err: true},
 			cred: &accesstokens.Credential{
-				Assertion: "assertion",
-				Expires:   time.Now().Add(5 * time.Minute),
-				Cert:      &x509.Certificate{},
+				AssertionCallback: callback,
+				Cert:              &x509.Certificate{},
 				// Key is nil and causes token.SignedString(c.Key) to fail in Credential.JWT()
 			},
 			err: true,
@@ -111,8 +111,7 @@ func TestCredential(t *testing.T) {
 			re:   fake.ResolveEndpoints{},
 			at:   &fake.AccessTokens{Err: true},
 			cred: &accesstokens.Credential{
-				Assertion: "assertion",
-				Expires:   time.Now().Add(-5 * time.Minute),
+				AssertionCallback: callback,
 			},
 			err: true,
 		},
@@ -129,8 +128,7 @@ func TestCredential(t *testing.T) {
 			re:   fake.ResolveEndpoints{},
 			at:   &fake.AccessTokens{},
 			cred: &accesstokens.Credential{
-				Assertion: "assertion",
-				Expires:   time.Now().Add(-5 * time.Minute),
+				AssertionCallback: callback,
 			},
 		},
 	}

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -42,9 +42,6 @@ const (
 	password      = "password"
 )
 
-// assertionLifetime allows tests to control the expiration time of JWT assertions created by Credential.
-var assertionLifetime = 10 * time.Minute
-
 //go:generate stringer -type=AppType
 
 // AppType is whether the authorization code flow is for a public or confidential client.

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
@@ -90,41 +89,24 @@ type Credential struct {
 	// Secret contains the credential secret if we are doing auth by secret.
 	Secret string
 
-	// Cert is the public x509 certificate if we are doing any auth other than secret.
+	// Cert is the public certificate, if we're authenticating by certificate.
 	Cert *x509.Certificate
-	// Key is the private key for signing if we are doing any auth other than secret.
+	// Key is the private key for signing, if we're authenticating by certificate.
 	Key crypto.PrivateKey
 
-	// mu protects everything below.
-	mu sync.Mutex
-	// Assertion is the signed JWT assertion if we have retrieved it or if it was passed.
-	Assertion string
-	// Expires is when the Assertion expires. Public to allow faking in tests.
-	// Any use outside msal is not supported by a compatibility promise.
-	Expires time.Time
+	// AssertionCallback is a function provided by the application, if we're authenticating by assertion.
+	AssertionCallback func(context.Context) (string, error)
 }
 
 // JWT gets the jwt assertion when the credential is not using a secret.
-func (c *Credential) JWT(authParams authority.AuthParams) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.Expires.After(time.Now()) {
-		return c.Assertion, nil
-	} else if c.Cert == nil || c.Key == nil {
-		// The assertion has expired and this Credential can't generate a new one. The assertion
-		// was presumably provided by the application via confidential.NewCredFromAssertion(). We
-		// return it despite its expiration to maintain the behavior of previous versions, and
-		// because there's no API enabling the application to replace the assertion
-		// (see https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/292).
-		return c.Assertion, nil
+func (c *Credential) JWT(ctx context.Context, authParams authority.AuthParams) (string, error) {
+	if c.AssertionCallback != nil {
+		return c.AssertionCallback(ctx)
 	}
-
-	expires := time.Now().Add(assertionLifetime)
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"aud": authParams.Endpoints.TokenEndpoint,
-		"exp": strconv.FormatInt(expires.Unix(), 10),
+		"exp": strconv.FormatInt(time.Now().Add(10*time.Minute).Unix(), 10),
 		"iss": authParams.ClientID,
 		"jti": uuid.New().String(),
 		"nbf": strconv.FormatInt(time.Now().Unix(), 10),
@@ -139,14 +121,12 @@ func (c *Credential) JWT(authParams authority.AuthParams) (string, error) {
 	if authParams.SendX5C {
 		token.Header["x5c"] = []string{base64.StdEncoding.EncodeToString(c.Cert.Raw)}
 	}
-	var err error
-	c.Assertion, err = token.SignedString(c.Key)
+
+	assertion, err := token.SignedString(c.Key)
 	if err != nil {
 		return "", fmt.Errorf("unable to sign a JWT token using private key: %w", err)
 	}
-
-	c.Expires = expires
-	return c.Assertion, nil
+	return assertion, nil
 }
 
 // thumbprint runs the asn1.Der bytes through sha1 for use in the x5t parameter of JWT.
@@ -213,7 +193,7 @@ func (c Client) FromAuthCode(ctx context.Context, req AuthCodeRequest) (TokenRes
 		if req.Credential == nil {
 			return TokenResponse{}, fmt.Errorf("AuthCodeRequest had nil Credential for Confidential app")
 		}
-		qv, err = prepURLVals(req.Credential, req.AuthParams)
+		qv, err = prepURLVals(ctx, req.Credential, req.AuthParams)
 		if err != nil {
 			return TokenResponse{}, err
 		}
@@ -239,7 +219,7 @@ func (c Client) FromRefreshToken(ctx context.Context, appType AppType, authParam
 	qv := url.Values{}
 	if appType == ATConfidential {
 		var err error
-		qv, err = prepURLVals(cc, authParams)
+		qv, err = prepURLVals(ctx, cc, authParams)
 		if err != nil {
 			return TokenResponse{}, err
 		}
@@ -374,14 +354,14 @@ func (c Client) doTokenResp(ctx context.Context, authParams authority.AuthParams
 
 // prepURLVals returns an url.Values that sets various key/values if we are doing secrets
 // or JWT assertions.
-func prepURLVals(cc *Credential, authParams authority.AuthParams) (url.Values, error) {
+func prepURLVals(ctx context.Context, cc *Credential, authParams authority.AuthParams) (url.Values, error) {
 	params := url.Values{}
 	if cc.Secret != "" {
 		params.Set("client_secret", cc.Secret)
 		return params, nil
 	}
 
-	jwt, err := cc.JWT(authParams)
+	jwt, err := cc.JWT(ctx, authParams)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This closes #292 by replacing the static string assertion with a callback that enables applications to generate assertions as needed. Following up on https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/313#discussion_r879838372, I also removed assertion caching; `Credential` will now acquire or create a new assertion for each token request.