### PR TITLE
AuthParams.WithTenant should copy all AuthorityInfo values

### DIFF
--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -205,6 +205,7 @@ func (p AuthParams) WithTenant(ID string) (AuthParams, error) {
 	authority := "https://" + path.Join(p.AuthorityInfo.Host, ID)
 	info, err := NewInfoFromAuthorityURI(authority, p.AuthorityInfo.ValidateAuthority)
 	if err == nil {
+		info.Region = p.AuthorityInfo.Region
 		p.AuthorityInfo = info
 	}
 	return p, err


### PR DESCRIPTION
This fixes an obscure bug that hasn't shipped yet: a client configured to use a regional endpoint sends requests for non-default tenants to the non-regional endpoint. That is to say, the per-request `WithTenantID()` option negates the client's region configuration for that request.

This happens because `AuthParams.WithTenant()` must update authority URLs when the user specifies a new tenant. That entails constructing a new `authority.Info`, whose constructor doesn't set its `Region` field. `AuthParams.WithTenant()` thus effectively resets `Region` to its zero value, which means "no region".

In this PR I've made the simplest fix and added a test that should prevent this problem from sneaking back in as `Info` expands. `Info` perhaps deserves another look from a design perspective to prevent this kind of thing but I chose not to get into that here because any improvement could require a large refactoring which may not be worth the effort--I don't have another example of the current design introducing risk.