### PR TITLE
[Hotfix] incorrect authParams passed to Refresh token method

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -270,7 +270,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 			cc = silent.Credential
 		}
 
-		token, err := b.Token.Refresh(ctx, silent.RequestType, b.AuthParams, cc, storageTokenResponse.RefreshToken)
+		token, err := b.Token.Refresh(ctx, silent.RequestType, authParams, cc, storageTokenResponse.RefreshToken)
 		if err != nil {
 			return AuthResult{}, err
 		}


### PR DESCRIPTION
fixed wrong authParams passed to Refresh function

Regarding this issue:
https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/322