### PR TITLE
Add Domain Hint

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -459,7 +459,7 @@ func WithLoginHint(username string) interface {
 	}
 }
 
-// WithDomainHint pre-populates the login prompt with the IdP domain.
+// WithDomainHint adds the IdP domain as domain_hint query parameter in the auth url.
 func WithDomainHint(domain string) interface {
 	AuthCodeURLOption
 	options.CallOption

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -420,7 +420,7 @@ type AuthCodeURLOption interface {
 
 // AuthCodeURL creates a URL used to acquire an authorization code. Users need to call CreateAuthorizationCodeURLParameters and pass it in.
 //
-// Options: [WithClaims], [WithLoginHint], [WithDomainHint], [WithTenantID]
+// Options: [WithClaims], [WithDomainHint], [WithLoginHint], [WithTenantID]
 func (cca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...AuthCodeURLOption) (string, error) {
 	o := authCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -410,7 +410,7 @@ func (cca Client) UserID() string {
 
 // authCodeURLOptions contains options for AuthCodeURL
 type authCodeURLOptions struct {
-	claims, loginHint, tenantID string
+	claims, loginHint, tenantID, domainHint string
 }
 
 // AuthCodeURLOption is implemented by options for AuthCodeURL
@@ -420,7 +420,7 @@ type AuthCodeURLOption interface {
 
 // AuthCodeURL creates a URL used to acquire an authorization code. Users need to call CreateAuthorizationCodeURLParameters and pass it in.
 //
-// Options: [WithClaims], [WithLoginHint], [WithTenantID]
+// Options: [WithClaims], [WithLoginHint], [WithDomainHint], [WithTenantID]
 func (cca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...AuthCodeURLOption) (string, error) {
 	o := authCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -432,6 +432,7 @@ func (cca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string,
 	}
 	ap.Claims = o.claims
 	ap.LoginHint = o.loginHint
+	ap.DomainHint = o.domainHint
 	return cca.base.AuthCodeURL(ctx, clientID, redirectURI, scopes, ap)
 }
 
@@ -449,6 +450,29 @@ func WithLoginHint(username string) interface {
 				switch t := a.(type) {
 				case *authCodeURLOptions:
 					t.loginHint = username
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
+
+// WithDomainHint pre-populates the login prompt with the IdP domain.
+func WithDomainHint(domain string) interface {
+	AuthCodeURLOption
+	options.CallOption
+} {
+	return struct {
+		AuthCodeURLOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *authCodeURLOptions:
+					t.domainHint = domain
 				default:
 					return fmt.Errorf("unexpected options type %T", a)
 				}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -256,14 +256,14 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 	if authParams.Prompt != "" {
 		v.Add("prompt", authParams.Prompt)
 	}
+	if authParams.DomainHint != "" {
+		v.Add("domain_hint", authParams.DomainHint)
+	}
 	// There were left over from an implementation that didn't use any of these.  We may
 	// need to add them later, but as of now aren't needed.
 	/*
 		if p.ResponseMode != "" {
 			urlParams.Add("response_mode", p.ResponseMode)
-		}
-		if p.DomainHint != "" {
-			urlParams.Add("domain_hint", p.DomainHint)
 		}
 	*/
 	baseURL.RawQuery = v.Encode()

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -167,6 +167,8 @@ type AuthParams struct {
 	KnownAuthorityHosts []string
 	// LoginHint is a username with which to pre-populate account selection during interactive auth
 	LoginHint string
+	// DomainHint is a directive that can be used to accelerate the user to their federated IdP sign-in page
+	DomainHint string
 }
 
 // NewAuthParams creates an authorization parameters object.

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -147,7 +147,7 @@ type CreateAuthCodeURLOption interface {
 
 // CreateAuthCodeURL creates a URL used to acquire an authorization code.
 //
-// Options: [WithClaims], [WithLoginHint], [WithDomainHint], [WithTenantID]
+// Options: [WithClaims], [WithDomainHint], [WithLoginHint], [WithTenantID]
 func (pca Client) CreateAuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...CreateAuthCodeURLOption) (string, error) {
 	o := createAuthCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -585,7 +585,7 @@ func WithRedirectURI(redirectURI string) interface {
 // AcquireTokenInteractive acquires a security token from the authority using the default web browser to select the account.
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#interactive-and-non-interactive-authentication
 //
-// Options: [WithLoginHint], [WithDomainHint], [WithRedirectURI], [WithTenantID]
+// Options: [WithDomainHint], [WithLoginHint], [WithRedirectURI], [WithTenantID]
 func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, opts ...AcquireInteractiveOption) (AuthResult, error) {
 	o := InteractiveAuthOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -137,7 +137,7 @@ func New(clientID string, options ...Option) (Client, error) {
 
 // createAuthCodeURLOptions contains options for CreateAuthCodeURL
 type createAuthCodeURLOptions struct {
-	claims, loginHint, tenantID string
+	claims, loginHint, tenantID, domainHint string
 }
 
 // CreateAuthCodeURLOption is implemented by options for CreateAuthCodeURL
@@ -147,7 +147,7 @@ type CreateAuthCodeURLOption interface {
 
 // CreateAuthCodeURL creates a URL used to acquire an authorization code.
 //
-// Options: [WithClaims], [WithLoginHint], [WithTenantID]
+// Options: [WithClaims], [WithLoginHint], [WithDomainHint], [WithTenantID]
 func (pca Client) CreateAuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...CreateAuthCodeURLOption) (string, error) {
 	o := createAuthCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -159,6 +159,7 @@ func (pca Client) CreateAuthCodeURL(ctx context.Context, clientID, redirectURI s
 	}
 	ap.Claims = o.claims
 	ap.LoginHint = o.loginHint
+	ap.DomainHint = o.domainHint
 	return pca.base.AuthCodeURL(ctx, clientID, redirectURI, scopes, ap)
 }
 
@@ -491,7 +492,7 @@ type InteractiveAuthOptions struct {
 	// All other URI components are ignored.
 	RedirectURI string
 
-	claims, loginHint, tenantID string
+	claims, loginHint, tenantID, domainHint string
 }
 
 // AcquireInteractiveOption is implemented by options for AcquireTokenInteractive
@@ -531,6 +532,33 @@ func WithLoginHint(username string) interface {
 	}
 }
 
+// WithDomainHint pre-populates the login prompt with the IdP domain.
+func WithDomainHint(domain string) interface {
+	AcquireInteractiveOption
+	CreateAuthCodeURLOption
+	options.CallOption
+} {
+	return struct {
+		AcquireInteractiveOption
+		CreateAuthCodeURLOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *createAuthCodeURLOptions:
+					t.domainHint = domain
+				case *InteractiveAuthOptions:
+					t.domainHint = domain
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
+
 // WithRedirectURI uses the specified redirect URI for interactive auth.
 func WithRedirectURI(redirectURI string) interface {
 	AcquireInteractiveOption
@@ -557,7 +585,7 @@ func WithRedirectURI(redirectURI string) interface {
 // AcquireTokenInteractive acquires a security token from the authority using the default web browser to select the account.
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#interactive-and-non-interactive-authentication
 //
-// Options: [WithLoginHint], [WithRedirectURI], [WithTenantID]
+// Options: [WithLoginHint], [WithDomainHint], [WithRedirectURI], [WithTenantID]
 func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, opts ...AcquireInteractiveOption) (AuthResult, error) {
 	o := InteractiveAuthOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -586,6 +614,7 @@ func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, 
 	authParams.CodeChallenge = challenge
 	authParams.CodeChallengeMethod = "S256"
 	authParams.LoginHint = o.loginHint
+	authParams.DomainHint = o.domainHint
 	authParams.State = uuid.New().String()
 	authParams.Prompt = "select_account"
 	res, err := pca.browserLogin(ctx, redirectURL, authParams)

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -532,7 +532,7 @@ func WithLoginHint(username string) interface {
 	}
 }
 
-// WithDomainHint pre-populates the login prompt with the IdP domain.
+// WithDomainHint adds the IdP domain as domain_hint query parameter in the auth url.
 func WithDomainHint(domain string) interface {
 	AcquireInteractiveOption
 	CreateAuthCodeURLOption


### PR DESCRIPTION
This PR Seeks to enable adding Domain Hint option to be used to accelerate the user to their federated IdP sign-in page. Or they can be used by a multi-tenant application to accelerate the user straight to the branded Azure AD sign-in page for their tenant.