### PR TITLE
added password flow for cca

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -430,7 +430,7 @@ func (cca Client) RemoveAccount(account Account) error {
 }
 
 // AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
-// NOTE: this flow is NOT recommended.
+// Note: The ROPC flow is not recommended, because it will block conditional access and multi-factor authentication, as these protection measures involve user interaction through a browser. It can still be used in special cases, such as for testing purposes and in scenarios where the resource does not allow application tokens - client_credentials.
 func (cca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (AuthResult, error) {
 	return cca.base.AcquireTokenByUsernamePassword(ctx, scopes, username, password)
 }

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -428,3 +428,9 @@ func (cca Client) RemoveAccount(account Account) error {
 	cca.base.RemoveAccount(account)
 	return nil
 }
+
+// AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
+// NOTE: this flow is NOT recommended.
+func (cca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (AuthResult, error) {
+	return cca.base.AcquireTokenByUsernamePassword(ctx, scopes, username, password)
+}

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -418,22 +418,6 @@ func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion stri
 	return cca.base.AcquireTokenOnBehalfOf(ctx, params)
 }
 
-// AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
-// NOTE: this flow is NOT recommended.
-func (cca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (AuthResult, error) {
-	authParams := cca.base.AuthParams
-	authParams.Scopes = scopes
-	authParams.AuthorizationType = authority.ATUsernamePassword
-	authParams.Username = username
-	authParams.Password = password
-
-	token, err := cca.base.Token.UsernamePassword(ctx, authParams)
-	if err != nil {
-		return AuthResult{}, err
-	}
-	return cca.base.AuthResultFromToken(ctx, authParams, token, true)
-}
-
 // Account gets the account in the token cache with the specified homeAccountID.
 func (cca Client) Account(homeAccountID string) Account {
 	return cca.base.Account(homeAccountID)

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -418,6 +418,22 @@ func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion stri
 	return cca.base.AcquireTokenOnBehalfOf(ctx, params)
 }
 
+// AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
+// NOTE: this flow is NOT recommended.
+func (cca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (AuthResult, error) {
+	authParams := cca.base.AuthParams
+	authParams.Scopes = scopes
+	authParams.AuthorizationType = authority.ATUsernamePassword
+	authParams.Username = username
+	authParams.Password = password
+
+	token, err := cca.base.Token.UsernamePassword(ctx, authParams)
+	if err != nil {
+		return AuthResult{}, err
+	}
+	return cca.base.AuthResultFromToken(ctx, authParams, token, true)
+}
+
 // Account gets the account in the token cache with the specified homeAccountID.
 func (cca Client) Account(homeAccountID string) Account {
 	return cca.base.Account(homeAccountID)

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -331,6 +331,22 @@ func (b Client) AcquireTokenOnBehalfOf(ctx context.Context, onBehalfOfParams Acq
 	return token, err
 }
 
+// AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
+// NOTE: this flow is NOT recommended.
+func (b Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (AuthResult, error) {
+	authParams := b.AuthParams
+	authParams.Scopes = scopes
+	authParams.AuthorizationType = authority.ATUsernamePassword
+	authParams.Username = username
+	authParams.Password = password
+
+	token, err := b.Token.UsernamePassword(ctx, authParams)
+	if err != nil {
+		return AuthResult{}, err
+	}
+	return b.AuthResultFromToken(ctx, authParams, token, true)
+}
+
 func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.AuthParams, token accesstokens.TokenResponse, cacheWrite bool) (AuthResult, error) {
 	if !cacheWrite {
 		return NewAuthResult(token, shared.Account{})

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -332,7 +332,8 @@ func (b Client) AcquireTokenOnBehalfOf(ctx context.Context, onBehalfOfParams Acq
 }
 
 // AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
-// NOTE: this flow is NOT recommended.
+// The ROPC flow is not recommended, because it will block conditional access and multi-factor authentication, as these protection measures involve user interaction through a browser.
+// It can still be used in special cases, such as for testing purposes and in scenarios where the resource does not allow application tokens - client_credentials."
 func (b Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (AuthResult, error) {
 	authParams := b.AuthParams
 	authParams.Scopes = scopes

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -332,8 +332,7 @@ func (b Client) AcquireTokenOnBehalfOf(ctx context.Context, onBehalfOfParams Acq
 }
 
 // AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
-// The ROPC flow is not recommended, because it will block conditional access and multi-factor authentication, as these protection measures involve user interaction through a browser.
-// It can still be used in special cases, such as for testing purposes and in scenarios where the resource does not allow application tokens - client_credentials."
+// Note: The ROPC flow is not recommended, because it will block conditional access and multi-factor authentication, as these protection measures involve user interaction through a browser. It can still be used in special cases, such as for testing purposes and in scenarios where the resource does not allow application tokens - client_credentials."
 func (b Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (AuthResult, error) {
 	authParams := b.AuthParams
 	authParams.Scopes = scopes

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -162,22 +162,6 @@ func (pca Client) AcquireTokenSilent(ctx context.Context, scopes []string, optio
 	return pca.base.AcquireTokenSilent(ctx, silentParameters)
 }
 
-// AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
-// NOTE: this flow is NOT recommended.
-func (pca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (AuthResult, error) {
-	authParams := pca.base.AuthParams
-	authParams.Scopes = scopes
-	authParams.AuthorizationType = authority.ATUsernamePassword
-	authParams.Username = username
-	authParams.Password = password
-
-	token, err := pca.base.Token.UsernamePassword(ctx, authParams)
-	if err != nil {
-		return AuthResult{}, err
-	}
-	return pca.base.AuthResultFromToken(ctx, authParams, token, true)
-}
-
 type DeviceCodeResult = accesstokens.DeviceCodeResult
 
 // DeviceCode provides the results of the device code flows first stage (containing the code)

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -162,6 +162,12 @@ func (pca Client) AcquireTokenSilent(ctx context.Context, scopes []string, optio
 	return pca.base.AcquireTokenSilent(ctx, silentParameters)
 }
 
+// AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
+// NOTE: this flow is NOT recommended.
+func (pca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username string, password string) (AuthResult, error) {
+	return pca.base.AcquireTokenByUsernamePassword(ctx, scopes, username, password)
+}
+
 type DeviceCodeResult = accesstokens.DeviceCodeResult
 
 // DeviceCode provides the results of the device code flows first stage (containing the code)


### PR DESCRIPTION
The password flow is useful especially for Accessing service account emails without using Applciation permissions.

It is missing from golang MSAL Confidential client, so i just copied it from the public one.