### PR TITLE
Support client capabilities and claims

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -284,6 +284,8 @@ type Options struct {
 
 	// Instructs MSAL Go to use an Azure regional token service with sepcified AzureRegion.
 	AzureRegion string
+
+	capabilities []string
 }
 
 func (o Options) validate() error {
@@ -312,6 +314,15 @@ func WithAuthority(authority string) Option {
 func WithAccessor(accessor cache.ExportReplace) Option {
 	return func(o *Options) {
 		o.Accessor = accessor
+	}
+}
+
+// WithClientCapabilities allows configuring one or more client capabilities such as "CP1"
+func WithClientCapabilities(capabilities []string) Option {
+	return func(o *Options) {
+		// there's no danger of sharing the slice's underlying memory with the application because
+		// this slice is simply passed to base.WithClientCapabilities, which copies its data
+		o.capabilities = capabilities
 	}
 }
 
@@ -369,6 +380,7 @@ func New(clientID string, cred Credential, options ...Option) (Client, error) {
 
 	baseOpts := []base.Option{
 		base.WithCacheAccessor(opts.Accessor),
+		base.WithClientCapabilities(opts.capabilities),
 		base.WithRegionDetection(opts.AzureRegion),
 		base.WithX5C(opts.SendX5C),
 	}
@@ -398,7 +410,7 @@ func (cca Client) UserID() string {
 
 // authCodeURLOptions contains options for AuthCodeURL
 type authCodeURLOptions struct {
-	loginHint, tenantID string
+	claims, loginHint, tenantID string
 }
 
 // AuthCodeURLOption is implemented by options for AuthCodeURL
@@ -409,6 +421,7 @@ type AuthCodeURLOption interface {
 // AuthCodeURL creates a URL used to acquire an authorization code. Users need to call CreateAuthorizationCodeURLParameters and pass it in.
 //
 // Options:
+// - [WithClaims]
 // - [WithLoginHint]
 // - [WithTenantID]
 func (cca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...AuthCodeURLOption) (string, error) {
@@ -420,6 +433,7 @@ func (cca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string,
 	if err != nil {
 		return "", err
 	}
+	ap.Claims = o.claims
 	ap.LoginHint = o.loginHint
 	return cca.base.AuthCodeURL(ctx, clientID, redirectURI, scopes, ap)
 }
@@ -438,6 +452,47 @@ func WithLoginHint(username string) interface {
 				switch t := a.(type) {
 				case *authCodeURLOptions:
 					t.loginHint = username
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
+
+// WithClaims sets additional claims to request for the token, such as those required by conditional access policies.
+// Use this option when Azure AD returned a claims challenge for a prior request. The argument must be decoded.
+// This option is valid for any token acquisition method.
+func WithClaims(claims string) interface {
+	AcquireByAuthCodeOption
+	AcquireByCredentialOption
+	AcquireOnBehalfOfOption
+	AcquireSilentOption
+	AuthCodeURLOption
+	options.CallOption
+} {
+	return struct {
+		AcquireByAuthCodeOption
+		AcquireByCredentialOption
+		AcquireOnBehalfOfOption
+		AcquireSilentOption
+		AuthCodeURLOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *AcquireTokenByAuthCodeOptions:
+					t.claims = claims
+				case *acquireTokenByCredentialOptions:
+					t.claims = claims
+				case *acquireTokenOnBehalfOfOptions:
+					t.claims = claims
+				case *AcquireTokenSilentOptions:
+					t.claims = claims
+				case *authCodeURLOptions:
+					t.claims = claims
 				default:
 					return fmt.Errorf("unexpected options type %T", a)
 				}
@@ -493,7 +548,7 @@ type AcquireTokenSilentOptions struct {
 	// Account represents the account to use. To set, use the WithSilentAccount() option.
 	Account Account
 
-	tenantID string
+	claims, tenantID string
 }
 
 // AcquireSilentOption is implemented by options for AcquireTokenSilent
@@ -532,12 +587,17 @@ func WithSilentAccount(account Account) interface {
 // AcquireTokenSilent acquires a token from either the cache or using a refresh token.
 //
 // Options:
+//   - [WithClaims]
 //   - [WithSilentAccount]
 //   - [WithTenantID]
 func (cca Client) AcquireTokenSilent(ctx context.Context, scopes []string, opts ...AcquireSilentOption) (AuthResult, error) {
 	o := AcquireTokenSilentOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
 		return AuthResult{}, err
+	}
+
+	if o.claims != "" {
+		return AuthResult{}, errors.New("call another AcquireToken method to request a new token having these claims")
 	}
 
 	silentParameters := base.AcquireTokenSilentParameters{
@@ -556,7 +616,7 @@ func (cca Client) AcquireTokenSilent(ctx context.Context, scopes []string, opts 
 type AcquireTokenByAuthCodeOptions struct {
 	Challenge string
 
-	tenantID string
+	claims, tenantID string
 }
 
 // AcquireByAuthCodeOption is implemented by options for AcquireTokenByAuthCode
@@ -597,6 +657,7 @@ func WithChallenge(challenge string) interface {
 //
 // Options:
 //   - [WithChallenge]
+//   - [WithClaims]
 //   - [WithTenantID]
 func (cca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redirectURI string, scopes []string, opts ...AcquireByAuthCodeOption) (AuthResult, error) {
 	o := AcquireTokenByAuthCodeOptions{}
@@ -608,6 +669,7 @@ func (cca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redir
 		Scopes:      scopes,
 		Code:        code,
 		Challenge:   o.Challenge,
+		Claims:      o.claims,
 		AppType:     accesstokens.ATConfidential,
 		Credential:  cca.cred, // This setting differs from public.Client.AcquireTokenByAuthCode
 		RedirectURI: redirectURI,
@@ -619,7 +681,7 @@ func (cca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redir
 
 // acquireTokenByCredentialOptions contains optional configuration for AcquireTokenByCredential
 type acquireTokenByCredentialOptions struct {
-	tenantID string
+	claims, tenantID string
 }
 
 // AcquireByCredentialOption is implemented by options for AcquireTokenByCredential
@@ -630,6 +692,7 @@ type AcquireByCredentialOption interface {
 // AcquireTokenByCredential acquires a security token from the authority, using the client credentials grant.
 //
 // Options:
+//   - [WithClaims]
 //   - [WithTenantID]
 func (cca Client) AcquireTokenByCredential(ctx context.Context, scopes []string, opts ...AcquireByCredentialOption) (AuthResult, error) {
 	o := acquireTokenByCredentialOptions{}
@@ -643,6 +706,7 @@ func (cca Client) AcquireTokenByCredential(ctx context.Context, scopes []string,
 	}
 	authParams.Scopes = scopes
 	authParams.AuthorizationType = authority.ATClientCredentials
+	authParams.Claims = o.claims
 
 	token, err := cca.base.Token.Credential(ctx, authParams, cca.cred)
 	if err != nil {
@@ -653,7 +717,7 @@ func (cca Client) AcquireTokenByCredential(ctx context.Context, scopes []string,
 
 // acquireTokenOnBehalfOfOptions contains optional configuration for AcquireTokenOnBehalfOf
 type acquireTokenOnBehalfOfOptions struct {
-	tenantID string
+	claims, tenantID string
 }
 
 // AcquireOnBehalfOfOption is implemented by options for AcquireTokenOnBehalfOf
@@ -665,6 +729,7 @@ type AcquireOnBehalfOfOption interface {
 // Refer https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow.
 //
 // Options:
+//   - [WithClaims]
 //   - [WithTenantID]
 func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion string, scopes []string, opts ...AcquireOnBehalfOfOption) (AuthResult, error) {
 	o := acquireTokenOnBehalfOfOptions{}
@@ -674,6 +739,7 @@ func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion stri
 	params := base.AcquireTokenOnBehalfOfParameters{
 		Scopes:        scopes,
 		UserAssertion: userAssertion,
+		Claims:        o.claims,
 		Credential:    cca.cred,
 		TenantID:      o.tenantID,
 	}

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -420,10 +420,7 @@ type AuthCodeURLOption interface {
 
 // AuthCodeURL creates a URL used to acquire an authorization code. Users need to call CreateAuthorizationCodeURLParameters and pass it in.
 //
-// Options:
-// - [WithClaims]
-// - [WithLoginHint]
-// - [WithTenantID]
+// Options: [WithClaims], [WithLoginHint], [WithTenantID]
 func (cca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...AuthCodeURLOption) (string, error) {
 	o := authCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -586,10 +583,7 @@ func WithSilentAccount(account Account) interface {
 
 // AcquireTokenSilent acquires a token from either the cache or using a refresh token.
 //
-// Options:
-//   - [WithClaims]
-//   - [WithSilentAccount]
-//   - [WithTenantID]
+// Options: [WithClaims], [WithSilentAccount], [WithTenantID]
 func (cca Client) AcquireTokenSilent(ctx context.Context, scopes []string, opts ...AcquireSilentOption) (AuthResult, error) {
 	o := AcquireTokenSilentOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -655,10 +649,7 @@ func WithChallenge(challenge string) interface {
 // AcquireTokenByAuthCode is a request to acquire a security token from the authority, using an authorization code.
 // The specified redirect URI must be the same URI that was used when the authorization code was requested.
 //
-// Options:
-//   - [WithChallenge]
-//   - [WithClaims]
-//   - [WithTenantID]
+// Options: [WithChallenge], [WithClaims], [WithTenantID]
 func (cca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redirectURI string, scopes []string, opts ...AcquireByAuthCodeOption) (AuthResult, error) {
 	o := AcquireTokenByAuthCodeOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -691,9 +682,7 @@ type AcquireByCredentialOption interface {
 
 // AcquireTokenByCredential acquires a security token from the authority, using the client credentials grant.
 //
-// Options:
-//   - [WithClaims]
-//   - [WithTenantID]
+// Options: [WithClaims], [WithTenantID]
 func (cca Client) AcquireTokenByCredential(ctx context.Context, scopes []string, opts ...AcquireByCredentialOption) (AuthResult, error) {
 	o := acquireTokenByCredentialOptions{}
 	err := options.ApplyOptions(&o, opts)
@@ -728,9 +717,7 @@ type AcquireOnBehalfOfOption interface {
 // AcquireTokenOnBehalfOf acquires a security token for an app using middle tier apps access token.
 // Refer https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow.
 //
-// Options:
-//   - [WithClaims]
-//   - [WithTenantID]
+// Options: [WithClaims], [WithTenantID]
 func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion string, scopes []string, opts ...AcquireOnBehalfOfOption) (AuthResult, error) {
 	o := acquireTokenOnBehalfOfOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -27,6 +28,7 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/kylelemons/godebug/pretty"
 )
 
 // errorClient is an HTTP client for tests that should fail when confidential.Client sends a request
@@ -529,6 +531,161 @@ func TestNewCredFromTokenProviderError(t *testing.T) {
 	}
 }
 
+func TestWithClaims(t *testing.T) {
+	cred, err := NewCredFromSecret("secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	accessToken := "at"
+	lmo, tenant := "login.microsoftonline.com", "tenant"
+	authority := fmt.Sprintf("https://%s/%s", lmo, tenant)
+	for _, test := range []struct {
+		capabilities     []string
+		claims, expected string
+	}{
+		{},
+		{
+			capabilities: []string{"cp1"},
+			expected:     `{"access_token":{"xms_cc":{"values":["cp1"]}}}`,
+		},
+		{
+			claims:   `{"id_token":{"auth_time":{"essential":true}}}`,
+			expected: `{"id_token":{"auth_time":{"essential":true}}}`,
+		},
+		{
+			capabilities: []string{"cp1", "cp2"},
+			claims:       `{"access_token":{"nbf":{"essential":true, "value":"42"}}}`,
+			expected:     `{"access_token":{"nbf":{"essential":true, "value":"42"}, "xms_cc":{"values":["cp1","cp2"]}}}`,
+		},
+	} {
+		var expected map[string]any
+		if err := json.Unmarshal([]byte(test.expected), &expected); err != nil && test.expected != "" {
+			t.Fatal("test bug: the expected result must be JSON or an empty string")
+		}
+		validate := func(t *testing.T, v url.Values) {
+			if test.expected == "" {
+				if v.Has("claims") {
+					t.Fatal("claims shouldn't be set")
+				}
+				return
+			}
+			claims, ok := v["claims"]
+			if !ok {
+				t.Fatal("claims should be set")
+			}
+			if len(claims) != 1 {
+				t.Fatalf("expected 1 value for claims, got %d", len(claims))
+			}
+			var actual map[string]any
+			if err := json.Unmarshal([]byte(claims[0]), &actual); err != nil {
+				t.Fatal(err)
+			}
+			if diff := pretty.Compare(expected, actual); diff != "" {
+				t.Fatal(diff)
+			}
+		}
+		for _, method := range []string{"authcode", "authcodeURL", "credential", "obo"} {
+			t.Run(method, func(t *testing.T) {
+				mockClient := mock.Client{}
+				clientInfo, idToken, refreshToken := "", "", ""
+				if method == "obo" {
+					clientInfo = base64.RawStdEncoding.EncodeToString([]byte(`{"uid":"uid","utid":"utid"}`))
+					idToken = mock.GetIDToken(tenant, authority)
+					refreshToken = "rt"
+					// TODO: OBO does instance discovery twice before first token request https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/351
+					mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, tenant)))
+				}
+				mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, tenant)))
+				mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+				mockClient.AppendResponse(
+					mock.WithBody(mock.GetAccessTokenBody(accessToken, idToken, refreshToken, clientInfo, 3600)),
+					mock.WithCallback(func(r *http.Request) {
+						if err := r.ParseForm(); err != nil {
+							t.Fatal(err)
+						}
+						validate(t, r.Form)
+					}),
+				)
+				client, err := New("client-id", cred, WithAuthority(authority), WithClientCapabilities(test.capabilities), WithHTTPClient(&mockClient))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err = client.AcquireTokenSilent(context.Background(), tokenScope); err == nil {
+					t.Fatal("silent authentication should fail because the cache is empty")
+				}
+				ctx := context.Background()
+				var ar AuthResult
+				switch method {
+				case "authcode":
+					ar, err = client.AcquireTokenByAuthCode(ctx, "code", "https://localhost", tokenScope, WithClaims(test.claims))
+				case "authcodeURL":
+					u := ""
+					if u, err = client.AuthCodeURL(ctx, "client-id", "https://localhost", tokenScope, WithClaims(test.claims)); err == nil {
+						var parsed *url.URL
+						if parsed, err = url.Parse(u); err == nil {
+							validate(t, parsed.Query())
+							return // didn't acquire a token, no need for further validation
+						}
+					}
+				case "credential":
+					ar, err = client.AcquireTokenByCredential(ctx, tokenScope, WithClaims(test.claims))
+				case "obo":
+					ar, err = client.AcquireTokenOnBehalfOf(ctx, "assertion", tokenScope, WithClaims(test.claims))
+				default:
+					t.Fatalf("test bug: no test for " + method)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if ar.AccessToken != accessToken {
+					t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
+				}
+				// silent auth should now succeed, provided no claims are requested, because the client has cached an access token
+				if method == "obo" {
+					ar, err = client.AcquireTokenOnBehalfOf(ctx, "assertion", tokenScope)
+				} else {
+					ar, err = client.AcquireTokenSilent(ctx, tokenScope)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if ar.AccessToken != accessToken {
+					t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
+				}
+				if test.claims != "" {
+					if _, err = client.AcquireTokenSilent(ctx, tokenScope, WithClaims(test.claims)); err == nil {
+						t.Fatal("AcquireTokenSilent should fail when given claims")
+					}
+					if method == "obo" {
+						// client has cached access and refresh tokens. When given claims, it should redeem a refresh token for a new access token.
+						newToken := "new-access-token"
+						mockClient.AppendResponse(
+							mock.WithBody(mock.GetAccessTokenBody(newToken, idToken, "", clientInfo, 3600)),
+							mock.WithCallback(func(r *http.Request) {
+								if err := r.ParseForm(); err != nil {
+									t.Fatal(err)
+								}
+								// all token requests should include any specified claims
+								validate(t, r.Form)
+								if actual := r.Form.Get("refresh_token"); actual != refreshToken {
+									t.Fatalf(`unexpected refresh token "%s"`, actual)
+								}
+							}),
+						)
+						ar, err = client.AcquireTokenOnBehalfOf(ctx, "assertion", tokenScope, WithClaims(test.claims))
+						if err != nil {
+							t.Fatal(err)
+						}
+						if ar.AccessToken != newToken {
+							t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestWithTenantID(t *testing.T) {
 	accessToken := "*"
 	uuid1 := "00000000-0000-0000-0000-000000000000"
@@ -585,7 +742,7 @@ func TestWithTenantID(t *testing.T) {
 				case "obo":
 					ar, err = client.AcquireTokenOnBehalfOf(ctx, "assertion", tokenScope, WithTenantID(test.tenant))
 				default:
-					t.Fatalf("no test for " + method)
+					t.Fatalf("test bug: no test for " + method)
 				}
 				if err != nil {
 					if test.expectError {

--- a/apps/internal/oauth/oauth.go
+++ b/apps/internal/oauth/oauth.go
@@ -100,8 +100,10 @@ func (t *Client) Credential(ctx context.Context, authParams authority.AuthParams
 		scopes := make([]string, len(authParams.Scopes))
 		copy(scopes, authParams.Scopes)
 		params := exported.TokenProviderParameters{
+			Claims:        authParams.Claims,
 			CorrelationID: uuid.New().String(),
 			Scopes:        scopes,
+			TenantID:      authParams.AuthorityInfo.Tenant,
 		}
 		tr, err := cred.TokenProvider(ctx, params)
 		if err != nil {

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -157,6 +157,9 @@ type Client struct {
 // FromUsernamePassword uses a username and password to get an access token.
 func (c Client) FromUsernamePassword(ctx context.Context, authParameters authority.AuthParams) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.Password)
 	qv.Set(username, authParameters.Username)
 	qv.Set(password, authParameters.Password)
@@ -219,6 +222,9 @@ func (c Client) FromAuthCode(ctx context.Context, req AuthCodeRequest) (TokenRes
 	qv.Set(clientID, req.AuthParams.ClientID)
 	qv.Set(clientInfo, clientInfoVal)
 	addScopeQueryParam(qv, req.AuthParams)
+	if err := addClaims(qv, req.AuthParams); err != nil {
+		return TokenResponse{}, err
+	}
 
 	return c.doTokenResp(ctx, req.AuthParams, qv)
 }
@@ -233,6 +239,9 @@ func (c Client) FromRefreshToken(ctx context.Context, appType AppType, authParam
 			return TokenResponse{}, err
 		}
 	}
+	if err := addClaims(qv, authParams); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.RefreshToken)
 	qv.Set(clientID, authParams.ClientID)
 	qv.Set(clientInfo, clientInfoVal)
@@ -245,6 +254,9 @@ func (c Client) FromRefreshToken(ctx context.Context, appType AppType, authParam
 // FromClientSecret uses a client's secret (aka password) to get a new token.
 func (c Client) FromClientSecret(ctx context.Context, authParameters authority.AuthParams, clientSecret string) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.ClientCredential)
 	qv.Set("client_secret", clientSecret)
 	qv.Set(clientID, authParameters.ClientID)
@@ -259,6 +271,9 @@ func (c Client) FromClientSecret(ctx context.Context, authParameters authority.A
 
 func (c Client) FromAssertion(ctx context.Context, authParameters authority.AuthParams, assertion string) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.ClientCredential)
 	qv.Set("client_assertion_type", grant.ClientAssertion)
 	qv.Set("client_assertion", assertion)
@@ -275,6 +290,9 @@ func (c Client) FromAssertion(ctx context.Context, authParameters authority.Auth
 
 func (c Client) FromUserAssertionClientSecret(ctx context.Context, authParameters authority.AuthParams, userAssertion string, clientSecret string) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.JWT)
 	qv.Set(clientID, authParameters.ClientID)
 	qv.Set("client_secret", clientSecret)
@@ -288,6 +306,9 @@ func (c Client) FromUserAssertionClientSecret(ctx context.Context, authParameter
 
 func (c Client) FromUserAssertionClientCertificate(ctx context.Context, authParameters authority.AuthParams, userAssertion string, assertion string) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.JWT)
 	qv.Set("client_assertion_type", grant.ClientAssertion)
 	qv.Set("client_assertion", assertion)
@@ -302,6 +323,9 @@ func (c Client) FromUserAssertionClientCertificate(ctx context.Context, authPara
 
 func (c Client) DeviceCodeResult(ctx context.Context, authParameters authority.AuthParams) (DeviceCodeResult, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return DeviceCodeResult{}, err
+	}
 	qv.Set(clientID, authParameters.ClientID)
 	addScopeQueryParam(qv, authParameters)
 
@@ -318,6 +342,9 @@ func (c Client) DeviceCodeResult(ctx context.Context, authParameters authority.A
 
 func (c Client) FromDeviceCodeResult(ctx context.Context, authParameters authority.AuthParams, deviceCodeResult DeviceCodeResult) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.DeviceCode)
 	qv.Set(deviceCode, deviceCodeResult.DeviceCode)
 	qv.Set(clientID, authParameters.ClientID)
@@ -329,6 +356,9 @@ func (c Client) FromDeviceCodeResult(ctx context.Context, authParameters authori
 
 func (c Client) FromSamlGrant(ctx context.Context, authParameters authority.AuthParams, samlGrant wstrust.SamlTokenInfo) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(username, authParameters.Username)
 	qv.Set(password, authParameters.Password)
 	qv.Set(clientID, authParameters.ClientID)
@@ -404,6 +434,15 @@ func AppendDefaultScopes(authParameters authority.AuthParams) []string {
 	}
 	scopes = append(scopes, defaultScopes...)
 	return scopes
+}
+
+// addClaims adds client capabilities and claims from AuthParams to the given url.Values
+func addClaims(v url.Values, ap authority.AuthParams) error {
+	claims, err := ap.MergeCapabilitiesAndClaims()
+	if err == nil && claims != "" {
+		v.Set("claims", claims)
+	}
+	return err
 }
 
 func addScopeQueryParam(queryParams url.Values, authParameters authority.AuthParams) {

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -157,6 +158,11 @@ type AuthParams struct {
 	SendX5C bool
 	// UserAssertion is the access token used to acquire token on behalf of user
 	UserAssertion string
+	// Capabilities the client will include with each token request, for example "CP1".
+	// Call [NewClientCapabilities] to construct a value for this field.
+	Capabilities ClientCapabilities
+	// Claims required for an access token to satisfy a conditional access policy
+	Claims string
 	// KnownAuthorityHosts don't require metadata discovery because they're known to the user
 	KnownAuthorityHosts []string
 	// LoginHint is a username with which to pre-populate account selection during interactive auth
@@ -202,6 +208,84 @@ func (p AuthParams) WithTenant(ID string) (AuthParams, error) {
 		p.AuthorityInfo = info
 	}
 	return p, err
+}
+
+// MergeCapabilitiesAndClaims combines client capabilities and challenge claims into a value suitable for an authentication request's "claims" parameter.
+func (p AuthParams) MergeCapabilitiesAndClaims() (string, error) {
+	claims := p.Claims
+	if len(p.Capabilities.asMap) > 0 {
+		if claims == "" {
+			// without claims the result is simply the capabilities
+			return p.Capabilities.asJSON, nil
+		}
+		// Otherwise, merge claims and capabilties into a single JSON object.
+		// We handle the claims challenge as a map because we don't know its structure.
+		var challenge map[string]any
+		if err := json.Unmarshal([]byte(claims), &challenge); err != nil {
+			return "", fmt.Errorf(`claims must be JSON. Are they base64 encoded? json.Unmarshal returned "%v"`, err)
+		}
+		if err := merge(p.Capabilities.asMap, challenge); err != nil {
+			return "", err
+		}
+		b, err := json.Marshal(challenge)
+		if err != nil {
+			return "", err
+		}
+		claims = string(b)
+	}
+	return claims, nil
+}
+
+// merges a into b without overwriting b's values. Returns an error when a and b share a key for which either has a non-object value.
+func merge(a, b map[string]any) error {
+	for k, av := range a {
+		if bv, ok := b[k]; !ok {
+			// b doesn't contain this key => simply set it to a's value
+			b[k] = av
+		} else {
+			// b does contain this key => recursively merge a[k] into b[k], provided both are maps. If a[k] or b[k] isn't
+			// a map, return an error because merging would overwrite some value in b. Errors shouldn't occur in practice
+			// because the challenge will be from AAD, which knows the capabilities format.
+			if A, ok := av.(map[string]any); ok {
+				if B, ok := bv.(map[string]any); ok {
+					return merge(A, B)
+				} else {
+					// b[k] isn't a map
+					return errors.New("challenge claims conflict with client capabilities")
+				}
+			} else {
+				// a[k] isn't a map
+				return errors.New("challenge claims conflict with client capabilities")
+			}
+		}
+	}
+	return nil
+}
+
+// ClientCapabilities stores capabilities in the formats used by AuthParams.MergeCapabilitiesAndClaims.
+// [NewClientCapabilities] precomputes these representations because capabilities are static for the
+// lifetime of a client and are included with every authentication request i.e., these computations
+// always have the same result and would otherwise have to be repeated for every request.
+type ClientCapabilities struct {
+	// asJSON is for the common case: adding the capabilities to an auth request with no challenge claims
+	asJSON string
+	// asMap is for merging the capabilities with challenge claims
+	asMap map[string]any
+}
+
+func NewClientCapabilities(capabilities []string) (ClientCapabilities, error) {
+	c := ClientCapabilities{}
+	var err error
+	if len(capabilities) > 0 {
+		cpbs := make([]string, len(capabilities))
+		for i := 0; i < len(cpbs); i++ {
+			cpbs[i] = fmt.Sprintf(`"%s"`, capabilities[i])
+		}
+		c.asJSON = fmt.Sprintf(`{"access_token":{"xms_cc":{"values":[%s]}}}`, strings.Join(cpbs, ","))
+		// note our JSON is valid but we can't stop users breaking it with garbage like "}"
+		err = json.Unmarshal([]byte(c.asJSON), &c.asMap)
+	}
+	return c, err
 }
 
 // Info consists of information about the authority.

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -60,6 +60,8 @@ type Options struct {
 	// The HTTP client used for making requests.
 	// It defaults to a shared http.Client.
 	HTTPClient ops.HTTPClient
+
+	capabilities []string
 }
 
 func (p *Options) validate() error {
@@ -90,6 +92,15 @@ func WithCache(accessor cache.ExportReplace) Option {
 	}
 }
 
+// WithClientCapabilities allows configuring one or more client capabilities such as "CP1"
+func WithClientCapabilities(capabilities []string) Option {
+	return func(o *Options) {
+		// there's no danger of sharing the slice's underlying memory with the application because
+		// this slice is simply passed to base.WithClientCapabilities, which copies its data
+		o.capabilities = capabilities
+	}
+}
+
 // WithHTTPClient allows for a custom HTTP client to be set.
 func WithHTTPClient(httpClient ops.HTTPClient) Option {
 	return func(o *Options) {
@@ -117,7 +128,7 @@ func New(clientID string, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithCacheAccessor(opts.Accessor))
+	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithCacheAccessor(opts.Accessor), base.WithClientCapabilities(opts.capabilities))
 	if err != nil {
 		return Client{}, err
 	}
@@ -126,7 +137,7 @@ func New(clientID string, options ...Option) (Client, error) {
 
 // createAuthCodeURLOptions contains options for CreateAuthCodeURL
 type createAuthCodeURLOptions struct {
-	loginHint, tenantID string
+	claims, loginHint, tenantID string
 }
 
 // CreateAuthCodeURLOption is implemented by options for CreateAuthCodeURL
@@ -137,6 +148,7 @@ type CreateAuthCodeURLOption interface {
 // CreateAuthCodeURL creates a URL used to acquire an authorization code.
 //
 // Options:
+// - [WithClaims]
 // - [WithLoginHint]
 // - [WithTenantID]
 func (pca Client) CreateAuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...CreateAuthCodeURLOption) (string, error) {
@@ -148,8 +160,54 @@ func (pca Client) CreateAuthCodeURL(ctx context.Context, clientID, redirectURI s
 	if err != nil {
 		return "", err
 	}
+	ap.Claims = o.claims
 	ap.LoginHint = o.loginHint
 	return pca.base.AuthCodeURL(ctx, clientID, redirectURI, scopes, ap)
+}
+
+// WithClaims sets additional claims to request for the token, such as those required by conditional access policies.
+// Use this option when Azure AD returned a claims challenge for a prior request. The argument must be decoded.
+// This option is valid for any token acquisition method.
+func WithClaims(claims string) interface {
+	AcquireByAuthCodeOption
+	AcquireByDeviceCodeOption
+	AcquireByUsernamePasswordOption
+	AcquireInteractiveOption
+	AcquireSilentOption
+	CreateAuthCodeURLOption
+	options.CallOption
+} {
+	return struct {
+		AcquireByAuthCodeOption
+		AcquireByDeviceCodeOption
+		AcquireByUsernamePasswordOption
+		AcquireInteractiveOption
+		AcquireSilentOption
+		CreateAuthCodeURLOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *AcquireTokenByAuthCodeOptions:
+					t.claims = claims
+				case *acquireTokenByDeviceCodeOptions:
+					t.claims = claims
+				case *acquireTokenByUsernamePasswordOptions:
+					t.claims = claims
+				case *AcquireTokenSilentOptions:
+					t.claims = claims
+				case *createAuthCodeURLOptions:
+					t.claims = claims
+				case *InteractiveAuthOptions:
+					t.claims = claims
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
 }
 
 // WithTenantID specifies a tenant for a single authentication. It may be different than the tenant set in [New] by [WithAuthority].
@@ -202,7 +260,7 @@ type AcquireTokenSilentOptions struct {
 	// Account represents the account to use. To set, use the WithSilentAccount() option.
 	Account Account
 
-	tenantID string
+	claims, tenantID string
 }
 
 // AcquireSilentOption is implemented by options for AcquireTokenSilent
@@ -241,6 +299,7 @@ func WithSilentAccount(account Account) interface {
 // AcquireTokenSilent acquires a token from either the cache or using a refresh token.
 //
 // Options:
+//   - [WithClaims]
 //   - [WithSilentAccount]
 //   - [WithTenantID]
 func (pca Client) AcquireTokenSilent(ctx context.Context, scopes []string, opts ...AcquireSilentOption) (AuthResult, error) {
@@ -252,6 +311,7 @@ func (pca Client) AcquireTokenSilent(ctx context.Context, scopes []string, opts 
 	silentParameters := base.AcquireTokenSilentParameters{
 		Scopes:      scopes,
 		Account:     o.Account,
+		Claims:      o.claims,
 		RequestType: accesstokens.ATPublic,
 		IsAppCache:  false,
 		TenantID:    o.tenantID,
@@ -262,7 +322,7 @@ func (pca Client) AcquireTokenSilent(ctx context.Context, scopes []string, opts 
 
 // acquireTokenByUsernamePasswordOptions contains optional configuration for AcquireTokenByUsernamePassword
 type acquireTokenByUsernamePasswordOptions struct {
-	tenantID string
+	claims, tenantID string
 }
 
 // AcquireByUsernamePasswordOption is implemented by options for AcquireTokenByUsernamePassword
@@ -274,6 +334,7 @@ type AcquireByUsernamePasswordOption interface {
 // NOTE: this flow is NOT recommended.
 //
 // Options:
+//   - [WithClaims]
 //   - [WithTenantID]
 func (pca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username, password string, opts ...AcquireByUsernamePasswordOption) (AuthResult, error) {
 	o := acquireTokenByUsernamePasswordOptions{}
@@ -286,6 +347,7 @@ func (pca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []s
 	}
 	authParams.Scopes = scopes
 	authParams.AuthorizationType = authority.ATUsernamePassword
+	authParams.Claims = o.claims
 	authParams.Username = username
 	authParams.Password = password
 
@@ -323,7 +385,7 @@ func (d DeviceCode) AuthenticationResult(ctx context.Context) (AuthResult, error
 
 // acquireTokenByDeviceCodeOptions contains optional configuration for AcquireTokenByDeviceCode
 type acquireTokenByDeviceCodeOptions struct {
-	tenantID string
+	claims, tenantID string
 }
 
 // AcquireByDeviceCodeOption is implemented by options for AcquireTokenByDeviceCode
@@ -335,6 +397,7 @@ type AcquireByDeviceCodeOption interface {
 // Users need to create an AcquireTokenDeviceCodeParameters instance and pass it in.
 //
 // Options:
+//   - [WithClaims]
 //   - [WithTenantID]
 func (pca Client) AcquireTokenByDeviceCode(ctx context.Context, scopes []string, opts ...AcquireByDeviceCodeOption) (DeviceCode, error) {
 	o := acquireTokenByDeviceCodeOptions{}
@@ -347,6 +410,7 @@ func (pca Client) AcquireTokenByDeviceCode(ctx context.Context, scopes []string,
 	}
 	authParams.Scopes = scopes
 	authParams.AuthorizationType = authority.ATDeviceCode
+	authParams.Claims = o.claims
 
 	dc, err := pca.base.Token.DeviceCode(ctx, authParams)
 	if err != nil {
@@ -360,7 +424,7 @@ func (pca Client) AcquireTokenByDeviceCode(ctx context.Context, scopes []string,
 type AcquireTokenByAuthCodeOptions struct {
 	Challenge string
 
-	tenantID string
+	claims, tenantID string
 }
 
 // AcquireByAuthCodeOption is implemented by options for AcquireTokenByAuthCode
@@ -401,6 +465,7 @@ func WithChallenge(challenge string) interface {
 //
 // Options:
 //   - [WithChallenge]
+//   - [WithClaims]
 //   - [WithTenantID]
 func (pca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redirectURI string, scopes []string, opts ...AcquireByAuthCodeOption) (AuthResult, error) {
 	o := AcquireTokenByAuthCodeOptions{}
@@ -412,6 +477,7 @@ func (pca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redir
 		Scopes:      scopes,
 		Code:        code,
 		Challenge:   o.Challenge,
+		Claims:      o.claims,
 		AppType:     accesstokens.ATPublic,
 		RedirectURI: redirectURI,
 		TenantID:    o.tenantID,
@@ -438,7 +504,7 @@ type InteractiveAuthOptions struct {
 	// All other URI components are ignored.
 	RedirectURI string
 
-	loginHint, tenantID string
+	claims, loginHint, tenantID string
 }
 
 // AcquireInteractiveOption is implemented by options for AcquireTokenInteractive
@@ -532,6 +598,7 @@ func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, 
 	}
 	authParams.Scopes = scopes
 	authParams.AuthorizationType = authority.ATInteractive
+	authParams.Claims = o.claims
 	authParams.CodeChallenge = challenge
 	authParams.CodeChallengeMethod = "S256"
 	authParams.LoginHint = o.loginHint

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -147,10 +147,7 @@ type CreateAuthCodeURLOption interface {
 
 // CreateAuthCodeURL creates a URL used to acquire an authorization code.
 //
-// Options:
-// - [WithClaims]
-// - [WithLoginHint]
-// - [WithTenantID]
+// Options: [WithClaims], [WithLoginHint], [WithTenantID]
 func (pca Client) CreateAuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...CreateAuthCodeURLOption) (string, error) {
 	o := createAuthCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -298,10 +295,7 @@ func WithSilentAccount(account Account) interface {
 
 // AcquireTokenSilent acquires a token from either the cache or using a refresh token.
 //
-// Options:
-//   - [WithClaims]
-//   - [WithSilentAccount]
-//   - [WithTenantID]
+// Options: [WithClaims], [WithSilentAccount], [WithTenantID]
 func (pca Client) AcquireTokenSilent(ctx context.Context, scopes []string, opts ...AcquireSilentOption) (AuthResult, error) {
 	o := AcquireTokenSilentOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -333,9 +327,7 @@ type AcquireByUsernamePasswordOption interface {
 // AcquireTokenByUsernamePassword acquires a security token from the authority, via Username/Password Authentication.
 // NOTE: this flow is NOT recommended.
 //
-// Options:
-//   - [WithClaims]
-//   - [WithTenantID]
+// Options: [WithClaims], [WithTenantID]
 func (pca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []string, username, password string, opts ...AcquireByUsernamePasswordOption) (AuthResult, error) {
 	o := acquireTokenByUsernamePasswordOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -396,9 +388,7 @@ type AcquireByDeviceCodeOption interface {
 // AcquireTokenByDeviceCode acquires a security token from the authority, by acquiring a device code and using that to acquire the token.
 // Users need to create an AcquireTokenDeviceCodeParameters instance and pass it in.
 //
-// Options:
-//   - [WithClaims]
-//   - [WithTenantID]
+// Options: [WithClaims], [WithTenantID]
 func (pca Client) AcquireTokenByDeviceCode(ctx context.Context, scopes []string, opts ...AcquireByDeviceCodeOption) (DeviceCode, error) {
 	o := acquireTokenByDeviceCodeOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -463,10 +453,7 @@ func WithChallenge(challenge string) interface {
 // AcquireTokenByAuthCode is a request to acquire a security token from the authority, using an authorization code.
 // The specified redirect URI must be the same URI that was used when the authorization code was requested.
 //
-// Options:
-//   - [WithChallenge]
-//   - [WithClaims]
-//   - [WithTenantID]
+// Options: [WithChallenge], [WithClaims], [WithTenantID]
 func (pca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redirectURI string, scopes []string, opts ...AcquireByAuthCodeOption) (AuthResult, error) {
 	o := AcquireTokenByAuthCodeOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -570,10 +557,7 @@ func WithRedirectURI(redirectURI string) interface {
 // AcquireTokenInteractive acquires a security token from the authority using the default web browser to select the account.
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#interactive-and-non-interactive-authentication
 //
-// Options:
-//   - [WithLoginHint]
-//   - [WithRedirectURI]
-//   - [WithTenantID]
+// Options: [WithLoginHint], [WithRedirectURI], [WithTenantID]
 func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, opts ...AcquireInteractiveOption) (AuthResult, error) {
 	o := InteractiveAuthOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {


### PR DESCRIPTION
Closes #263 by adding a `WithClientCapabilities` option for client constructors and a `WithClaims` option for token acquisition methods. Usage looks like this:
```go
client, err := New("id", cred, WithClientCapabilities([]string{"CP1"}))
token, err := client.AcquireTokenByCredential(ctx, scope, WithClaims("some JSON"))
```
(confidential and public clients have the same options)

I believe I've covered all the bases here (see the e2e tests) but please look closely; many code paths are impacted. Let me highlight a few subtleties:
- capabilities must interpolate into a valid JSON array but otherwise we have no opinion on their validity
- claims must be valid JSON. Callers are responsible for decoding challenges. This is documented and the error returned for invalid JSON calls this out.
- `AcquireTokenSilent(..., WithClaims("..."))` won't return a cached access token. This means it always fails for confidential clients. It can succeed for public clients that have a refresh token for the account. Similarly, `AcquireTokenOnBehalfOf` can succeed silently for confidential clients.