### PR TITLE
Remove silent auth special case for home tenant aliases

### DIFF
--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 )
 
-const localhost = "https://localhost"
+const localhost = "http://localhost"
 
 // errorClient is an HTTP client for tests that should fail when confidential.Client sends a request
 type errorClient struct{}

--- a/apps/internal/base/internal/storage/partitioned_storage.go
+++ b/apps/internal/base/internal/storage/partitioned_storage.go
@@ -87,11 +87,11 @@ func (m *PartitionedManager) Write(authParameters authority.AuthParams, tokenRes
 	authParameters.HomeAccountID = tokenResponse.ClientInfo.HomeAccountID()
 	homeAccountID := authParameters.HomeAccountID
 	environment := authParameters.AuthorityInfo.Host
+	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID
 	target := strings.Join(tokenResponse.GrantedScopes.Slice, scopeSeparator)
 	userAssertionHash := authParameters.AssertionHash()
 	cachedAt := time.Now()
-	realm := authParameters.AuthorityInfo.Tenant
 
 	var account shared.Account
 

--- a/apps/internal/base/internal/storage/partitioned_storage.go
+++ b/apps/internal/base/internal/storage/partitioned_storage.go
@@ -87,11 +87,15 @@ func (m *PartitionedManager) Write(authParameters authority.AuthParams, tokenRes
 	authParameters.HomeAccountID = tokenResponse.ClientInfo.HomeAccountID()
 	homeAccountID := authParameters.HomeAccountID
 	environment := authParameters.AuthorityInfo.Host
-	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID
 	target := strings.Join(tokenResponse.GrantedScopes.Slice, scopeSeparator)
 	userAssertionHash := authParameters.AssertionHash()
 	cachedAt := time.Now()
+	realm := authParameters.AuthorityInfo.Tenant
+	if (realm == "common" || realm == "organizations") && tokenResponse.IDToken.TenantID != "" {
+		// "common" and "organizations" are aliases for the user's home tenant, indicated by the idt's "tid" claim, which issued these tokens
+		realm = tokenResponse.IDToken.TenantID
+	}
 
 	var account shared.Account
 

--- a/apps/internal/base/internal/storage/partitioned_storage.go
+++ b/apps/internal/base/internal/storage/partitioned_storage.go
@@ -92,10 +92,6 @@ func (m *PartitionedManager) Write(authParameters authority.AuthParams, tokenRes
 	userAssertionHash := authParameters.AssertionHash()
 	cachedAt := time.Now()
 	realm := authParameters.AuthorityInfo.Tenant
-	if (realm == "common" || realm == "organizations") && tokenResponse.IDToken.TenantID != "" {
-		// "common" and "organizations" are aliases for the user's home tenant, indicated by the idt's "tid" claim, which issued these tokens
-		realm = tokenResponse.IDToken.TenantID
-	}
 
 	var account shared.Account
 

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -136,9 +136,13 @@ func (m *Manager) Write(authParameters authority.AuthParams, tokenResponse acces
 	authParameters.HomeAccountID = tokenResponse.ClientInfo.HomeAccountID()
 	homeAccountID := authParameters.HomeAccountID
 	environment := authParameters.AuthorityInfo.Host
-	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID
 	target := strings.Join(tokenResponse.GrantedScopes.Slice, scopeSeparator)
+	realm := authParameters.AuthorityInfo.Tenant
+	if (realm == "common" || realm == "organizations") && tokenResponse.IDToken.TenantID != "" {
+		// "common" and "organizations" are aliases for the user's home tenant, indicated by the idt's "tid" claim, which issued these tokens
+		realm = tokenResponse.IDToken.TenantID
+	}
 
 	cachedAt := time.Now()
 

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -136,9 +136,9 @@ func (m *Manager) Write(authParameters authority.AuthParams, tokenResponse acces
 	authParameters.HomeAccountID = tokenResponse.ClientInfo.HomeAccountID()
 	homeAccountID := authParameters.HomeAccountID
 	environment := authParameters.AuthorityInfo.Host
+	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID
 	target := strings.Join(tokenResponse.GrantedScopes.Slice, scopeSeparator)
-	realm := authParameters.AuthorityInfo.Tenant
 	cachedAt := time.Now()
 
 	var account shared.Account

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -139,11 +139,6 @@ func (m *Manager) Write(authParameters authority.AuthParams, tokenResponse acces
 	clientID := authParameters.ClientID
 	target := strings.Join(tokenResponse.GrantedScopes.Slice, scopeSeparator)
 	realm := authParameters.AuthorityInfo.Tenant
-	if (realm == "common" || realm == "organizations") && tokenResponse.IDToken.TenantID != "" {
-		// "common" and "organizations" are aliases for the user's home tenant, indicated by the idt's "tid" claim, which issued these tokens
-		realm = tokenResponse.IDToken.TenantID
-	}
-
 	cachedAt := time.Now()
 
 	var account shared.Account

--- a/apps/internal/mock/mock.go
+++ b/apps/internal/mock/mock.go
@@ -94,7 +94,7 @@ func GetAccessTokenBody(accessToken, idToken, refreshToken, clientInfo string, e
 
 func GetIDToken(tenant, issuer string) string {
 	now := time.Now().Unix()
-	payload := []byte(fmt.Sprintf(`{"aud": "%s","exp": %d,"iat": %d,"iss": "%s"}`, tenant, now+3600, now, issuer))
+	payload := []byte(fmt.Sprintf(`{"aud": "%s","exp": %d,"iat": %d,"iss": "%s","tid": "%s"}`, tenant, now+3600, now, issuer, tenant))
 	return fmt.Sprintf("header.%s.signature", base64.RawStdEncoding.EncodeToString(payload))
 }
 

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -77,7 +77,42 @@ func TestAcquireTokenInteractive(t *testing.T) {
 	}
 }
 
-func TestAcquireTokenSilentTenants(t *testing.T) {
+func TestAcquireTokenSilentHomeTenantAliases(t *testing.T) {
+	accessToken := "*"
+	homeTenant := "home-tenant"
+	clientInfo := base64.RawStdEncoding.EncodeToString([]byte(
+		fmt.Sprintf(`{"uid":"uid","utid":"%s"}`, homeTenant),
+	))
+	lmo := "login.microsoftonline.com"
+	for _, alias := range []string{"common", "organizations"} {
+		mockClient := mock.Client{}
+		mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, alias)))
+		mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody(accessToken, mock.GetIDToken(homeTenant, fmt.Sprintf("https://%s/%s", lmo, homeTenant)), "rt", clientInfo, 3600)))
+		mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, homeTenant)))
+		client, err := New("client-id", WithAuthority(fmt.Sprintf("https://%s/%s", lmo, alias)), WithHTTPClient(&mockClient))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// the auth flow isn't important, we just need to populate the cache
+		ar, err := client.AcquireTokenByAuthCode(context.Background(), "code", "https://localhost", tokenScope)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ar.AccessToken != accessToken {
+			t.Fatalf("expected %q, got %q", accessToken, ar.AccessToken)
+		}
+		account := ar.Account
+		ar, err = client.AcquireTokenSilent(context.Background(), tokenScope, WithSilentAccount(account))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ar.AccessToken != accessToken {
+			t.Fatalf("expected %q, got %q", accessToken, ar.AccessToken)
+		}
+	}
+}
+
+func TestAcquireTokenSilentWithTenantID(t *testing.T) {
 	tenantA, tenantB := "a", "b"
 	lmo := "login.microsoftonline.com"
 	mockClient := mock.Client{}

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 )
 
+const authorityFmt = "https://%s/%s"
+
 var tokenScope = []string{"the_scope"}
 
 func fakeBrowserOpenURL(authURL string) error {
@@ -87,9 +89,9 @@ func TestAcquireTokenSilentHomeTenantAliases(t *testing.T) {
 	for _, alias := range []string{"common", "organizations"} {
 		mockClient := mock.Client{}
 		mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, alias)))
-		mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody(accessToken, mock.GetIDToken(homeTenant, fmt.Sprintf("https://%s/%s", lmo, homeTenant)), "rt", clientInfo, 3600)))
+		mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody(accessToken, mock.GetIDToken(homeTenant, fmt.Sprintf(authorityFmt, lmo, homeTenant)), "rt", clientInfo, 3600)))
 		mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, homeTenant)))
-		client, err := New("client-id", WithAuthority(fmt.Sprintf("https://%s/%s", lmo, alias)), WithHTTPClient(&mockClient))
+		client, err := New("client-id", WithAuthority(fmt.Sprintf(authorityFmt, lmo, alias)), WithHTTPClient(&mockClient))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -117,7 +119,7 @@ func TestAcquireTokenSilentWithTenantID(t *testing.T) {
 	lmo := "login.microsoftonline.com"
 	mockClient := mock.Client{}
 	mockClient.AppendResponse(mock.WithBody(mock.GetInstanceDiscoveryBody(lmo, tenantA)))
-	client, err := New("client-id", WithAuthority(fmt.Sprintf("https://%s/%s", lmo, tenantA)), WithHTTPClient(&mockClient))
+	client, err := New("client-id", WithAuthority(fmt.Sprintf(authorityFmt, lmo, tenantA)), WithHTTPClient(&mockClient))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +133,7 @@ func TestAcquireTokenSilentWithTenantID(t *testing.T) {
 		mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
 		mockClient.AppendResponse(mock.WithBody([]byte(`{"account_type":"Managed","cloud_audience_urn":"urn","cloud_instance_name":"...","domain_name":"..."}`)))
 		mockClient.AppendResponse(mock.WithBody(
-			mock.GetAccessTokenBody(tenant, mock.GetIDToken(tenant, fmt.Sprintf("https://%s/%s", lmo, tenant)), "rt-"+tenant, clientInfo, 3600)),
+			mock.GetAccessTokenBody(tenant, mock.GetIDToken(tenant, fmt.Sprintf(authorityFmt, lmo, tenant)), "rt-"+tenant, clientInfo, 3600)),
 		)
 		ar, err := client.AcquireTokenByUsernamePassword(ctx, tokenScope, "username", "password", WithTenantID(tenant))
 		if err != nil {
@@ -379,7 +381,7 @@ func TestWithCache(t *testing.T) {
 	clientInfo := base64.RawStdEncoding.EncodeToString([]byte(`{"uid":"uid","utid":"utid"}`))
 	lmo := "login.microsoftonline.com"
 	tenantA, tenantB := "a", "b"
-	authorityA, authorityB := fmt.Sprintf("https://%s/%s", lmo, tenantA), fmt.Sprintf("https://%s/%s", lmo, tenantB)
+	authorityA, authorityB := fmt.Sprintf(authorityFmt, lmo, tenantA), fmt.Sprintf(authorityFmt, lmo, tenantB)
 	mockClient := mock.Client{}
 	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenantA)))
 	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody(accessToken, mock.GetIDToken(tenantA, authorityA), refreshToken, clientInfo, 3600)))
@@ -445,7 +447,7 @@ func TestWithClaims(t *testing.T) {
 
 	clientInfo := base64.RawStdEncoding.EncodeToString([]byte(`{"uid":"uid","utid":"utid"}`))
 	lmo, tenant := "login.microsoftonline.com", "tenant"
-	authority := fmt.Sprintf("https://%s/%s", lmo, tenant)
+	authority := fmt.Sprintf(authorityFmt, lmo, tenant)
 	accessToken, idToken, refreshToken := "at", mock.GetIDToken(tenant, lmo), "rt"
 	for _, test := range []struct {
 		capabilities     []string


### PR DESCRIPTION
#366 made access token cache reads prefer a user's home tenant over an alias for that tenant ("common", "organizations"). However, it didn't make a corresponding change to cache writes, which use the alias for the realm. The result is an unnecessary token request during silent auth because the cache wrote a token for e.g. "common" and the client searches for one matching the home tenant. 

This PR prevents that unnecessary request by making the cache tenant agnostic according to the rationale here: https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/341#issuecomment-1400936207. When the client requests a token from "common", for example, it will cache that token with realm "common". I first took the other approach, having cache writes follow reads in replacing aliases with the user's home tenant ID, but found making that work might require a separate implementation of `AcquireTokenSilent` for OBO authentication. The "tenant agnostic" approach is much simpler.