### PR TITLE
Multitenant silent authentication fixes

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -399,6 +399,7 @@ func New(clientID string, cred Credential, options ...Option) (Client, error) {
 	if err != nil {
 		return Client{}, err
 	}
+	base.AuthParams.IsConfidentialClient = true
 
 	return Client{base: base, cred: internalCred}, nil
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -271,11 +271,8 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 }
 
 func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilentParameters) (AuthResult, error) {
-	tenant := silent.TenantID
-	if tenant == "" {
-		tenant = silent.Account.Realm
-	}
-	authParams, err := b.AuthParams.WithTenant(tenant)
+	// when silent.TenantID == "", this is a no-op and we use the client application's configured tenant
+	authParams, err := b.AuthParams.WithTenant(silent.TenantID)
 	if err != nil {
 		return AuthResult{}, err
 	}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -271,8 +271,27 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 }
 
 func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilentParameters) (AuthResult, error) {
-	// when silent.TenantID == "", this is a no-op and we use the client application's configured tenant
-	authParams, err := b.AuthParams.WithTenant(silent.TenantID)
+	tenant := silent.TenantID
+	if tenant == "" {
+		// the caller didn't specify a tenant, so we'll use the client's configured tenant or the given account's home tenant
+		switch tenant = b.AuthParams.AuthorityInfo.Tenant; tenant {
+		case "common", "organizations":
+			if _, homeTenant, found := strings.Cut(silent.Account.HomeAccountID, "."); found {
+				// note that both public and confidential clients allow specifying an account for silent auth
+				tenant = homeTenant
+			} else if !b.AuthParams.IsConfidentialClient {
+				// public client requires the caller to identify a specific user for silent authentication
+				return AuthResult{}, errors.New("use the WithSilentAccount option to specify an account")
+			}
+			// else we have a confidential client and no account specified. We can't return an error here because
+			// the caller may have configured the client with a custom token provider, in which case the client
+			// handles caching and the token provider is responsible for everything else, including determining
+			// the correct tenant.
+		default:
+			// use the client's configured tenant
+		}
+	}
+	authParams, err := b.AuthParams.WithTenant(tenant)
 	if err != nil {
 		return AuthResult{}, err
 	}


### PR DESCRIPTION
This fixes a couple bugs:
1. Silent auth defaults to the given account's tenant instead of the client's configured tenant.
1. Silent auth fails when the cache lacks an ID token from the requested tenant even though the cache contains a valid refresh token. My fix here is to have the cache return all the matching data it has instead of returning an error on the first miss. The caller is responsible for deciding whether the returned data is sufficient for its purpose.