### PR TITLE
Document improvement: Alert user to use confidential.WithX5C() option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Acquiring tokens with MSAL Go follows this general three step pattern. There mig
    * Initializing a public client:
 
     ```go
-    publicClientApp, err := public.New("client_id", public.WithAuthority("https://login.microsoftonline.com/Enter_The_Tenant_Name_Here"))
+    publicClientApp, err := public.New("client_id", public.WithAuthority("https://login.microsoftonline.com/Enter_The_Tenant_Name_Here"), confidential.WithX5C())
     ```
 
    * Initializing a confidential client:
@@ -54,7 +54,7 @@ Acquiring tokens with MSAL Go follows this general three step pattern. There mig
     if err != nil {
         return nil, fmt.Errorf("could not create a cred from a secret: %w", err)
     }
-    confidentialClientApp, err := confidential.New("client_id", cred, confidential.WithAuthority("https://login.microsoftonline.com/Enter_The_Tenant_Name_Here"))
+    confidentialClientApp, err := confidential.New("client_id", cred, confidential.WithAuthority("https://login.microsoftonline.com/Enter_The_Tenant_Name_Here"), confidential.WithX5C())
     ```
 
 1. MSAL comes packaged with an in-memory cache. Utilizing the cache is optional, but we would highly recommend it.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Acquiring tokens with MSAL Go follows this general three step pattern. There mig
    * Initializing a public client:
 
     ```go
-    publicClientApp, err := public.New("client_id", public.WithAuthority("https://login.microsoftonline.com/Enter_The_Tenant_Name_Here"), confidential.WithX5C())
+    publicClientApp, err := public.New("client_id", public.WithAuthority("https://login.microsoftonline.com/Enter_The_Tenant_Name_Here"))
     ```
 
    * Initializing a confidential client:


### PR DESCRIPTION
Some microsoft endpoints require the `x5c` option to be set. However, almost nobody knows this knowledge, and it will cost the engineer several hours to hunting this hidden issue. 

After wasting 4 hours on bug-hunting, I think it's very very important to add these information into our document, to help other users avoid this issue. 

I'm not sure about the best method to improve the doc. This is some proposal, and welcome for suggestion.  