### PR TITLE
MSAL Go 0.8.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ["1.18", "1.17"]
+        go: ["1.19", "1.18"]
 
     steps:
       - name: Set up Go 1.x

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.48
+          version: v1.49
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -286,6 +286,8 @@ type Options struct {
 	AzureRegion string
 
 	capabilities []string
+
+	disableInstanceDiscovery bool
 }
 
 func (o Options) validate() error {
@@ -340,6 +342,13 @@ func WithX5C() Option {
 	}
 }
 
+// WithInstanceDiscovery set to false to disable authority validation (to support private cloud scenarios)
+func WithInstanceDiscovery(enabled bool) Option {
+	return func(o *Options) {
+		o.disableInstanceDiscovery = !enabled
+	}
+}
+
 // WithAzureRegion sets the region(preferred) or Confidential.AutoDetectRegion() for auto detecting region.
 // Region names as per https://azure.microsoft.com/en-ca/global-infrastructure/geographies/.
 // See https://aka.ms/region-map for more details on region names.
@@ -383,17 +392,11 @@ func New(clientID string, cred Credential, options ...Option) (Client, error) {
 		base.WithClientCapabilities(opts.capabilities),
 		base.WithRegionDetection(opts.AzureRegion),
 		base.WithX5C(opts.SendX5C),
+		base.WithInstanceDiscovery(!opts.disableInstanceDiscovery),
 	}
 	if cred.tokenProvider != nil {
 		// The caller will handle all details of authentication, using Client only as a token cache.
-		// Declaring the authority host known prevents unnecessary metadata discovery requests. (The
-		// authority is irrelevant to Client and friends because the token provider is responsible
-		// for authentication.)
-		parsed, err := url.Parse(opts.Authority)
-		if err != nil {
-			return Client{}, errors.New("invalid authority")
-		}
-		baseOpts = append(baseOpts, base.WithKnownAuthorityHosts([]string{parsed.Hostname()}))
+		baseOpts = append(baseOpts, base.WithInstanceDiscovery(false))
 	}
 	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), baseOpts...)
 	if err != nil {

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -399,6 +399,7 @@ func New(clientID string, cred Credential, options ...Option) (Client, error) {
 	if err != nil {
 		return Client{}, err
 	}
+	base.AuthParams.IsConfidentialClient = true
 
 	return Client{base: base, cred: internalCred}, nil
 }

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -27,6 +28,7 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/kylelemons/godebug/pretty"
 )
 
 // errorClient is an HTTP client for tests that should fail when confidential.Client sends a request
@@ -529,6 +531,185 @@ func TestNewCredFromTokenProviderError(t *testing.T) {
 	}
 }
 
+func TestTokenProviderOptions(t *testing.T) {
+	accessToken, claims, tenant := "at", "claims", "tenant"
+	cred := NewCredFromTokenProvider(func(ctx context.Context, tpp TokenProviderParameters) (TokenProviderResult, error) {
+		if tpp.Claims != claims {
+			t.Fatalf(`unexpected claims "%s"`, tpp.Claims)
+		}
+		if tpp.TenantID != tenant {
+			t.Fatalf(`unexpected tenant "%s"`, tpp.TenantID)
+		}
+		return TokenProviderResult{AccessToken: accessToken, ExpiresInSeconds: 3600}, nil
+	})
+	client, err := New("id", cred, WithHTTPClient(&errorClient{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ar, err := client.AcquireTokenByCredential(context.Background(), tokenScope, WithClaims(claims), WithTenantID(tenant))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ar.AccessToken != accessToken {
+		t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
+	}
+}
+
+func TestWithClaims(t *testing.T) {
+	cred, err := NewCredFromSecret("secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	accessToken := "at"
+	lmo, tenant := "login.microsoftonline.com", "tenant"
+	authority := fmt.Sprintf("https://%s/%s", lmo, tenant)
+	for _, test := range []struct {
+		capabilities     []string
+		claims, expected string
+	}{
+		{},
+		{
+			capabilities: []string{"cp1"},
+			expected:     `{"access_token":{"xms_cc":{"values":["cp1"]}}}`,
+		},
+		{
+			claims:   `{"id_token":{"auth_time":{"essential":true}}}`,
+			expected: `{"id_token":{"auth_time":{"essential":true}}}`,
+		},
+		{
+			capabilities: []string{"cp1", "cp2"},
+			claims:       `{"access_token":{"nbf":{"essential":true, "value":"42"}}}`,
+			expected:     `{"access_token":{"nbf":{"essential":true, "value":"42"}, "xms_cc":{"values":["cp1","cp2"]}}}`,
+		},
+	} {
+		var expected map[string]any
+		if err := json.Unmarshal([]byte(test.expected), &expected); err != nil && test.expected != "" {
+			t.Fatal("test bug: the expected result must be JSON or an empty string")
+		}
+		validate := func(t *testing.T, v url.Values) {
+			if test.expected == "" {
+				if v.Has("claims") {
+					t.Fatal("claims shouldn't be set")
+				}
+				return
+			}
+			claims, ok := v["claims"]
+			if !ok {
+				t.Fatal("claims should be set")
+			}
+			if len(claims) != 1 {
+				t.Fatalf("expected 1 value for claims, got %d", len(claims))
+			}
+			var actual map[string]any
+			if err := json.Unmarshal([]byte(claims[0]), &actual); err != nil {
+				t.Fatal(err)
+			}
+			if diff := pretty.Compare(expected, actual); diff != "" {
+				t.Fatal(diff)
+			}
+		}
+		for _, method := range []string{"authcode", "authcodeURL", "credential", "obo"} {
+			t.Run(method, func(t *testing.T) {
+				mockClient := mock.Client{}
+				clientInfo, idToken, refreshToken := "", "", ""
+				if method == "obo" {
+					clientInfo = base64.RawStdEncoding.EncodeToString([]byte(`{"uid":"uid","utid":"utid"}`))
+					idToken = mock.GetIDToken(tenant, authority)
+					refreshToken = "rt"
+					// TODO: OBO does instance discovery twice before first token request https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/351
+					mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, tenant)))
+				}
+				mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, tenant)))
+				mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+				mockClient.AppendResponse(
+					mock.WithBody(mock.GetAccessTokenBody(accessToken, idToken, refreshToken, clientInfo, 3600)),
+					mock.WithCallback(func(r *http.Request) {
+						if err := r.ParseForm(); err != nil {
+							t.Fatal(err)
+						}
+						validate(t, r.Form)
+					}),
+				)
+				client, err := New("client-id", cred, WithAuthority(authority), WithClientCapabilities(test.capabilities), WithHTTPClient(&mockClient))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err = client.AcquireTokenSilent(context.Background(), tokenScope); err == nil {
+					t.Fatal("silent authentication should fail because the cache is empty")
+				}
+				ctx := context.Background()
+				var ar AuthResult
+				switch method {
+				case "authcode":
+					ar, err = client.AcquireTokenByAuthCode(ctx, "code", "https://localhost", tokenScope, WithClaims(test.claims))
+				case "authcodeURL":
+					u := ""
+					if u, err = client.AuthCodeURL(ctx, "client-id", "https://localhost", tokenScope, WithClaims(test.claims)); err == nil {
+						var parsed *url.URL
+						if parsed, err = url.Parse(u); err == nil {
+							validate(t, parsed.Query())
+							return // didn't acquire a token, no need for further validation
+						}
+					}
+				case "credential":
+					ar, err = client.AcquireTokenByCredential(ctx, tokenScope, WithClaims(test.claims))
+				case "obo":
+					ar, err = client.AcquireTokenOnBehalfOf(ctx, "assertion", tokenScope, WithClaims(test.claims))
+				default:
+					t.Fatalf("test bug: no test for " + method)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if ar.AccessToken != accessToken {
+					t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
+				}
+				// silent auth should now succeed, provided no claims are requested, because the client has cached an access token
+				if method == "obo" {
+					ar, err = client.AcquireTokenOnBehalfOf(ctx, "assertion", tokenScope)
+				} else {
+					ar, err = client.AcquireTokenSilent(ctx, tokenScope)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if ar.AccessToken != accessToken {
+					t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
+				}
+				if test.claims != "" {
+					if _, err = client.AcquireTokenSilent(ctx, tokenScope, WithClaims(test.claims)); err == nil {
+						t.Fatal("AcquireTokenSilent should fail when given claims")
+					}
+					if method == "obo" {
+						// client has cached access and refresh tokens. When given claims, it should redeem a refresh token for a new access token.
+						newToken := "new-access-token"
+						mockClient.AppendResponse(
+							mock.WithBody(mock.GetAccessTokenBody(newToken, idToken, "", clientInfo, 3600)),
+							mock.WithCallback(func(r *http.Request) {
+								if err := r.ParseForm(); err != nil {
+									t.Fatal(err)
+								}
+								// all token requests should include any specified claims
+								validate(t, r.Form)
+								if actual := r.Form.Get("refresh_token"); actual != refreshToken {
+									t.Fatalf(`unexpected refresh token "%s"`, actual)
+								}
+							}),
+						)
+						ar, err = client.AcquireTokenOnBehalfOf(ctx, "assertion", tokenScope, WithClaims(test.claims))
+						if err != nil {
+							t.Fatal(err)
+						}
+						if ar.AccessToken != newToken {
+							t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestWithTenantID(t *testing.T) {
 	accessToken := "*"
 	uuid1 := "00000000-0000-0000-0000-000000000000"
@@ -585,7 +766,7 @@ func TestWithTenantID(t *testing.T) {
 				case "obo":
 					ar, err = client.AcquireTokenOnBehalfOf(ctx, "assertion", tokenScope, WithTenantID(test.tenant))
 				default:
-					t.Fatalf("no test for " + method)
+					t.Fatalf("test bug: no test for " + method)
 				}
 				if err != nil {
 					if test.expectError {

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -219,6 +219,9 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 	if authParams.CodeChallengeMethod != "" {
 		v.Add("code_challenge_method", authParams.CodeChallengeMethod)
 	}
+	if authParams.LoginHint != "" {
+		v.Add("login_hint", authParams.LoginHint)
+	}
 	if authParams.Prompt != "" {
 		v.Add("prompt", authParams.Prompt)
 	}
@@ -227,9 +230,6 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 	/*
 		if p.ResponseMode != "" {
 			urlParams.Add("response_mode", p.ResponseMode)
-		}
-		if p.LoginHint != "" {
-			urlParams.Add("login_hint", p.LoginHint)
 		}
 		if p.DomainHint != "" {
 			urlParams.Add("domain_hint", p.DomainHint)

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -58,6 +58,7 @@ type AcquireTokenSilentParameters struct {
 	TenantID          string
 	UserAssertion     string
 	AuthorizationType authority.AuthorizeType
+	Claims            string
 }
 
 // AcquireTokenAuthCodeParameters contains the parameters required to acquire an access token using the auth code flow.
@@ -68,6 +69,7 @@ type AcquireTokenAuthCodeParameters struct {
 	Scopes      []string
 	Code        string
 	Challenge   string
+	Claims      string
 	RedirectURI string
 	AppType     accesstokens.AppType
 	Credential  *accesstokens.Credential
@@ -76,6 +78,7 @@ type AcquireTokenAuthCodeParameters struct {
 
 type AcquireTokenOnBehalfOfParameters struct {
 	Scopes        []string
+	Claims        string
 	Credential    *accesstokens.Credential
 	TenantID      string
 	UserAssertion string
@@ -139,36 +142,54 @@ type Client struct {
 }
 
 // Option is an optional argument to the New constructor.
-type Option func(c *Client)
+type Option func(c *Client) error
 
 // WithCacheAccessor allows you to set some type of cache for storing authentication tokens.
 func WithCacheAccessor(ca cache.ExportReplace) Option {
-	return func(c *Client) {
+	return func(c *Client) error {
 		if ca != nil {
 			c.cacheAccessor = ca
 		}
+		return nil
+	}
+}
+
+// WithClientCapabilities allows configuring one or more client capabilities such as "CP1"
+func WithClientCapabilities(capabilities []string) Option {
+	return func(c *Client) error {
+		var err error
+		if len(capabilities) > 0 {
+			cc, err := authority.NewClientCapabilities(capabilities)
+			if err == nil {
+				c.AuthParams.Capabilities = cc
+			}
+		}
+		return err
 	}
 }
 
 // WithKnownAuthorityHosts specifies hosts Client shouldn't validate or request metadata for because they're known to the user
 func WithKnownAuthorityHosts(hosts []string) Option {
-	return func(c *Client) {
+	return func(c *Client) error {
 		cp := make([]string, len(hosts))
 		copy(cp, hosts)
 		c.AuthParams.KnownAuthorityHosts = cp
+		return nil
 	}
 }
 
 // WithX5C specifies if x5c claim(public key of the certificate) should be sent to STS to enable Subject Name Issuer Authentication.
 func WithX5C(sendX5C bool) Option {
-	return func(c *Client) {
+	return func(c *Client) error {
 		c.AuthParams.SendX5C = sendX5C
+		return nil
 	}
 }
 
 func WithRegionDetection(region string) Option {
-	return func(c *Client) {
+	return func(c *Client) error {
 		c.AuthParams.AuthorityInfo.Region = region
+		return nil
 	}
 }
 
@@ -187,9 +208,11 @@ func New(clientID string, authorityURI string, token *oauth.Client, options ...O
 		pmanager:      storage.NewPartitionedManager(token),
 	}
 	for _, o := range options {
-		o(&client)
+		if err = o(&client); err != nil {
+			break
+		}
 	}
-	return client, nil
+	return client, err
 
 }
 
@@ -205,6 +228,11 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 		return "", err
 	}
 
+	claims, err := authParams.MergeCapabilitiesAndClaims()
+	if err != nil {
+		return "", err
+	}
+
 	v := url.Values{}
 	v.Add("client_id", clientID)
 	v.Add("response_type", "code")
@@ -212,6 +240,9 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 	v.Add("scope", strings.Join(scopes, scopeSeparator))
 	if authParams.State != "" {
 		v.Add("state", authParams.State)
+	}
+	if claims != "" {
+		v.Add("claims", claims)
 	}
 	if authParams.CodeChallenge != "" {
 		v.Add("code_challenge", authParams.CodeChallenge)
@@ -251,6 +282,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 	authParams.Scopes = silent.Scopes
 	authParams.HomeAccountID = silent.Account.HomeAccountID
 	authParams.AuthorizationType = silent.AuthorizationType
+	authParams.Claims = silent.Claims
 	authParams.UserAssertion = silent.UserAssertion
 
 	var storageTokenResponse storage.TokenResponse
@@ -277,25 +309,29 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 		}
 	}
 
-	result, err := AuthResultFromStorage(storageTokenResponse)
-	if err != nil {
-		if reflect.ValueOf(storageTokenResponse.RefreshToken).IsZero() {
-			return AuthResult{}, errors.New("no token found")
+	// ignore cached access tokens when given claims
+	if silent.Claims == "" {
+		result, err := AuthResultFromStorage(storageTokenResponse)
+		if err == nil {
+			return result, nil
 		}
-
-		var cc *accesstokens.Credential
-		if silent.RequestType == accesstokens.ATConfidential {
-			cc = silent.Credential
-		}
-
-		token, err := b.Token.Refresh(ctx, silent.RequestType, authParams, cc, storageTokenResponse.RefreshToken)
-		if err != nil {
-			return AuthResult{}, err
-		}
-
-		return b.AuthResultFromToken(ctx, authParams, token, true)
 	}
-	return result, nil
+
+	// redeem a cached refresh token, if available
+	if reflect.ValueOf(storageTokenResponse.RefreshToken).IsZero() {
+		return AuthResult{}, errors.New("no token found")
+	}
+	var cc *accesstokens.Credential
+	if silent.RequestType == accesstokens.ATConfidential {
+		cc = silent.Credential
+	}
+
+	token, err := b.Token.Refresh(ctx, silent.RequestType, authParams, cc, storageTokenResponse.RefreshToken)
+	if err != nil {
+		return AuthResult{}, err
+	}
+
+	return b.AuthResultFromToken(ctx, authParams, token, true)
 }
 
 func (b Client) AcquireTokenByAuthCode(ctx context.Context, authCodeParams AcquireTokenAuthCodeParameters) (AuthResult, error) {
@@ -303,6 +339,7 @@ func (b Client) AcquireTokenByAuthCode(ctx context.Context, authCodeParams Acqui
 	if err != nil {
 		return AuthResult{}, err
 	}
+	authParams.Claims = authCodeParams.Claims
 	authParams.Scopes = authCodeParams.Scopes
 	authParams.Redirecturi = authCodeParams.RedirectURI
 	authParams.AuthorizationType = authority.ATAuthCode
@@ -328,14 +365,7 @@ func (b Client) AcquireTokenByAuthCode(ctx context.Context, authCodeParams Acqui
 
 // AcquireTokenOnBehalfOf acquires a security token for an app using middle tier apps access token.
 func (b Client) AcquireTokenOnBehalfOf(ctx context.Context, onBehalfOfParams AcquireTokenOnBehalfOfParameters) (AuthResult, error) {
-	authParams, err := b.AuthParams.WithTenant(onBehalfOfParams.TenantID)
-	if err != nil {
-		return AuthResult{}, err
-	}
-	authParams.Scopes = onBehalfOfParams.Scopes
-	authParams.AuthorizationType = authority.ATOnBehalfOf
-	authParams.UserAssertion = onBehalfOfParams.UserAssertion
-
+	var ar AuthResult
 	silentParameters := AcquireTokenSilentParameters{
 		Scopes:            onBehalfOfParams.Scopes,
 		RequestType:       accesstokens.ATConfidential,
@@ -343,17 +373,25 @@ func (b Client) AcquireTokenOnBehalfOf(ctx context.Context, onBehalfOfParams Acq
 		UserAssertion:     onBehalfOfParams.UserAssertion,
 		AuthorizationType: authority.ATOnBehalfOf,
 		TenantID:          onBehalfOfParams.TenantID,
+		Claims:            onBehalfOfParams.Claims,
 	}
-	token, err := b.AcquireTokenSilent(ctx, silentParameters)
+	ar, err := b.AcquireTokenSilent(ctx, silentParameters)
+	if err == nil {
+		return ar, err
+	}
+	authParams, err := b.AuthParams.WithTenant(onBehalfOfParams.TenantID)
 	if err != nil {
-		fmt.Println("Acquire Token Silent failed ")
-		token, err := b.Token.OnBehalfOf(ctx, authParams, onBehalfOfParams.Credential)
-		if err != nil {
-			return AuthResult{}, err
-		}
-		return b.AuthResultFromToken(ctx, authParams, token, true)
+		return AuthResult{}, err
 	}
-	return token, err
+	authParams.AuthorizationType = authority.ATOnBehalfOf
+	authParams.Claims = onBehalfOfParams.Claims
+	authParams.Scopes = onBehalfOfParams.Scopes
+	authParams.UserAssertion = onBehalfOfParams.UserAssertion
+	token, err := b.Token.OnBehalfOf(ctx, authParams, onBehalfOfParams.Credential)
+	if err == nil {
+		ar, err = b.AuthResultFromToken(ctx, authParams, token, true)
+	}
+	return ar, err
 }
 
 func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.AuthParams, token accesstokens.TokenResponse, cacheWrite bool) (AuthResult, error) {

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -193,9 +193,18 @@ func WithRegionDetection(region string) Option {
 	}
 }
 
+func WithInstanceDiscovery(instanceDiscoveryEnabled bool) Option {
+	return func(c *Client) error {
+		c.AuthParams.AuthorityInfo.ValidateAuthority = instanceDiscoveryEnabled
+		c.AuthParams.AuthorityInfo.InstanceDiscoveryDisabled = !instanceDiscoveryEnabled
+		return nil
+	}
+}
+
 // New is the constructor for Base.
 func New(clientID string, authorityURI string, token *oauth.Client, options ...Option) (Client, error) {
-	authInfo, err := authority.NewInfoFromAuthorityURI(authorityURI, true)
+	//By default, validateAuthority is set to true and instanceDiscoveryDisabled is set to false
+	authInfo, err := authority.NewInfoFromAuthorityURI(authorityURI, true, false)
 	if err != nil {
 		return Client{}, err
 	}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -273,7 +273,23 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilentParameters) (AuthResult, error) {
 	tenant := silent.TenantID
 	if tenant == "" {
-		tenant = silent.Account.Realm
+		// the caller didn't specify a tenant, so we'll use the client's configured tenant or the given account's home tenant
+		switch tenant = b.AuthParams.AuthorityInfo.Tenant; tenant {
+		case "common", "organizations":
+			if _, homeTenant, found := strings.Cut(silent.Account.HomeAccountID, "."); found {
+				// note that both public and confidential clients allow specifying an account for silent auth
+				tenant = homeTenant
+			} else if !b.AuthParams.IsConfidentialClient {
+				// public client requires the caller to identify a specific user for silent authentication
+				return AuthResult{}, errors.New("use the WithSilentAccount option to specify an account")
+			}
+			// else we have a confidential client and no account specified. We can't return an error here because
+			// the caller may have configured the client with a custom token provider, in which case the client
+			// handles caching and the token provider is responsible for everything else, including determining
+			// the correct tenant.
+		default:
+			// use the client's configured tenant
+		}
 	}
 	authParams, err := b.AuthParams.WithTenant(tenant)
 	if err != nil {

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -256,14 +256,14 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 	if authParams.Prompt != "" {
 		v.Add("prompt", authParams.Prompt)
 	}
+	if authParams.DomainHint != "" {
+		v.Add("domain_hint", authParams.DomainHint)
+	}
 	// There were left over from an implementation that didn't use any of these.  We may
 	// need to add them later, but as of now aren't needed.
 	/*
 		if p.ResponseMode != "" {
 			urlParams.Add("response_mode", p.ResponseMode)
-		}
-		if p.DomainHint != "" {
-			urlParams.Add("domain_hint", p.DomainHint)
 		}
 	*/
 	baseURL.RawQuery = v.Encode()

--- a/apps/internal/mock/mock.go
+++ b/apps/internal/mock/mock.go
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package mock
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type response struct {
+	body     []byte
+	callback func(*http.Request)
+	code     int
+	headers  http.Header
+}
+
+type responseOption interface {
+	apply(*response)
+}
+
+type respOpt func(*response)
+
+func (fn respOpt) apply(r *response) {
+	fn(r)
+}
+
+// WithBody sets the HTTP response's body to the specified value.
+func WithBody(b []byte) responseOption {
+	return respOpt(func(r *response) {
+		r.body = b
+	})
+}
+
+// WithCallback sets a callback to invoke before returning the response.
+func WithCallback(callback func(*http.Request)) responseOption {
+	return respOpt(func(r *response) {
+		r.callback = callback
+	})
+}
+
+// Client is a mock HTTP client that returns a sequence of responses. Use AppendResponse to specify the sequence.
+type Client struct {
+	resp []response
+}
+
+func (c *Client) AppendResponse(opts ...responseOption) {
+	r := response{code: http.StatusOK, headers: http.Header{}}
+	for _, o := range opts {
+		o.apply(&r)
+	}
+	c.resp = append(c.resp, r)
+}
+
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if len(c.resp) == 0 {
+		panic(fmt.Sprintf(`no response for "%s"`, req.URL.String()))
+	}
+	resp := c.resp[0]
+	c.resp = c.resp[1:]
+	if resp.callback != nil {
+		resp.callback(req)
+	}
+	res := http.Response{Header: resp.headers, StatusCode: resp.code}
+	res.Body = io.NopCloser(bytes.NewReader(resp.body))
+	return &res, nil
+}
+
+// CloseIdleConnections implements the comm.HTTPClient interface
+func (*Client) CloseIdleConnections() {}
+
+func GetAccessTokenBody(accessToken, idToken, refreshToken, clientInfo string, expiresIn int) []byte {
+	body := fmt.Sprintf(
+		`{"access_token": "%s","expires_in": %d,"expires_on": %d`,
+		accessToken, expiresIn, time.Now().Add(time.Duration(expiresIn)*time.Second).Unix(),
+	)
+	if clientInfo != "" {
+		body += fmt.Sprintf(`, "client_info": "%s"`, clientInfo)
+	}
+	if idToken != "" {
+		body += fmt.Sprintf(`, "id_token": "%s"`, idToken)
+	}
+	if refreshToken != "" {
+		body += fmt.Sprintf(`, "refresh_token": "%s"`, refreshToken)
+	}
+	body += "}"
+	return []byte(body)
+}
+
+func GetIDToken(tenant, issuer string) string {
+	now := time.Now().Unix()
+	payload := []byte(fmt.Sprintf(`{"aud": "%s","exp": %d,"iat": %d,"iss": "%s"}`, tenant, now+3600, now, issuer))
+	return fmt.Sprintf("header.%s.signature", base64.RawStdEncoding.EncodeToString(payload))
+}
+
+func GetInstanceDiscoveryBody(host, tenant string) []byte {
+	authority := fmt.Sprintf("https://%s/%s", host, tenant)
+	body := fmt.Sprintf(`{"tenant_discovery_endpoint": "%s/v2.0/.well-known/openid-configuration","api-version": "1.1","metadata": [{"preferred_network": "%s","preferred_cache": "%s","aliases": ["%s"]}]}`,
+		authority, host, host, host,
+	)
+	headers := http.Header{}
+	headers.Add("Content-Type", "application/json; charset=utf-8")
+	return []byte(body)
+}
+
+func GetTenantDiscoveryBody(host, tenant string) []byte {
+	authority := fmt.Sprintf("https://%s/%s", host, tenant)
+	content := strings.ReplaceAll(`{"token_endpoint": "{authority}/oauth2/v2.0/token",
+		"token_endpoint_auth_methods_supported": [
+			"client_secret_post",
+			"private_key_jwt",
+			"client_secret_basic"
+		],
+		"jwks_uri": "{authority}/discovery/v2.0/keys",
+		"response_modes_supported": [
+			"query",
+			"fragment",
+			"form_post"
+		],
+		"subject_types_supported": [
+			"pairwise"
+		],
+		"id_token_signing_alg_values_supported": [
+			"RS256"
+		],
+		"response_types_supported": [
+			"code",
+			"id_token",
+			"code id_token",
+			"id_token token"
+		],
+		"scopes_supported": [
+			"openid",
+			"profile",
+			"email",
+			"offline_access"
+		],
+		"issuer": "{authority}/v2.0",
+		"request_uri_parameter_supported": false,
+		"userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+		"authorization_endpoint": "{authority}/oauth2/v2.0/authorize",
+		"device_authorization_endpoint": "{authority}/oauth2/v2.0/devicecode",
+		"http_logout_supported": true,
+		"frontchannel_logout_supported": true,
+		"end_session_endpoint": "{authority}/oauth2/v2.0/logout",
+		"claims_supported": [
+			"sub",
+			"iss",
+			"cloud_instance_name",
+			"cloud_instance_host_name",
+			"cloud_graph_host_name",
+			"msgraph_host",
+			"aud",
+			"exp",
+			"iat",
+			"auth_time",
+			"acr",
+			"nonce",
+			"preferred_username",
+			"name",
+			"tid",
+			"ver",
+			"at_hash",
+			"c_hash",
+			"email"
+		],
+		"kerberos_endpoint": "{authority}/kerberos",
+		"tenant_region_scope": "NA",
+		"cloud_instance_name": "microsoftonline.com",
+		"cloud_graph_host_name": "graph.windows.net",
+		"msgraph_host": "graph.microsoft.com",
+		"rbac_url": "https://pas.windows.net"
+	}`, "{authority}", authority)
+	return []byte(content)
+}

--- a/apps/internal/oauth/fake/fake.go
+++ b/apps/internal/oauth/fake/fake.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
-	internalTime "github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/json/types/time"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust"
@@ -114,7 +112,7 @@ func (f *AccessTokens) FromDeviceCodeResult(ctx context.Context, authParameters 
 		defer func() { f.Next++ }()
 		v := f.Result[f.Next]
 		if v == nil {
-			return accesstokens.TokenResponse{ExpiresOn: internalTime.DurationTime{T: time.Now().Add(5 * time.Minute)}}, nil
+			return f.AccessToken, nil
 		}
 		return accesstokens.TokenResponse{}, v
 	}

--- a/apps/internal/oauth/oauth.go
+++ b/apps/internal/oauth/oauth.go
@@ -100,8 +100,10 @@ func (t *Client) Credential(ctx context.Context, authParams authority.AuthParams
 		scopes := make([]string, len(authParams.Scopes))
 		copy(scopes, authParams.Scopes)
 		params := exported.TokenProviderParameters{
+			Claims:        authParams.Claims,
 			CorrelationID: uuid.New().String(),
 			Scopes:        scopes,
+			TenantID:      authParams.AuthorityInfo.Tenant,
 		}
 		tr, err := cred.TokenProvider(ctx, params)
 		if err != nil {

--- a/apps/internal/oauth/oauth.go
+++ b/apps/internal/oauth/oauth.go
@@ -140,7 +140,6 @@ func (t *Client) OnBehalfOf(ctx context.Context, authParams authority.AuthParams
 
 	if cred.Secret != "" {
 		return t.AccessTokens.FromUserAssertionClientSecret(ctx, authParams, authParams.UserAssertion, cred.Secret)
-
 	}
 	jwt, err := cred.JWT(ctx, authParams)
 	if err != nil {

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -157,6 +157,9 @@ type Client struct {
 // FromUsernamePassword uses a username and password to get an access token.
 func (c Client) FromUsernamePassword(ctx context.Context, authParameters authority.AuthParams) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.Password)
 	qv.Set(username, authParameters.Username)
 	qv.Set(password, authParameters.Password)
@@ -219,6 +222,9 @@ func (c Client) FromAuthCode(ctx context.Context, req AuthCodeRequest) (TokenRes
 	qv.Set(clientID, req.AuthParams.ClientID)
 	qv.Set(clientInfo, clientInfoVal)
 	addScopeQueryParam(qv, req.AuthParams)
+	if err := addClaims(qv, req.AuthParams); err != nil {
+		return TokenResponse{}, err
+	}
 
 	return c.doTokenResp(ctx, req.AuthParams, qv)
 }
@@ -233,6 +239,9 @@ func (c Client) FromRefreshToken(ctx context.Context, appType AppType, authParam
 			return TokenResponse{}, err
 		}
 	}
+	if err := addClaims(qv, authParams); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.RefreshToken)
 	qv.Set(clientID, authParams.ClientID)
 	qv.Set(clientInfo, clientInfoVal)
@@ -245,6 +254,9 @@ func (c Client) FromRefreshToken(ctx context.Context, appType AppType, authParam
 // FromClientSecret uses a client's secret (aka password) to get a new token.
 func (c Client) FromClientSecret(ctx context.Context, authParameters authority.AuthParams, clientSecret string) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.ClientCredential)
 	qv.Set("client_secret", clientSecret)
 	qv.Set(clientID, authParameters.ClientID)
@@ -259,6 +271,9 @@ func (c Client) FromClientSecret(ctx context.Context, authParameters authority.A
 
 func (c Client) FromAssertion(ctx context.Context, authParameters authority.AuthParams, assertion string) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.ClientCredential)
 	qv.Set("client_assertion_type", grant.ClientAssertion)
 	qv.Set("client_assertion", assertion)
@@ -275,6 +290,9 @@ func (c Client) FromAssertion(ctx context.Context, authParameters authority.Auth
 
 func (c Client) FromUserAssertionClientSecret(ctx context.Context, authParameters authority.AuthParams, userAssertion string, clientSecret string) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.JWT)
 	qv.Set(clientID, authParameters.ClientID)
 	qv.Set("client_secret", clientSecret)
@@ -288,6 +306,9 @@ func (c Client) FromUserAssertionClientSecret(ctx context.Context, authParameter
 
 func (c Client) FromUserAssertionClientCertificate(ctx context.Context, authParameters authority.AuthParams, userAssertion string, assertion string) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.JWT)
 	qv.Set("client_assertion_type", grant.ClientAssertion)
 	qv.Set("client_assertion", assertion)
@@ -302,6 +323,9 @@ func (c Client) FromUserAssertionClientCertificate(ctx context.Context, authPara
 
 func (c Client) DeviceCodeResult(ctx context.Context, authParameters authority.AuthParams) (DeviceCodeResult, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return DeviceCodeResult{}, err
+	}
 	qv.Set(clientID, authParameters.ClientID)
 	addScopeQueryParam(qv, authParameters)
 
@@ -318,6 +342,9 @@ func (c Client) DeviceCodeResult(ctx context.Context, authParameters authority.A
 
 func (c Client) FromDeviceCodeResult(ctx context.Context, authParameters authority.AuthParams, deviceCodeResult DeviceCodeResult) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(grantType, grant.DeviceCode)
 	qv.Set(deviceCode, deviceCodeResult.DeviceCode)
 	qv.Set(clientID, authParameters.ClientID)
@@ -329,6 +356,9 @@ func (c Client) FromDeviceCodeResult(ctx context.Context, authParameters authori
 
 func (c Client) FromSamlGrant(ctx context.Context, authParameters authority.AuthParams, samlGrant wstrust.SamlTokenInfo) (TokenResponse, error) {
 	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
 	qv.Set(username, authParameters.Username)
 	qv.Set(password, authParameters.Password)
 	qv.Set(clientID, authParameters.ClientID)
@@ -404,6 +434,15 @@ func AppendDefaultScopes(authParameters authority.AuthParams) []string {
 	}
 	scopes = append(scopes, defaultScopes...)
 	return scopes
+}
+
+// addClaims adds client capabilities and claims from AuthParams to the given url.Values
+func addClaims(v url.Values, ap authority.AuthParams) error {
+	claims, err := ap.MergeCapabilitiesAndClaims()
+	if err == nil && claims != "" {
+		v.Set("claims", claims)
+	}
+	return err
 }
 
 func addScopeQueryParam(queryParams url.Values, authParameters authority.AuthParams) {

--- a/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
@@ -953,6 +953,7 @@ func TestHomeAccountID(t *testing.T) {
 		{
 			desc: "UTID is not set",
 			ci:   ClientInfo{UID: "uid"},
+			want: "uid.uid",
 		},
 		{
 			desc: "UID and UTID are set",

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -148,10 +148,13 @@ func (c *ClientInfo) UnmarshalJSON(b []byte) error {
 
 // HomeAccountID creates the home account ID.
 func (c ClientInfo) HomeAccountID() string {
-	if c.UID == "" || c.UTID == "" {
+	if c.UID == "" {
 		return ""
+	} else if c.UTID == "" {
+		return fmt.Sprintf("%s.%s", c.UID, c.UID)
+	} else {
+		return fmt.Sprintf("%s.%s", c.UID, c.UTID)
 	}
-	return fmt.Sprintf("%s.%s", c.UID, c.UTID)
 }
 
 // Scopes represents scopes in a TokenResponse.

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -205,6 +205,7 @@ func (p AuthParams) WithTenant(ID string) (AuthParams, error) {
 	authority := "https://" + path.Join(p.AuthorityInfo.Host, ID)
 	info, err := NewInfoFromAuthorityURI(authority, p.AuthorityInfo.ValidateAuthority)
 	if err == nil {
+		info.Region = p.AuthorityInfo.Region
 		p.AuthorityInfo = info
 	}
 	return p, err

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -157,6 +158,11 @@ type AuthParams struct {
 	SendX5C bool
 	// UserAssertion is the access token used to acquire token on behalf of user
 	UserAssertion string
+	// Capabilities the client will include with each token request, for example "CP1".
+	// Call [NewClientCapabilities] to construct a value for this field.
+	Capabilities ClientCapabilities
+	// Claims required for an access token to satisfy a conditional access policy
+	Claims string
 	// KnownAuthorityHosts don't require metadata discovery because they're known to the user
 	KnownAuthorityHosts []string
 	// LoginHint is a username with which to pre-populate account selection during interactive auth
@@ -202,6 +208,84 @@ func (p AuthParams) WithTenant(ID string) (AuthParams, error) {
 		p.AuthorityInfo = info
 	}
 	return p, err
+}
+
+// MergeCapabilitiesAndClaims combines client capabilities and challenge claims into a value suitable for an authentication request's "claims" parameter.
+func (p AuthParams) MergeCapabilitiesAndClaims() (string, error) {
+	claims := p.Claims
+	if len(p.Capabilities.asMap) > 0 {
+		if claims == "" {
+			// without claims the result is simply the capabilities
+			return p.Capabilities.asJSON, nil
+		}
+		// Otherwise, merge claims and capabilties into a single JSON object.
+		// We handle the claims challenge as a map because we don't know its structure.
+		var challenge map[string]any
+		if err := json.Unmarshal([]byte(claims), &challenge); err != nil {
+			return "", fmt.Errorf(`claims must be JSON. Are they base64 encoded? json.Unmarshal returned "%v"`, err)
+		}
+		if err := merge(p.Capabilities.asMap, challenge); err != nil {
+			return "", err
+		}
+		b, err := json.Marshal(challenge)
+		if err != nil {
+			return "", err
+		}
+		claims = string(b)
+	}
+	return claims, nil
+}
+
+// merges a into b without overwriting b's values. Returns an error when a and b share a key for which either has a non-object value.
+func merge(a, b map[string]any) error {
+	for k, av := range a {
+		if bv, ok := b[k]; !ok {
+			// b doesn't contain this key => simply set it to a's value
+			b[k] = av
+		} else {
+			// b does contain this key => recursively merge a[k] into b[k], provided both are maps. If a[k] or b[k] isn't
+			// a map, return an error because merging would overwrite some value in b. Errors shouldn't occur in practice
+			// because the challenge will be from AAD, which knows the capabilities format.
+			if A, ok := av.(map[string]any); ok {
+				if B, ok := bv.(map[string]any); ok {
+					return merge(A, B)
+				} else {
+					// b[k] isn't a map
+					return errors.New("challenge claims conflict with client capabilities")
+				}
+			} else {
+				// a[k] isn't a map
+				return errors.New("challenge claims conflict with client capabilities")
+			}
+		}
+	}
+	return nil
+}
+
+// ClientCapabilities stores capabilities in the formats used by AuthParams.MergeCapabilitiesAndClaims.
+// [NewClientCapabilities] precomputes these representations because capabilities are static for the
+// lifetime of a client and are included with every authentication request i.e., these computations
+// always have the same result and would otherwise have to be repeated for every request.
+type ClientCapabilities struct {
+	// asJSON is for the common case: adding the capabilities to an auth request with no challenge claims
+	asJSON string
+	// asMap is for merging the capabilities with challenge claims
+	asMap map[string]any
+}
+
+func NewClientCapabilities(capabilities []string) (ClientCapabilities, error) {
+	c := ClientCapabilities{}
+	var err error
+	if len(capabilities) > 0 {
+		cpbs := make([]string, len(capabilities))
+		for i := 0; i < len(cpbs); i++ {
+			cpbs[i] = fmt.Sprintf(`"%s"`, capabilities[i])
+		}
+		c.asJSON = fmt.Sprintf(`{"access_token":{"xms_cc":{"values":[%s]}}}`, strings.Join(cpbs, ","))
+		// note our JSON is valid but we can't stop users breaking it with garbage like "}"
+		err = json.Unmarshal([]byte(c.asJSON), &c.asMap)
+	}
+	return c, err
 }
 
 // Info consists of information about the authority.

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -168,6 +169,38 @@ func NewAuthParams(clientID string, authorityInfo Info) AuthParams {
 		AuthorityInfo: authorityInfo,
 		CorrelationID: uuid.New().String(),
 	}
+}
+
+// WithTenant returns a copy of the AuthParams having the specified tenant ID. If the given
+// ID is empty, the copy is identical to the original. This function returns an error in
+// several cases:
+//   - ID isn't specific (for example, it's "common")
+//   - ID is non-empty and the authority doesn't support tenants (for example, it's an ADFS authority)
+//   - the client is configured to authenticate only Microsoft accounts via the "consumers" endpoint
+//   - the resulting authority URL is invalid
+func (p AuthParams) WithTenant(ID string) (AuthParams, error) {
+	switch ID {
+	case "", p.AuthorityInfo.Tenant:
+		// keep the default tenant because the caller didn't override it
+		return p, nil
+	case "common", "consumers", "organizations":
+		if p.AuthorityInfo.AuthorityType == AAD {
+			return p, fmt.Errorf(`tenant ID must be a specific tenant, not "%s"`, ID)
+		}
+		// else we'll return a better error below
+	}
+	if p.AuthorityInfo.AuthorityType != AAD {
+		return p, errors.New("the authority doesn't support tenants")
+	}
+	if p.AuthorityInfo.Tenant == "consumers" {
+		return p, errors.New(`client is configured to authenticate only personal Microsoft accounts, via the "consumers" endpoint`)
+	}
+	authority := "https://" + path.Join(p.AuthorityInfo.Host, ID)
+	info, err := NewInfoFromAuthorityURI(authority, p.AuthorityInfo.ValidateAuthority)
+	if err == nil {
+		p.AuthorityInfo = info
+	}
+	return p, err
 }
 
 // Info consists of information about the authority.

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -157,9 +157,10 @@ type AuthParams struct {
 	SendX5C bool
 	// UserAssertion is the access token used to acquire token on behalf of user
 	UserAssertion string
-
 	// KnownAuthorityHosts don't require metadata discovery because they're known to the user
 	KnownAuthorityHosts []string
+	// LoginHint is a username with which to pre-populate account selection during interactive auth
+	LoginHint string
 }
 
 // NewAuthParams creates an authorization parameters object.

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -167,6 +167,8 @@ type AuthParams struct {
 	KnownAuthorityHosts []string
 	// LoginHint is a username with which to pre-populate account selection during interactive auth
 	LoginHint string
+	// DomainHint is a directive that can be used to accelerate the user to their federated IdP sign-in page
+	DomainHint string
 }
 
 // NewAuthParams creates an authorization parameters object.

--- a/apps/internal/oauth/ops/authority/authority_test.go
+++ b/apps/internal/oauth/ops/authority/authority_test.go
@@ -309,7 +309,7 @@ func TestCreateAuthorityInfoFromAuthorityUri(t *testing.T) {
 		Tenant:                "common",
 		ValidateAuthority:     true,
 	}
-	got, err := NewInfoFromAuthorityURI(authorityURI, true)
+	got, err := NewInfoFromAuthorityURI(authorityURI, true, false)
 	if err != nil {
 		t.Fatalf("TestCreateAuthorityInfoFromAuthorityUri: got err == %s, want err == nil", err)
 	}
@@ -336,7 +336,7 @@ func TestAuthParamsWithTenant(t *testing.T) {
 		{authority: host + "consumers", tenant: uuid1, expectError: true},
 	} {
 		t.Run("", func(t *testing.T) {
-			info, err := NewInfoFromAuthorityURI(test.authority, false)
+			info, err := NewInfoFromAuthorityURI(test.authority, false, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -362,7 +362,7 @@ func TestAuthParamsWithTenant(t *testing.T) {
 	t.Run("AuthorityInfo", func(t *testing.T) {
 		a := "A"
 		b := "B"
-		before, err := NewInfoFromAuthorityURI("https://localhost/"+a, true)
+		before, err := NewInfoFromAuthorityURI("https://localhost/"+a, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apps/internal/oauth/resolvers.go
+++ b/apps/internal/oauth/resolvers.go
@@ -46,9 +46,6 @@ func newAuthorityEndpoint(rest *ops.REST) *authorityEndpoint {
 
 // ResolveEndpoints gets the authorization and token endpoints and creates an AuthorityEndpoints instance
 func (m *authorityEndpoint) ResolveEndpoints(ctx context.Context, authorityInfo authority.Info, userPrincipalName string) (authority.Endpoints, error) {
-	if authorityInfo.AuthorityType == ADFS && len(userPrincipalName) == 0 {
-		return authority.Endpoints{}, errors.New("UPN required for authority validation for ADFS")
-	}
 
 	if endpoints, found := m.cachedEndpoints(authorityInfo, userPrincipalName); found {
 		return endpoints, nil

--- a/apps/internal/options/options.go
+++ b/apps/internal/options/options.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package options
+
+import (
+	"errors"
+	"fmt"
+)
+
+// CallOption implements an optional argument to a method call. See
+// https://blog.devgenius.io/go-call-option-that-can-be-used-with-multiple-methods-6c81734f3dbe
+// for an explanation of the usage pattern.
+type CallOption interface {
+	Do(any) error
+	callOption()
+}
+
+// ApplyOptions applies all the callOptions to options. options must be a pointer to a struct and
+// callOptions must be a list of objects that implement CallOption.
+func ApplyOptions[O, C any](options O, callOptions []C) error {
+	for _, o := range callOptions {
+		if t, ok := any(o).(CallOption); !ok {
+			return fmt.Errorf("unexpected option type %T", o)
+		} else if err := t.Do(options); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NewCallOption returns a new CallOption whose Do() method calls function "f".
+func NewCallOption(f func(any) error) CallOption {
+	if f == nil {
+		// This isn't a practical concern because only an MSAL maintainer can get
+		// us here, by implementing a do-nothing option. But if someone does that,
+		// the below ensures the method invoked with the option returns an error.
+		return callOption(func(any) error {
+			return errors.New("invalid option: missing implementation")
+		})
+	}
+	return callOption(f)
+}
+
+// callOption is an adapter for a function to a CallOption
+type callOption func(any) error
+
+func (c callOption) Do(a any) error {
+	return c(a)
+}
+
+func (callOption) callOption() {}

--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -5,4 +5,4 @@
 package version
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "0.7.0"
+const Version = "0.8.0"

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -62,6 +62,8 @@ type Options struct {
 	HTTPClient ops.HTTPClient
 
 	capabilities []string
+
+	disableInstanceDiscovery bool
 }
 
 func (p *Options) validate() error {
@@ -108,6 +110,13 @@ func WithHTTPClient(httpClient ops.HTTPClient) Option {
 	}
 }
 
+// WithInstanceDiscovery set to false to disable authority validation (to support private cloud scenarios)
+func WithInstanceDiscovery(enabled bool) Option {
+	return func(o *Options) {
+		o.disableInstanceDiscovery = !enabled
+	}
+}
+
 // Client is a representation of authentication client for public applications as defined in the
 // package doc. For more information, visit https://docs.microsoft.com/azure/active-directory/develop/msal-client-applications.
 type Client struct {
@@ -128,7 +137,7 @@ func New(clientID string, options ...Option) (Client, error) {
 		return Client{}, err
 	}
 
-	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithCacheAccessor(opts.Accessor), base.WithClientCapabilities(opts.capabilities))
+	base, err := base.New(clientID, opts.Authority, oauth.New(opts.HTTPClient), base.WithCacheAccessor(opts.Accessor), base.WithClientCapabilities(opts.capabilities), base.WithInstanceDiscovery(!opts.disableInstanceDiscovery))
 	if err != nil {
 		return Client{}, err
 	}

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -137,7 +137,7 @@ func New(clientID string, options ...Option) (Client, error) {
 
 // createAuthCodeURLOptions contains options for CreateAuthCodeURL
 type createAuthCodeURLOptions struct {
-	claims, loginHint, tenantID string
+	claims, loginHint, tenantID, domainHint string
 }
 
 // CreateAuthCodeURLOption is implemented by options for CreateAuthCodeURL
@@ -147,7 +147,7 @@ type CreateAuthCodeURLOption interface {
 
 // CreateAuthCodeURL creates a URL used to acquire an authorization code.
 //
-// Options: [WithClaims], [WithLoginHint], [WithTenantID]
+// Options: [WithClaims], [WithDomainHint], [WithLoginHint], [WithTenantID]
 func (pca Client) CreateAuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...CreateAuthCodeURLOption) (string, error) {
 	o := createAuthCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -159,6 +159,7 @@ func (pca Client) CreateAuthCodeURL(ctx context.Context, clientID, redirectURI s
 	}
 	ap.Claims = o.claims
 	ap.LoginHint = o.loginHint
+	ap.DomainHint = o.domainHint
 	return pca.base.AuthCodeURL(ctx, clientID, redirectURI, scopes, ap)
 }
 
@@ -491,7 +492,7 @@ type InteractiveAuthOptions struct {
 	// All other URI components are ignored.
 	RedirectURI string
 
-	claims, loginHint, tenantID string
+	claims, loginHint, tenantID, domainHint string
 }
 
 // AcquireInteractiveOption is implemented by options for AcquireTokenInteractive
@@ -531,6 +532,33 @@ func WithLoginHint(username string) interface {
 	}
 }
 
+// WithDomainHint adds the IdP domain as domain_hint query parameter in the auth url.
+func WithDomainHint(domain string) interface {
+	AcquireInteractiveOption
+	CreateAuthCodeURLOption
+	options.CallOption
+} {
+	return struct {
+		AcquireInteractiveOption
+		CreateAuthCodeURLOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *createAuthCodeURLOptions:
+					t.domainHint = domain
+				case *InteractiveAuthOptions:
+					t.domainHint = domain
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
+
 // WithRedirectURI uses the specified redirect URI for interactive auth.
 func WithRedirectURI(redirectURI string) interface {
 	AcquireInteractiveOption
@@ -557,7 +585,7 @@ func WithRedirectURI(redirectURI string) interface {
 // AcquireTokenInteractive acquires a security token from the authority using the default web browser to select the account.
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#interactive-and-non-interactive-authentication
 //
-// Options: [WithLoginHint], [WithRedirectURI], [WithTenantID]
+// Options: [WithDomainHint], [WithLoginHint], [WithRedirectURI], [WithTenantID]
 func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, opts ...AcquireInteractiveOption) (AuthResult, error) {
 	o := InteractiveAuthOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -586,6 +614,7 @@ func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, 
 	authParams.CodeChallenge = challenge
 	authParams.CodeChallengeMethod = "S256"
 	authParams.LoginHint = o.loginHint
+	authParams.DomainHint = o.domainHint
 	authParams.State = uuid.New().String()
 	authParams.Prompt = "select_account"
 	res, err := pca.browserLogin(ctx, redirectURL, authParams)

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -5,14 +5,19 @@ package public
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/mock"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/fake"
 )
+
+var tokenScope = []string{"the_scope"}
 
 func fakeBrowserOpenURL(authURL string) error {
 	// we will get called with the URL for requesting an auth code
@@ -63,5 +68,166 @@ func TestAcquireTokenInteractive(t *testing.T) {
 	_, err = client.AcquireTokenInteractive(context.Background(), []string{"the_scope"})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAcquireTokenSilentTenants(t *testing.T) {
+	tenants := []string{"a", "b"}
+	lmo := "login.microsoftonline.com"
+	mockClient := mock.Client{}
+	mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, tenants[0])))
+	client, err := New("client-id", WithHTTPClient(&mockClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientInfo := base64.RawStdEncoding.EncodeToString([]byte(`{"uid":"uid","utid":"utid"}`))
+	ctx := context.Background()
+	accounts := make([]Account, len(tenants))
+	// cache an access token for each tenant. To simplify determining their provenance below, the value of each token is the ID of the tenant that provided it.
+	for i, tenant := range tenants {
+		if _, err = client.AcquireTokenSilent(ctx, tokenScope, WithTenantID(tenant)); err == nil {
+			t.Fatal("silent auth should fail because the cache is empty")
+		}
+		mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+		mockClient.AppendResponse(mock.WithBody([]byte(`{"account_type":"Managed","cloud_audience_urn":"urn","cloud_instance_name":"...","domain_name":"..."}`)))
+		mockClient.AppendResponse(mock.WithBody(
+			mock.GetAccessTokenBody(tenant, mock.GetIDToken(tenant, fmt.Sprintf("https://%s/%s", lmo, tenant)), "rt-"+tenant, clientInfo, 3600)),
+		)
+		ar, err := client.AcquireTokenByUsernamePassword(ctx, tokenScope, "username", "password", WithTenantID(tenant))
+		if err != nil {
+			t.Fatal(err)
+		}
+		accounts[i] = ar.Account
+	}
+	// cache should return the correct access token for each tenant
+	for i, account := range accounts {
+		if account.Realm != tenants[i] {
+			t.Fatalf(`unexpected realm "%s"`, account.Realm)
+		}
+		otherTenant := tenants[(i+1)%len(tenants)]
+		for _, test := range []struct {
+			desc, expected string
+			opts           []AcquireSilentOption
+		}{
+			{"account only", account.Realm, []AcquireSilentOption{WithSilentAccount(account)}},
+			{"matching account and tenant", account.Realm, []AcquireSilentOption{WithSilentAccount(account), WithTenantID(account.Realm)}},
+			{"tenant overriding account", otherTenant, []AcquireSilentOption{WithSilentAccount(account), WithTenantID(otherTenant)}},
+		} {
+			t.Run(test.desc, func(t *testing.T) {
+				ar, err := client.AcquireTokenSilent(ctx, tokenScope, test.opts...)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if ar.AccessToken != test.expected {
+					t.Fatalf(`expected "%s", got "%s"`, test.expected, ar.AccessToken)
+				}
+			})
+		}
+	}
+}
+
+func TestAcquireTokenWithTenantID(t *testing.T) {
+	// replacing browserOpenURL with a fake for the duration of this test enables testing AcquireTokenInteractive
+	realBrowserOpenURL := browserOpenURL
+	defer func() { browserOpenURL = realBrowserOpenURL }()
+	browserOpenURL = fakeBrowserOpenURL
+
+	accessToken := "*"
+	clientInfo := base64.RawStdEncoding.EncodeToString([]byte(`{"uid":"uid","utid":"utid"}`))
+	uuid1 := "00000000-0000-0000-0000-000000000000"
+	uuid2 := strings.ReplaceAll(uuid1, "0", "1")
+	lmo := "login.microsoftonline.com"
+	host := fmt.Sprintf("https://%s/", lmo)
+	for _, test := range []struct {
+		authority, expectedAuthority, tenant string
+		expectError                          bool
+	}{
+		{authority: host + "common", tenant: uuid1, expectedAuthority: host + uuid1},
+		{authority: host + "organizations", tenant: uuid1, expectedAuthority: host + uuid1},
+		{authority: host + uuid1, tenant: uuid2, expectedAuthority: host + uuid2},
+		{authority: host + uuid1, tenant: "common", expectError: true},
+		{authority: host + uuid1, tenant: "organizations", expectError: true},
+		{authority: host + "consumers", tenant: uuid1, expectError: true},
+	} {
+		for _, method := range []string{"authcode", "authcodeURL", "devicecode", "interactive", "password"} {
+			t.Run(method, func(t *testing.T) {
+				URL := ""
+				mockClient := mock.Client{}
+				if method == "obo" {
+					// TODO: OBO does instance discovery twice before first token request https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/351
+					mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, test.tenant)))
+				}
+				mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, test.tenant)))
+				mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, test.tenant)))
+				if method == "devicecode" {
+					mockClient.AppendResponse(mock.WithBody([]byte(`{"device_code":"...","expires_in":600}`)))
+				} else if method == "password" {
+					// user realm metadata
+					mockClient.AppendResponse(mock.WithBody([]byte(`{"account_type":"Managed","cloud_audience_urn":"urn","cloud_instance_name":"...","domain_name":"..."}`)))
+				}
+				mockClient.AppendResponse(
+					mock.WithBody(mock.GetAccessTokenBody(accessToken, mock.GetIDToken(test.tenant, test.authority), "rt", clientInfo, 3600)),
+					mock.WithCallback(func(r *http.Request) { URL = r.URL.String() }),
+				)
+				client, err := New("client-id", WithAuthority(test.authority), WithHTTPClient(&mockClient))
+				if err != nil {
+					t.Fatal(err)
+				}
+				ctx := context.Background()
+				if _, err = client.AcquireTokenSilent(ctx, tokenScope, WithTenantID(test.tenant)); err == nil {
+					t.Fatal("silent auth should fail because the cache is empty")
+				}
+
+				var ar AuthResult
+				var dc DeviceCode
+				switch method {
+				case "authcode":
+					ar, err = client.AcquireTokenByAuthCode(ctx, "auth code", "https://localhost", tokenScope, WithTenantID(test.tenant))
+				case "authcodeURL":
+					URL, err = client.CreateAuthCodeURL(ctx, "client-id", "https://localhost", tokenScope, WithTenantID(test.tenant))
+				case "devicecode":
+					dc, err = client.AcquireTokenByDeviceCode(ctx, tokenScope, WithTenantID(test.tenant))
+				case "interactive":
+					ar, err = client.AcquireTokenInteractive(ctx, tokenScope, WithTenantID(test.tenant))
+				case "password":
+					ar, err = client.AcquireTokenByUsernamePassword(ctx, tokenScope, "username", "password", WithTenantID(test.tenant))
+				default:
+					t.Fatalf("no test for " + method)
+				}
+				if err != nil {
+					if test.expectError {
+						return
+					}
+					t.Fatal(err)
+				} else if test.expectError {
+					t.Fatal("expected an error")
+				}
+				if method == "devicecode" {
+					if ar, err = dc.AuthenticationResult(ctx); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if !strings.HasPrefix(URL, test.expectedAuthority) {
+					t.Fatalf(`expected "%s", got "%s"`, test.expectedAuthority, URL)
+				}
+				if method == "authcodeURL" {
+					// didn't acquire a token, no need to test silent auth
+					return
+				}
+				if ar.AccessToken != accessToken {
+					t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
+				}
+				// silent authentication should succeed for the given tenant...
+				if ar, err = client.AcquireTokenSilent(ctx, tokenScope, WithSilentAccount(ar.Account), WithTenantID(test.tenant)); err != nil {
+					t.Fatal(err)
+				} else if ar.AccessToken != accessToken {
+					t.Fatal("cached access token should match the one returned by AcquireToken...")
+				}
+				// ...but fail for another tenant
+				if _, err = client.AcquireTokenSilent(ctx, tokenScope, WithSilentAccount(ar.Account), WithTenantID("not-"+test.tenant)); err == nil {
+					t.Fatal("expected an error")
+				}
+			})
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AzureAD/microsoft-authentication-library-for-go
 
-go 1.17
+go 1.18
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.4.2


### PR DESCRIPTION
Enhancements:

* Add per-request tenant ID option `WithTenantID` (#296, #343)
* Add `WithLoginHint` option for interactive authentication (#271, #354)
* Adding a `WithClientCapabilities` option for client constructors and a `WithClaims` option for token acquisition methods (#263, #355)
* Adding Domain Hint option to be used to accelerate the user to their federated IdP sign-in page (#363)
*  Add support for disabling instance discovery for AzureStack scenarios (#362)

Bug fixes:
* AuthParams.WithTenant should copy all AuthorityInfo values (#364)
* Multitenant silent authentication fixes (#366)