### PR TITLE
Release 0.8.1

### DIFF
--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -139,7 +139,6 @@ func (m *Manager) Write(authParameters authority.AuthParams, tokenResponse acces
 	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID
 	target := strings.Join(tokenResponse.GrantedScopes.Slice, scopeSeparator)
-
 	cachedAt := time.Now()
 
 	var account shared.Account

--- a/apps/internal/mock/mock.go
+++ b/apps/internal/mock/mock.go
@@ -94,7 +94,7 @@ func GetAccessTokenBody(accessToken, idToken, refreshToken, clientInfo string, e
 
 func GetIDToken(tenant, issuer string) string {
 	now := time.Now().Unix()
-	payload := []byte(fmt.Sprintf(`{"aud": "%s","exp": %d,"iat": %d,"iss": "%s"}`, tenant, now+3600, now, issuer))
+	payload := []byte(fmt.Sprintf(`{"aud": "%s","exp": %d,"iat": %d,"iss": "%s","tid": "%s"}`, tenant, now+3600, now, issuer, tenant))
 	return fmt.Sprintf("header.%s.signature", base64.RawStdEncoding.EncodeToString(payload))
 }
 

--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -5,4 +5,4 @@
 package version
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "0.8.0"
+const Version = "0.8.1"


### PR DESCRIPTION
Bugfix: Fix a regression introduced in 0.8.0 causing unnecessary token request during silent auth with "common" or "organizations" home tenant alias. (#375)