### PR TITLE
MSAL Go Release 0.7.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,8 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.32
+          version: v1.48
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
-

--- a/apps/confidential/examples_test.go
+++ b/apps/confidential/examples_test.go
@@ -5,14 +5,14 @@ package confidential_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
 )
 
 func ExampleNewCredFromCert_pem() {
-	b, err := ioutil.ReadFile("key.pem")
+	b, err := os.ReadFile("key.pem")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func ExampleNewCredFromCert_pem() {
 }
 
 func ExampleNewCredFromCertChain() {
-	b, err := ioutil.ReadFile("key.pem")
+	b, err := os.ReadFile("key.pem")
 	if err != nil {
 		// TODO: handle error
 	}

--- a/apps/errors/errors.go
+++ b/apps/errors/errors.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -21,7 +20,7 @@ var prettyConf = &pretty.Config{
 	TrackCycles:       true,
 	Formatter: map[reflect.Type]interface{}{
 		reflect.TypeOf((*io.Reader)(nil)).Elem(): func(r io.Reader) string {
-			b, err := ioutil.ReadAll(r)
+			b, err := io.ReadAll(r)
 			if err != nil {
 				return "could not read io.Reader content"
 			}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -239,7 +239,7 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilentParameters) (AuthResult, error) {
 	authParams := b.AuthParams // This is a copy, as we dont' have a pointer receiver and authParams is not a pointer.
 	authParams.Scopes = silent.Scopes
-	authParams.HomeaccountID = silent.Account.HomeAccountID
+	authParams.HomeAccountID = silent.Account.HomeAccountID
 	authParams.AuthorizationType = silent.AuthorizationType
 	authParams.UserAssertion = silent.UserAssertion
 
@@ -385,7 +385,7 @@ func (b Client) AllAccounts() []shared.Account {
 func (b Client) Account(homeAccountID string) shared.Account {
 	authParams := b.AuthParams // This is a copy, as we dont' have a pointer receiver and .AuthParams is not a pointer.
 	authParams.AuthorizationType = authority.AccountByID
-	authParams.HomeaccountID = homeAccountID
+	authParams.HomeAccountID = homeAccountID
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
 		b.cacheAccessor.Replace(s, suggestedCacheKey)

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -147,6 +147,15 @@ func WithCacheAccessor(ca cache.ExportReplace) Option {
 	}
 }
 
+// WithKnownAuthorityHosts specifies hosts Client shouldn't validate or request metadata for because they're known to the user
+func WithKnownAuthorityHosts(hosts []string) Option {
+	return func(c *Client) {
+		cp := make([]string, len(hosts))
+		copy(cp, hosts)
+		c.AuthParams.KnownAuthorityHosts = cp
+	}
+}
+
 // WithX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication.
 func WithX5C(sendX5C bool) Option {
 	return func(c *Client) {

--- a/apps/internal/base/internal/storage/items_test.go
+++ b/apps/internal/base/internal/storage/items_test.go
@@ -5,7 +5,6 @@ package storage
 
 import (
 	stdJSON "encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -204,13 +203,7 @@ func TestAppMetaDataMarshal(t *testing.T) {
 }
 
 func TestContractUnmarshalJSON(t *testing.T) {
-	jsonFile, err := os.Open(testFile)
-	if err != nil {
-		panic(err)
-	}
-	defer jsonFile.Close()
-
-	testCache, err := ioutil.ReadAll(jsonFile)
+	testCache, err := os.ReadFile(testFile)
 	if err != nil {
 		panic(err)
 	}

--- a/apps/internal/base/internal/storage/partitioned_storage.go
+++ b/apps/internal/base/internal/storage/partitioned_storage.go
@@ -83,8 +83,8 @@ func (m *PartitionedManager) Read(ctx context.Context, authParameters authority.
 
 // Write writes a token response to the cache and returns the account information the token is stored with.
 func (m *PartitionedManager) Write(authParameters authority.AuthParams, tokenResponse accesstokens.TokenResponse) (shared.Account, error) {
-	authParameters.HomeaccountID = tokenResponse.ClientInfo.HomeAccountID()
-	homeAccountID := authParameters.HomeaccountID
+	authParameters.HomeAccountID = tokenResponse.ClientInfo.HomeAccountID()
+	homeAccountID := authParameters.HomeAccountID
 	environment := authParameters.AuthorityInfo.Host
 	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -84,7 +84,7 @@ func isMatchingScopes(scopesOne []string, scopesTwo string) bool {
 
 // Read reads a storage token from the cache if it exists.
 func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams, account shared.Account) (TokenResponse, error) {
-	homeAccountID := authParameters.HomeaccountID
+	homeAccountID := authParameters.HomeAccountID
 	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID
 	scopes := authParameters.Scopes
@@ -140,8 +140,8 @@ const scopeSeparator = " "
 
 // Write writes a token response to the cache and returns the account information the token is stored with.
 func (m *Manager) Write(authParameters authority.AuthParams, tokenResponse accesstokens.TokenResponse) (shared.Account, error) {
-	authParameters.HomeaccountID = tokenResponse.ClientInfo.HomeAccountID()
-	homeAccountID := authParameters.HomeaccountID
+	authParameters.HomeAccountID = tokenResponse.ClientInfo.HomeAccountID()
+	homeAccountID := authParameters.HomeAccountID
 	environment := authParameters.AuthorityInfo.Host
 	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -747,7 +747,7 @@ func TestRead(t *testing.T) {
 		Tenant: "realm",
 	}
 	authParameters := authority.AuthParams{
-		HomeaccountID: "hid",
+		HomeAccountID: "hid",
 		AuthorityInfo: authInfo,
 		ClientID:      "cid",
 		Scopes:        []string{"openid", "profile"},

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -6,7 +6,7 @@ package storage
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -635,7 +635,7 @@ func TestStorageManagerSerialize(t *testing.T) {
 
 func TestUnmarshal(t *testing.T) {
 	manager := newForTest(nil)
-	b, err := ioutil.ReadFile(testFile)
+	b, err := os.ReadFile(testFile)
 	if err != nil {
 		panic(err)
 	}

--- a/apps/internal/exported/exported.go
+++ b/apps/internal/exported/exported.go
@@ -12,3 +12,23 @@ type AssertionRequestOptions struct {
 	// TokenEndpoint is the intended token endpoint. Used as the assertion's "aud" claim.
 	TokenEndpoint string
 }
+
+// TokenProviderParameters is the authentication parameters passed to token providers
+type TokenProviderParameters struct {
+	// Claims contains any additional claims requested for the token
+	Claims string
+	// CorrelationID of the authentication request
+	CorrelationID string
+	// Scopes requested for the token
+	Scopes []string
+	// TenantID identifies the tenant in which to authenticate
+	TenantID string
+}
+
+// TokenProviderResult is the authentication result returned by custom token providers
+type TokenProviderResult struct {
+	// AccessToken is the requested token
+	AccessToken string
+	// ExpiresInSeconds is the lifetime of the token in seconds
+	ExpiresInSeconds int
+}

--- a/apps/internal/json/json.go
+++ b/apps/internal/json/json.go
@@ -52,7 +52,7 @@ func Marshal(i interface{}) ([]byte, error) {
 	if v.Kind() != reflect.Ptr && v.CanAddr() {
 		v = v.Addr()
 	}
-	err := marshalStruct(reflect.ValueOf(i), &buff, enc)
+	err := marshalStruct(v, &buff, enc)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/internal/local/server.go
+++ b/apps/internal/local/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var okPage = []byte(`
@@ -84,7 +85,7 @@ func New(reqState string, port int) (*Server, error) {
 
 	serv := &Server{
 		Addr:     fmt.Sprintf("http://localhost:%s", portStr),
-		s:        &http.Server{Addr: "localhost:0"},
+		s:        &http.Server{Addr: "localhost:0", ReadHeaderTimeout: time.Second},
 		reqState: reqState,
 		resultCh: make(chan Result, 1),
 	}

--- a/apps/internal/local/server_test.go
+++ b/apps/internal/local/server_test.go
@@ -5,7 +5,7 @@ package local
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -112,7 +112,7 @@ func TestServer(t *testing.T) {
 			continue
 		}
 
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		if err != nil {
 			panic(err)
 		}

--- a/apps/internal/oauth/oauth.go
+++ b/apps/internal/oauth/oauth.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors"
@@ -233,7 +233,7 @@ func isWaitDeviceCodeErr(err error) bool {
 	}
 	var dCErr deviceCodeError
 	defer c.Resp.Body.Close()
-	body, err := ioutil.ReadAll(c.Resp.Body)
+	body, err := io.ReadAll(c.Resp.Body)
 	if err != nil {
 		return false
 	}

--- a/apps/internal/oauth/oauth_test.go
+++ b/apps/internal/oauth/oauth_test.go
@@ -13,7 +13,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -292,19 +292,19 @@ func TestDeviceCode(t *testing.T) {
 						errors.CallErr{
 							Resp: &http.Response{
 								StatusCode: 400,
-								Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"error": "authorization_pending"}`))),
+								Body:       io.NopCloser(bytes.NewReader([]byte(`{"error": "authorization_pending"}`))),
 							},
 						},
 						errors.CallErr{
 							Resp: &http.Response{
 								StatusCode: 400,
-								Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"error": "slow_down"}`))),
+								Body:       io.NopCloser(bytes.NewReader([]byte(`{"error": "slow_down"}`))),
 							},
 						},
 						errors.CallErr{
 							Resp: &http.Response{
 								StatusCode: 400,
-								Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"error": "bad_error"}`))),
+								Body:       io.NopCloser(bytes.NewReader([]byte(`{"error": "bad_error"}`))),
 							},
 						},
 						nil,
@@ -324,13 +324,13 @@ func TestDeviceCode(t *testing.T) {
 						errors.CallErr{
 							Resp: &http.Response{
 								StatusCode: 400,
-								Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"error": "authorization_pending"}`))),
+								Body:       io.NopCloser(bytes.NewReader([]byte(`{"error": "authorization_pending"}`))),
 							},
 						},
 						errors.CallErr{
 							Resp: &http.Response{
 								StatusCode: 400,
-								Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"error": "slow_down"}`))),
+								Body:       io.NopCloser(bytes.NewReader([]byte(`{"error": "slow_down"}`))),
 							},
 						},
 						nil,

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -97,6 +97,10 @@ type Credential struct {
 
 	// AssertionCallback is a function provided by the application, if we're authenticating by assertion.
 	AssertionCallback func(context.Context, exported.AssertionRequestOptions) (string, error)
+
+	// TokenProvider is a function provided by the application that implements custom authentication
+	// logic for a confidential client
+	TokenProvider func(context.Context, exported.TokenProviderParameters) (exported.TokenProviderResult, error)
 }
 
 // JWT gets the jwt assertion when the credential is not using a secret.

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -9,7 +9,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -383,7 +383,7 @@ func detectRegion(ctx context.Context) string {
 		}
 	}
 	defer resp.Body.Close()
-	response, err := ioutil.ReadAll(resp.Body)
+	response, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return ""
 	}

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -133,7 +133,7 @@ type AuthParams struct {
 	ClientID      string
 	// Redirecturi is used for auth flows that specify a redirect URI (e.g. local server for interactive auth flow).
 	Redirecturi   string
-	HomeaccountID string
+	HomeAccountID string
 	// Username is the user-name portion for username/password auth flow.
 	Username string
 	// Password is the password portion for username/password auth flow.
@@ -401,7 +401,7 @@ func (a *AuthParams) CacheKey(isAppCache bool) string {
 		return a.AppKey()
 	}
 	if a.AuthorizationType == ATRefreshToken || a.AuthorizationType == AccountByID {
-		return a.HomeaccountID
+		return a.HomeAccountID
 	}
 	return ""
 }

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -156,6 +156,9 @@ type AuthParams struct {
 	SendX5C bool
 	// UserAssertion is the access token used to acquire token on behalf of user
 	UserAssertion string
+
+	// KnownAuthorityHosts don't require metadata discovery because they're known to the user
+	KnownAuthorityHosts []string
 }
 
 // NewAuthParams creates an authorization parameters object.

--- a/apps/internal/oauth/ops/internal/comm/comm.go
+++ b/apps/internal/oauth/ops/internal/comm/comm.go
@@ -11,7 +11,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -89,7 +88,7 @@ func (c *Client) JSONCall(ctx context.Context, endpoint string, headers http.Hea
 		if err != nil {
 			return fmt.Errorf("bug: conn.Call(): could not marshal the body object: %w", err)
 		}
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+		req.Body = io.NopCloser(bytes.NewBuffer(data))
 		req.Method = http.MethodPost
 	}
 
@@ -163,7 +162,7 @@ func (c *Client) xmlCall(ctx context.Context, u *url.URL, headers http.Header, b
 
 	if len(body) > 0 {
 		req.Method = http.MethodPost
-		req.Body = ioutil.NopCloser(strings.NewReader(body))
+		req.Body = io.NopCloser(strings.NewReader(body))
 	}
 
 	data, err := c.do(ctx, req)
@@ -201,9 +200,9 @@ func (c *Client) URLFormCall(ctx context.Context, endpoint string, qv url.Values
 		URL:           u,
 		Header:        headers,
 		ContentLength: int64(len(enc)),
-		Body:          ioutil.NopCloser(strings.NewReader(enc)),
+		Body:          io.NopCloser(strings.NewReader(enc)),
 		GetBody: func() (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader(enc)), nil
+			return io.NopCloser(strings.NewReader(enc)), nil
 		},
 	}
 
@@ -248,7 +247,7 @@ func (c *Client) do(ctx context.Context, req *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read the body of an HTTP Response: %w", err)
 	}
-	reply.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+	reply.Body = io.NopCloser(bytes.NewBuffer(data))
 
 	// NOTE: This doesn't happen immediately after the call so that we can get an error message
 	// from the server and include it in our error.
@@ -297,7 +296,7 @@ func (c *Client) readBody(resp *http.Response) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("bug: comm.Client.JSONCall(): content was send with unsupported content-encoding %s", resp.Header.Get("Content-Encoding"))
 	}
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 var testID string

--- a/apps/internal/oauth/ops/internal/comm/comm_test.go
+++ b/apps/internal/oauth/ops/internal/comm/comm_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -46,7 +46,7 @@ func (rec *recorder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	rec.gotMethod = r.Method
 	rec.gotQV = r.URL.Query()
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -5,4 +5,4 @@
 package version
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "0.6.1"
+const Version = "0.7.0"

--- a/apps/tests/devapps/client_certificate_sample.go
+++ b/apps/tests/devapps/client_certificate_sample.go
@@ -6,8 +6,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
 )
@@ -15,7 +15,7 @@ import (
 func acquireTokenClientCertificate() {
 	config := CreateConfig("confidential_config.json")
 
-	pemData, err := ioutil.ReadFile(config.PemData)
+	pemData, err := os.ReadFile(config.PemData)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/apps/tests/devapps/confidential_auth_code_sample.go
+++ b/apps/tests/devapps/confidential_auth_code_sample.go
@@ -59,13 +59,7 @@ func getTokenConfidential(w http.ResponseWriter, r *http.Request) {
 // thumbprint directly.
 /*
 func acquireByAuthorizationCodeConfidential() {
-	file, err := os.Open(confidentialConfig.KeyFile)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer file.Close()
-
-	key, err := ioutil.ReadAll(file)
+	key, err := os.ReadFile(confidentialConfig.KeyFile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/apps/tests/devapps/sample_cache_accessor.go
+++ b/apps/tests/devapps/sample_cache_accessor.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -16,12 +15,7 @@ type TokenCache struct {
 }
 
 func (t *TokenCache) Replace(cache cache.Unmarshaler, key string) {
-	jsonFile, err := os.Open(t.file)
-	if err != nil {
-		log.Println(err)
-	}
-	defer jsonFile.Close()
-	data, err := ioutil.ReadAll(jsonFile)
+	data, err := os.ReadFile(t.file)
 	if err != nil {
 		log.Println(err)
 	}
@@ -36,7 +30,7 @@ func (t *TokenCache) Export(cache cache.Marshaler, key string) {
 	if err != nil {
 		log.Println(err)
 	}
-	err = ioutil.WriteFile(t.file, data, 0600)
+	err = os.WriteFile(t.file, data, 0600)
 	if err != nil {
 		log.Println(err)
 	}

--- a/apps/tests/devapps/sample_utils.go
+++ b/apps/tests/devapps/sample_utils.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 )
@@ -28,12 +27,7 @@ type Config struct {
 
 // CreateConfig creates the Config struct from a json file.
 func CreateConfig(fileName string) *Config {
-	jsonFile, err := os.Open(fileName)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer jsonFile.Close()
-	data, err := ioutil.ReadAll(jsonFile)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/apps/tests/integration/integration_test.go
+++ b/apps/tests/integration/integration_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -53,7 +53,7 @@ func httpRequest(ctx context.Context, url string, query url.Values, accessToken 
 		return nil, fmt.Errorf("http.Get(%s) failed: %w", req.URL.String(), err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("http.Get(%s): could not read body: %w", req.URL.String(), err)
 	}


### PR DESCRIPTION
* Enhancement: Enable using confidential.Client only for token caching (#302, #344)
* Enhancement: Upgrade linter (#340)