### PR TITLE
MSAL Go 0.5.2

### DIFF
--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -22,7 +22,7 @@ import (
 const (
 	authorizationEndpoint             = "https://%v/%v/oauth2/v2.0/authorize"
 	instanceDiscoveryEndpoint         = "https://%v/common/discovery/instance"
-	TenantDiscoveryEndpointWithRegion = "https://%v.r.%v/%v/v2.0/.well-known/openid-configuration"
+	tenantDiscoveryEndpointWithRegion = "https://%s.%s/%s/v2.0/.well-known/openid-configuration"
 	regionName                        = "REGION_NAME"
 	defaultAPIVersion                 = "2021-10-01"
 	imdsEndpoint                      = "http://169.254.169.254/metadata/instance/compute/location?format=text&api-version=" + defaultAPIVersion
@@ -332,7 +332,12 @@ func (c Client) AADInstanceDiscovery(ctx context.Context, authorityInfo Info) (I
 		region = detectRegion(ctx)
 	}
 	if region != "" {
-		resp.TenantDiscoveryEndpoint = fmt.Sprintf(TenantDiscoveryEndpointWithRegion, region, authorityInfo.Host, authorityInfo.Tenant)
+		environment := authorityInfo.Host
+		switch environment {
+		case "login.microsoft.com", "login.windows.net", "sts.windows.net", defaultHost:
+			environment = "r." + defaultHost
+		}
+		resp.TenantDiscoveryEndpoint = fmt.Sprintf(tenantDiscoveryEndpointWithRegion, region, environment, authorityInfo.Tenant)
 		metadata := InstanceDiscoveryMetadata{
 			PreferredNetwork: fmt.Sprintf("%v.%v", region, authorityInfo.Host),
 			PreferredCache:   authorityInfo.Host,

--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -5,4 +5,4 @@
 package version
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "0.5.1"
+const Version = "0.5.2"


### PR DESCRIPTION
* Bugfix: Now we use correct regional tenant discovery endpoints. (#320, #321)