### PR TITLE
Fix silent auth scopes and refresh behavior

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -262,7 +262,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 	result, err := AuthResultFromStorage(storageTokenResponse)
 	if err != nil {
 		if reflect.ValueOf(storageTokenResponse.RefreshToken).IsZero() {
-			return AuthResult{}, errors.New("no refresh token found")
+			return AuthResult{}, errors.New("no token found")
 		}
 
 		var cc *accesstokens.Credential

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -270,7 +270,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 			cc = silent.Credential
 		}
 
-		token, err := b.Token.Refresh(ctx, silent.RequestType, b.AuthParams, cc, storageTokenResponse.RefreshToken)
+		token, err := b.Token.Refresh(ctx, silent.RequestType, authParams, cc, storageTokenResponse.RefreshToken)
 		if err != nil {
 			return AuthResult{}, err
 		}

--- a/apps/internal/base/base_test.go
+++ b/apps/internal/base/base_test.go
@@ -33,6 +33,7 @@ var (
 	fakeIDToken = accesstokens.IDToken{
 		Oid:               "oid",
 		PreferredUsername: fakeUsername,
+		RawToken:          "x.e30",
 		TenantID:          fakeTenantID,
 		UPN:               fakeUsername,
 	}
@@ -85,6 +86,12 @@ func TestAcquireTokenSilentEmptyCache(t *testing.T) {
 }
 
 func TestAcquireTokenSilentScopes(t *testing.T) {
+	// ensure fakeIDToken.RawToken unmarshals (doesn't matter to what) because an unmarshalling
+	// error can conceal a test bug by making an "err != nil" check true for the wrong reason
+	var idToken accesstokens.IDToken
+	if err := idToken.UnmarshalJSON([]byte(fakeIDToken.RawToken)); err != nil {
+		t.Fatal(err)
+	}
 	for _, test := range []struct {
 		desc              string
 		cachedTokenScopes []string
@@ -124,7 +131,7 @@ func TestAcquireTokenSilentScopes(t *testing.T) {
 				},
 				accesstokens.TokenResponse{
 					AccessToken:   fakeAccessToken,
-					ExpiresOn:     internalTime.DurationTime{T: time.Now().Add(time.Hour)},
+					ExpiresOn:     internalTime.DurationTime{T: time.Now().Add(-time.Hour)},
 					GrantedScopes: accesstokens.Scopes{Slice: test.cachedTokenScopes},
 					IDToken:       fakeIDToken,
 					RefreshToken:  fakeRefreshToken,

--- a/apps/internal/base/internal/storage/items.go
+++ b/apps/internal/base/internal/storage/items.go
@@ -103,8 +103,14 @@ func (a AccessToken) Key() string {
 	)
 }
 
+// FakeValidate enables tests to fake access token validation
+var FakeValidate func(AccessToken) error
+
 // Validate validates that this AccessToken can be used.
 func (a AccessToken) Validate() error {
+	if FakeValidate != nil {
+		return FakeValidate(a)
+	}
 	if a.CachedAt.T.After(time.Now()) {
 		return errors.New("access token isn't valid, it was cached at a future time")
 	}

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -136,28 +136,25 @@ func TestReadAccessToken(t *testing.T) {
 	storageManager := newForTest(nil)
 	storageManager.update(cache)
 
-	retAccessToken, err := storageManager.readAccessToken(
+	retAccessToken := storageManager.readAccessToken(
 		"hid",
 		[]string{"hello", "env", "test"},
 		"realm",
 		"cid",
 		[]string{"user.read", "openid"},
 	)
-	if err != nil {
-		t.Errorf("readAccessToken(): got err == %s, want err == nil", err)
-	}
 	if diff := pretty.Compare(testAccessToken, retAccessToken); diff != "" {
 		t.Fatalf("Returned access token is not the same as expected access token: -want/+got:\n%s", diff)
 	}
-	_, err = storageManager.readAccessToken(
+	retAccessToken = storageManager.readAccessToken(
 		"this_should_break_it",
 		[]string{"hello", "env", "test"},
 		"realm",
 		"cid",
 		[]string{"user.read", "openid"},
 	)
-	if err == nil {
-		t.Errorf("readAccessToken(): got err == nil, want err != nil")
+	if !reflect.ValueOf(retAccessToken).IsZero() {
+		t.Fatal("expected to find no access token")
 	}
 }
 

--- a/apps/internal/oauth/fake/fake.go
+++ b/apps/internal/oauth/fake/fake.go
@@ -47,6 +47,9 @@ type AccessTokens struct {
 
 	// fake result to return
 	DeviceCode accesstokens.DeviceCodeResult
+
+	// FromRefreshTokenCallback is an optional callback invoked by FromRefreshToken
+	FromRefreshTokenCallback func(appType accesstokens.AppType, authParams authority.AuthParams, cc *accesstokens.Credential, refreshToken string)
 }
 
 func (f *AccessTokens) FromUsernamePassword(ctx context.Context, authParameters authority.AuthParams) (accesstokens.TokenResponse, error) {
@@ -62,6 +65,9 @@ func (f *AccessTokens) FromAuthCode(ctx context.Context, req accesstokens.AuthCo
 	return f.AccessToken, nil
 }
 func (f *AccessTokens) FromRefreshToken(ctx context.Context, appType accesstokens.AppType, authParams authority.AuthParams, cc *accesstokens.Credential, refreshToken string) (accesstokens.TokenResponse, error) {
+	if f.FromRefreshTokenCallback != nil {
+		f.FromRefreshTokenCallback(appType, authParams, cc, refreshToken)
+	}
 	if f.Err {
 		return accesstokens.TokenResponse{}, fmt.Errorf("error")
 	}

--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -5,4 +5,4 @@
 package version
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "0.5.2"
+const Version = "0.5.3"


### PR DESCRIPTION
This fixes two problems with silent authentication:
  1. it ignores the requested scopes (closes #322; thanks @mkurock)
  1. it uses refresh tokens only to refresh expired access tokens i.e., silent authentication for a given scope succeeds only when the cache contains an access token (expired or not) for that scope

Fixing the first problem is straightforward: just pass the right argument. The second problem is more complex. It arises in the cache's `Read` method, which assumes the caller requires an access token matching the given parameters and returns an error when it doesn't find one. If the caller could in principle use a previously cached refresh token to authenticate, it never gets the chance because `Read` doesn't return that refresh token. I fixed this by having `Read` continue past an access token cache miss to fetch more data, such as a refresh token, before returning. This means `Read` now returns a zero-valued access token in some cases. This is okay because `base.Client` is the only caller and already validates access tokens before returning them to the application.