### PR TITLE
Delete unused PartitionedManager.Read account parameter

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -37,9 +37,9 @@ type manager interface {
 }
 
 // partitionedManager provides an internal cache. It is defined to allow faking the cache in tests.
-// In all production use it is a *storage.Manager.
+// In all production use it is a *storage.PartitionedManager.
 type partitionedManager interface {
-	Read(ctx context.Context, authParameters authority.AuthParams, account shared.Account) (storage.TokenResponse, error)
+	Read(ctx context.Context, authParameters authority.AuthParams) (storage.TokenResponse, error)
 	Write(authParameters authority.AuthParams, tokenResponse accesstokens.TokenResponse) (shared.Account, error)
 }
 
@@ -242,7 +242,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 			b.cacheAccessor.Replace(s, suggestedCacheKey)
 			defer b.cacheAccessor.Export(s, suggestedCacheKey)
 		}
-		storageTokenResponse, err = b.pmanager.Read(ctx, authParams, silent.Account)
+		storageTokenResponse, err = b.pmanager.Read(ctx, authParams)
 		if err != nil {
 			return AuthResult{}, err
 		}

--- a/apps/internal/base/internal/storage/partitioned_storage.go
+++ b/apps/internal/base/internal/storage/partitioned_storage.go
@@ -36,7 +36,7 @@ func NewPartitionedManager(requests *oauth.Client) *PartitionedManager {
 }
 
 // Read reads a storage token from the cache if it exists.
-func (m *PartitionedManager) Read(ctx context.Context, authParameters authority.AuthParams, account shared.Account) (TokenResponse, error) {
+func (m *PartitionedManager) Read(ctx context.Context, authParameters authority.AuthParams) (TokenResponse, error) {
 	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID
 	scopes := authParameters.Scopes
@@ -69,7 +69,7 @@ func (m *PartitionedManager) Read(ctx context.Context, authParameters authority.
 		return TokenResponse{}, err
 	}
 
-	account, err = m.readAccount(metadata.Aliases, realm, userAssertionHash, idToken.HomeAccountID)
+	account, err := m.readAccount(metadata.Aliases, realm, userAssertionHash, idToken.HomeAccountID)
 	if err != nil {
 		return TokenResponse{}, err
 	}


### PR DESCRIPTION
This has no impact on user code because `PartitionedManager` is internal. The parameter is unnecessary because the partitioned cache is used only in the OBO flow. This means the cache is always partitioned by unique user assertions, and `Read()` doesn't need more information to locate data or disambiguate users. It also means `Read()` never gets account data anyway--the argument is always empty because the public `AcquireTokenOnBehalfOf` method doesn't take account data as input.

I imagine we'll restore this parameter when we want to partition the cache on home account IDs. Until then it just triggers linter warnings and looks like a bug 😊 