### PR TITLE
Adds support for custom success page

### DIFF
--- a/apps/internal/local/server.go
+++ b/apps/internal/local/server.go
@@ -59,7 +59,7 @@ type Server struct {
 }
 
 // New creates a local HTTP server and starts it.
-func New(reqState string, port int) (*Server, error) {
+func New(reqState string, port int, okHtml []byte) (*Server, error) {
 	var l net.Listener
 	var err error
 	var portStr string
@@ -81,6 +81,10 @@ func New(reqState string, port int) (*Server, error) {
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if okHtml != nil {
+		okPage = okHtml
 	}
 
 	serv := &Server{

--- a/apps/internal/local/server_test.go
+++ b/apps/internal/local/server_test.go
@@ -66,7 +66,7 @@ func TestServer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		serv, err := New(test.reqState, test.port)
+		serv, err := New(test.reqState, test.port, nil)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Allows the success page displayed in browser after a successful `AcquireTokenInteractive` flow to be customised by the application.

Closes #356 