### PR TITLE
Add WithLoginHint option for interactive authentication

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -219,6 +219,9 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 	if authParams.CodeChallengeMethod != "" {
 		v.Add("code_challenge_method", authParams.CodeChallengeMethod)
 	}
+	if authParams.LoginHint != "" {
+		v.Add("login_hint", authParams.LoginHint)
+	}
 	if authParams.Prompt != "" {
 		v.Add("prompt", authParams.Prompt)
 	}
@@ -227,9 +230,6 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 	/*
 		if p.ResponseMode != "" {
 			urlParams.Add("response_mode", p.ResponseMode)
-		}
-		if p.LoginHint != "" {
-			urlParams.Add("login_hint", p.LoginHint)
 		}
 		if p.DomainHint != "" {
 			urlParams.Add("domain_hint", p.DomainHint)

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -157,9 +157,10 @@ type AuthParams struct {
 	SendX5C bool
 	// UserAssertion is the access token used to acquire token on behalf of user
 	UserAssertion string
-
 	// KnownAuthorityHosts don't require metadata discovery because they're known to the user
 	KnownAuthorityHosts []string
+	// LoginHint is a username with which to pre-populate account selection during interactive auth
+	LoginHint string
 }
 
 // NewAuthParams creates an authorization parameters object.

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -436,7 +436,7 @@ type InteractiveAuthOptions struct {
 	// All other URI components are ignored.
 	RedirectURI string
 
-	tenantID string
+	loginHint, tenantID string
 }
 
 // AcquireInteractiveOption is implemented by options for AcquireTokenInteractive
@@ -448,6 +448,29 @@ type AcquireInteractiveOption interface {
 type InteractiveAuthOption func(*InteractiveAuthOptions)
 
 func (InteractiveAuthOption) acquireInteractiveOption() {}
+
+// WithLoginHint pre-populates the login prompt with a username.
+func WithLoginHint(username string) interface {
+	AcquireInteractiveOption
+	options.CallOption
+} {
+	return struct {
+		AcquireInteractiveOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *InteractiveAuthOptions:
+					t.loginHint = username
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
 
 // WithRedirectURI uses the specified redirect URI for interactive auth.
 func WithRedirectURI(redirectURI string) interface {
@@ -476,6 +499,7 @@ func WithRedirectURI(redirectURI string) interface {
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#interactive-and-non-interactive-authentication
 //
 // Options:
+//   - [WithLoginHint]
 //   - [WithRedirectURI]
 //   - [WithTenantID]
 func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, opts ...AcquireInteractiveOption) (AuthResult, error) {
@@ -504,6 +528,7 @@ func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, 
 	authParams.AuthorizationType = authority.ATInteractive
 	authParams.CodeChallenge = challenge
 	authParams.CodeChallengeMethod = "S256"
+	authParams.LoginHint = o.loginHint
 	authParams.State = uuid.New().String()
 	authParams.Prompt = "select_account"
 	res, err := pca.browserLogin(ctx, redirectURL, authParams)

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -73,57 +73,6 @@ func TestAcquireTokenInteractive(t *testing.T) {
 	}
 }
 
-func TestAcquireTokenInteractiveWithLoginHint(t *testing.T) {
-	realBrowserOpenURL := browserOpenURL
-	defer func() { browserOpenURL = realBrowserOpenURL }()
-	upn := "user@localhost"
-	client, err := New("client-id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.base.Token.AccessTokens = &fake.AccessTokens{}
-	client.base.Token.Authority = &fake.Authority{}
-	client.base.Token.Resolver = &fake.ResolveEndpoints{}
-	for _, expectHint := range []bool{true, false} {
-		t.Run(fmt.Sprint(expectHint), func(t *testing.T) {
-			// replace the browser launching function with a fake that validates login_hint is set as expected
-			called := false
-			browserOpenURL = func(authURL string) error {
-				called = true
-				parsed, err := url.Parse(authURL)
-				if err != nil {
-					return err
-				}
-				query, err := url.ParseQuery(parsed.RawQuery)
-				if err != nil {
-					return err
-				}
-				v, ok := query["login_hint"]
-				if ok != expectHint || expectHint && (len(v) != 1 || v[0] != upn) {
-					err = fmt.Errorf(`unexpected login_hint "%v"`, v)
-				}
-				if err != nil {
-					t.Fatal(err)
-					return err
-				}
-				// this helper validates the other params and completes the redirect
-				return fakeBrowserOpenURL(authURL)
-			}
-			options := []AcquireInteractiveOption{}
-			if expectHint {
-				options = append(options, WithLoginHint(upn))
-			}
-			_, err = client.AcquireTokenInteractive(context.Background(), tokenScope, options...)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !called {
-				t.Fatal("browserOpenURL wasn't called")
-			}
-		})
-	}
-}
-
 func TestAcquireTokenSilentTenants(t *testing.T) {
 	tenants := []string{"a", "b"}
 	lmo := "login.microsoftonline.com"
@@ -282,5 +231,79 @@ func TestAcquireTokenWithTenantID(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestWithLoginHint(t *testing.T) {
+	realBrowserOpenURL := browserOpenURL
+	defer func() { browserOpenURL = realBrowserOpenURL }()
+	upn := "user@localhost"
+	client, err := New("client-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.base.Token.AccessTokens = &fake.AccessTokens{}
+	client.base.Token.Authority = &fake.Authority{}
+	client.base.Token.Resolver = &fake.ResolveEndpoints{}
+	for _, expectHint := range []bool{true, false} {
+		t.Run(fmt.Sprint(expectHint), func(t *testing.T) {
+			// replace the browser launching function with a fake that validates login_hint is set as expected
+			called := false
+			validate := func(v url.Values) error {
+				if !v.Has("login_hint") {
+					if !expectHint {
+						return nil
+					}
+					return errors.New("expected a login hint")
+				} else if !expectHint {
+					return errors.New("expected no login hint")
+				}
+				if actual := v["login_hint"]; len(actual) != 1 || actual[0] != upn {
+					err = fmt.Errorf(`unexpected login_hint "%v"`, actual)
+				}
+				return err
+			}
+			browserOpenURL = func(authURL string) error {
+				called = true
+				parsed, err := url.Parse(authURL)
+				if err != nil {
+					return err
+				}
+				query, err := url.ParseQuery(parsed.RawQuery)
+				if err != nil {
+					return err
+				}
+				if err = validate(query); err != nil {
+					t.Fatal(err)
+					return err
+				}
+				// this helper validates the other params and completes the redirect
+				return fakeBrowserOpenURL(authURL)
+			}
+			acquireOpts := []AcquireInteractiveOption{}
+			urlOpts := []CreateAuthCodeURLOption{}
+			if expectHint {
+				acquireOpts = append(acquireOpts, WithLoginHint(upn))
+				urlOpts = append(urlOpts, WithLoginHint(upn))
+			}
+			_, err = client.AcquireTokenInteractive(context.Background(), tokenScope, acquireOpts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !called {
+				t.Fatal("browserOpenURL wasn't called")
+			}
+			u, err := client.CreateAuthCodeURL(context.Background(), "id", "https://localhost", tokenScope, urlOpts...)
+			if err == nil {
+				var parsed *url.URL
+				parsed, err = url.Parse(u)
+				if err == nil {
+					err = validate(parsed.Query())
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #271 by adding an option to set `login_hint` for interactive auth and auth code URLs. Usage looks like this:
```go
token, err := client.AcquireTokenInteractive(context.Background(), scopes, public.WithLoginHint("upn")
```