### PR TITLE
Enable using confidential.Client only for token caching

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -237,9 +237,9 @@ type TokenProviderParameters = exported.TokenProviderParameters
 // TokenProviderResult is the authentication result returned by custom token providers
 type TokenProviderResult = exported.TokenProviderResult
 
-// NewCredFromTokenProvider creates a Credential from a function that provides access tokens. This
-// is for advanced scenarios in applications that need custom authentication logic and want to use
-// MSAL only for token caching. The token provider function must be concurrency safe.
+// NewCredFromTokenProvider creates a Credential from a function that provides access tokens. The function
+// must be concurrency safe. This is intended only to allow the Azure SDK to cache MSI tokens. It isn't
+// useful to applications in general because the token provider must implement all authentication logic.
 func NewCredFromTokenProvider(provider func(context.Context, TokenProviderParameters) (TokenProviderResult, error)) Credential {
 	return Credential{tokenProvider: provider}
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -147,6 +147,15 @@ func WithCacheAccessor(ca cache.ExportReplace) Option {
 	}
 }
 
+// WithKnownAuthorityHosts specifies hosts Client shouldn't validate or request metadata for because they're known to the user
+func WithKnownAuthorityHosts(hosts []string) Option {
+	return func(c *Client) {
+		cp := make([]string, len(hosts))
+		copy(cp, hosts)
+		c.AuthParams.KnownAuthorityHosts = cp
+	}
+}
+
 // WithX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication.
 func WithX5C(sendX5C bool) Option {
 	return func(c *Client) {

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -89,7 +89,7 @@ func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams,
 	clientID := authParameters.ClientID
 	scopes := authParameters.Scopes
 
-	// fetch metadata iff the authority isn't explicitly trusted
+	// fetch metadata if and only if the authority isn't explicitly trusted
 	aliases := authParameters.KnownAuthorityHosts
 	if len(aliases) == 0 {
 		metadata, err := m.getMetadataEntry(ctx, authParameters.AuthorityInfo)

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -89,12 +89,17 @@ func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams,
 	clientID := authParameters.ClientID
 	scopes := authParameters.Scopes
 
-	metadata, err := m.getMetadataEntry(ctx, authParameters.AuthorityInfo)
-	if err != nil {
-		return TokenResponse{}, err
+	// fetch metadata iff the authority isn't explicitly trusted
+	aliases := authParameters.KnownAuthorityHosts
+	if len(aliases) == 0 {
+		metadata, err := m.getMetadataEntry(ctx, authParameters.AuthorityInfo)
+		if err != nil {
+			return TokenResponse{}, err
+		}
+		aliases = metadata.Aliases
 	}
 
-	accessToken := m.readAccessToken(homeAccountID, metadata.Aliases, realm, clientID, scopes)
+	accessToken := m.readAccessToken(homeAccountID, aliases, realm, clientID, scopes)
 
 	if account.IsZero() {
 		return TokenResponse{
@@ -104,22 +109,22 @@ func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams,
 			Account:      shared.Account{},
 		}, nil
 	}
-	idToken, err := m.readIDToken(homeAccountID, metadata.Aliases, realm, clientID)
+	idToken, err := m.readIDToken(homeAccountID, aliases, realm, clientID)
 	if err != nil {
 		return TokenResponse{}, err
 	}
 
-	AppMetaData, err := m.readAppMetaData(metadata.Aliases, clientID)
+	AppMetaData, err := m.readAppMetaData(aliases, clientID)
 	if err != nil {
 		return TokenResponse{}, err
 	}
 	familyID := AppMetaData.FamilyID
 
-	refreshToken, err := m.readRefreshToken(homeAccountID, metadata.Aliases, familyID, clientID)
+	refreshToken, err := m.readRefreshToken(homeAccountID, aliases, familyID, clientID)
 	if err != nil {
 		return TokenResponse{}, err
 	}
-	account, err = m.readAccount(homeAccountID, metadata.Aliases, realm)
+	account, err = m.readAccount(homeAccountID, aliases, realm)
 	if err != nil {
 		return TokenResponse{}, err
 	}

--- a/apps/internal/exported/exported.go
+++ b/apps/internal/exported/exported.go
@@ -12,3 +12,23 @@ type AssertionRequestOptions struct {
 	// TokenEndpoint is the intended token endpoint. Used as the assertion's "aud" claim.
 	TokenEndpoint string
 }
+
+// TokenProviderParameters is the authentication parameters passed to token providers
+type TokenProviderParameters struct {
+	// Claims contains any additional claims requested for the token
+	Claims string
+	// CorrelationID of the authentication request
+	CorrelationID string
+	// Scopes requested for the token
+	Scopes []string
+	// TenantID identifies the tenant in which to authenticate
+	TenantID string
+}
+
+// TokenProviderResult is the authentication result returned by custom token providers
+type TokenProviderResult struct {
+	// AccessToken is the requested token
+	AccessToken string
+	// ExpiresInSeconds is the lifetime of the token in seconds
+	ExpiresInSeconds int
+}

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -97,6 +97,10 @@ type Credential struct {
 
 	// AssertionCallback is a function provided by the application, if we're authenticating by assertion.
 	AssertionCallback func(context.Context, exported.AssertionRequestOptions) (string, error)
+
+	// TokenProvider is a function provided by the application that implements custom authentication
+	// logic for a confidential client
+	TokenProvider func(context.Context, exported.TokenProviderParameters) (exported.TokenProviderResult, error)
 }
 
 // JWT gets the jwt assertion when the credential is not using a secret.

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -156,6 +156,9 @@ type AuthParams struct {
 	SendX5C bool
 	// UserAssertion is the access token used to acquire token on behalf of user
 	UserAssertion string
+
+	// KnownAuthorityHosts don't require metadata discovery because they're known to the user
+	KnownAuthorityHosts []string
 }
 
 // NewAuthParams creates an authorization parameters object.


### PR DESCRIPTION
Closes #302 by adding `confidential.NewCredFromTokenProvider()`, which enables creating a confidential client that invokes a callback to acquire access tokens. Applications can use this to handle all the details of authentication themselves while relying on the MSAL client for token caching. I mostly followed the design doc but want to call out one change: `TokenProviderResult` here doesn't have a `RefreshInSeconds` field. I omitted this because MSAL for Go currently uses a hardcoded refresh window and I don't want to imply to users that setting `RefreshInSeconds` would have an effect. Adding this field later won't break the API.

To prevent unnecessary authority validation and metadata discovery, I added an internal known authority API. This isn't part of the public API but is a start on #301.