### PR TITLE
Provide Accounts() with confidential client

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -418,6 +418,12 @@ func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion stri
 	return cca.base.AcquireTokenOnBehalfOf(ctx, params)
 }
 
+// Accounts gets all the accounts in the token cache.
+// If there are no accounts in the cache the returned slice is empty.
+func (cca Client) Accounts() []Account {
+        return cca.base.AllAccounts()
+}
+
 // Account gets the account in the token cache with the specified homeAccountID.
 func (cca Client) Account(homeAccountID string) Account {
 	return cca.base.Account(homeAccountID)


### PR DESCRIPTION
The public client provides this method and the confidential one should do so too.
Otherwise we can't get the home id for acquiring a silent token when we already have a cache.