### PR TITLE
Adding ExportReplace to support the Context object [breaking change for 1.0]

### DIFF
--- a/apps/cache/cache.go
+++ b/apps/cache/cache.go
@@ -29,36 +29,18 @@ type Serializer interface {
 	Unmarshaler
 }
 
-// ExportReplaceCtx is the same as ExportReplace except that it supports passing a context.Context
-// object. A type implementing ExportReplaceCtx must make calls to ExportReplace.Replace/Export call
-// ReplaceCtx/ExportCtx with a context.Background() set to the default timeout.
-// nil Context is not supported and we do not define
-// the outcome of passing one. A Context without a timeout must receive a default timeout specified
-// by the implementor. Retries must be implemented inside the implementation.
-type ExportReplaceCtx interface {
-	ExportReplace
-
-	// ReplaceCtx replaces the cache with what is in external storage.
-	// key is the suggested key which can be used for partioning the cache.
-	// Implementors should honor Context cancellations and return a context.Canceled or
-	// context.DeadlineExceeded in those cases.
-	ReplaceCtx(ctx context.Context, cache Unmarshaler, key string) error
-	// ExportCtx writes the binary representation of the cache (cache.Marshal()) to
-	// external storage. This is considered opaque.
-	// key is the suggested key which can be used for partioning the cache.
-	// Context cancellations should be honorted as in ReplaceCtx.
-	ExportCtx(ctx context.Context, cache Marshaler, key string) error
-}
-
-// ExportReplace is used to export or replace what is in the cache. It must implement a default
-// timeout for both Replace and Export. Errors must be retried until the timeout.  A call to Replace
-// or Export is not guaranteed to succeed. If creating a new implementation, use ExportReplaceCtx.
+// ExportReplace exports and replaces in-memory cache data. It doesn't support nil Context or
+// define the outcome of passing one. A Context without a timeout must receive a default timeout
+// specified by the implementor. Retries must be implemented inside the implementation.
 type ExportReplace interface {
 	// Replace replaces the cache with what is in external storage.
-	// key is the suggested key which can be used for partioning the cache
-	Replace(cache Unmarshaler, key string)
+	// key is the suggested key which can be used for partitioning the cache.
+	// Implementors should honor Context cancellations and return a context.Canceled or
+	// context.DeadlineExceeded in those cases.
+	Replace(ctx context.Context, cache Unmarshaler, key string) error
 	// Export writes the binary representation of the cache (cache.Marshal()) to
 	// external storage. This is considered opaque.
-	// key is the suggested key which can be used for partioning the cache
-	Export(cache Marshaler, key string)
+	// key is the suggested key which can be used for partitioning the cache.
+	// Context cancellations should be honored as in Replace.
+	Export(ctx context.Context, cache Marshaler, key string) error
 }

--- a/apps/cache/cache.go
+++ b/apps/cache/cache.go
@@ -11,6 +11,8 @@ implementers on the format being passed.
 */
 package cache
 
+import "context"
+
 // Marshaler marshals data from an internal cache to bytes that can be stored.
 type Marshaler interface {
 	Marshal() ([]byte, error)
@@ -27,7 +29,30 @@ type Serializer interface {
 	Unmarshaler
 }
 
-// ExportReplace is used export or replace what is in the cache.
+// ExportReplaceCtx is the same as ExportReplace except that it supports passing a context.Context
+// object. A type implementing ExportReplaceCtx must make calls to ExportReplace.Replace/Export call
+// ReplaceCtx/ExportCtx with a context.Background() set to the default timeout.
+// nil Context is not supported and we do not define
+// the outcome of passing one. A Context without a timeout must receive a default timeout specified
+// by the implementor. Retries must be implemented inside the implementation.
+type ExportReplaceCtx interface {
+	ExportReplace
+
+	// ReplaceCtx replaces the cache with what is in external storage.
+	// key is the suggested key which can be used for partioning the cache.
+	// Implementors should honor Context cancellations and return a context.Canceled or
+	// context.DeadlineExceeded in those cases.
+	ReplaceCtx(ctx context.Context, cache Unmarshaler, key string) error
+	// ExportCtx writes the binary representation of the cache (cache.Marshal()) to
+	// external storage. This is considered opaque.
+	// key is the suggested key which can be used for partioning the cache.
+	// Context cancellations should be honorted as in ReplaceCtx.
+	ExportCtx(ctx context.Context, cache Marshaler, key string) error
+}
+
+// ExportReplace is used to export or replace what is in the cache. It must implement a default
+// timeout for both Replace and Export. Errors must be retried until the timeout.  A call to Replace
+// or Export is not guaranteed to succeed. If creating a new implementation, use ExportReplaceCtx.
 type ExportReplace interface {
 	// Replace replaces the cache with what is in external storage.
 	// key is the suggested key which can be used for partioning the cache

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -740,12 +740,12 @@ func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion stri
 
 // Account gets the account in the token cache with the specified homeAccountID.
 func (cca Client) AccountCtx(ctx context.Context, homeAccountID string) Account {
-	return cca.base.Account(ctx, homeAccountID)
+	return cca.base.AccountCtx(ctx, homeAccountID)
 }
 
 // RemoveAccountCtx signs the account out and forgets account from token cache.
 func (cca Client) RemoveAccountCtx(ctx context.Context, account Account) error {
-	cca.base.RemoveAccount(ctx, account)
+	cca.base.RemoveAccountCtx(ctx, account)
 	return nil
 }
 
@@ -753,13 +753,13 @@ func (cca Client) RemoveAccountCtx(ctx context.Context, account Account) error {
 //
 // Deprecated: This function is replaced with AccountCtx().
 func (cca Client) Account(homeAccountID string) Account {
-	return cca.base.Account(context.Background(), homeAccountID)
+	return cca.base.AccountCtx(context.Background(), homeAccountID)
 }
 
 // RemoveAccount signs the account out and forgets account from token cache.
 //
 // Deprecated: This function is replaced with AccountCtx().
 func (cca Client) RemoveAccount(account Account) error {
-	cca.base.RemoveAccount(context.Background(), account)
+	cca.base.RemoveAccountCtx(context.Background(), account)
 	return nil
 }

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -50,8 +50,7 @@ duplication.
 .Net People, Take note on X509:
 This uses x509.Certificates and private keys. x509 does not store private keys. .Net
 has some x509.Certificate2 thing that has private keys, but that is just some bullcrap that .Net
-added, it doesn't exist in real life.  Seriously, "x509.Certificate2", bahahahaha.  As such I've
-put a PEM decoder into here.
+added, it doesn't exist in real life. As such I've put a PEM decoder into here.
 */
 
 // TODO(msal): This should have example code for each method on client using Go's example doc framework.
@@ -740,12 +739,27 @@ func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion stri
 }
 
 // Account gets the account in the token cache with the specified homeAccountID.
+func (cca Client) AccountCtx(ctx context.Context, homeAccountID string) Account {
+	return cca.base.Account(ctx, homeAccountID)
+}
+
+// RemoveAccountCtx signs the account out and forgets account from token cache.
+func (cca Client) RemoveAccountCtx(ctx context.Context, account Account) error {
+	cca.base.RemoveAccount(ctx, account)
+	return nil
+}
+
+// Account gets the account in the token cache with the specified homeAccountID.
+//
+// Deprecated: This function is replaced with AccountCtx().
 func (cca Client) Account(homeAccountID string) Account {
-	return cca.base.Account(homeAccountID)
+	return cca.base.Account(context.Background(), homeAccountID)
 }
 
 // RemoveAccount signs the account out and forgets account from token cache.
+//
+// Deprecated: This function is replaced with AccountCtx().
 func (cca Client) RemoveAccount(account Account) error {
-	cca.base.RemoveAccount(account)
+	cca.base.RemoveAccount(context.Background(), account)
 	return nil
 }

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -739,8 +739,8 @@ func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion stri
 }
 
 // Account gets the account in the token cache with the specified homeAccountID.
-func (cca Client) Account(ctx context.Context, homeAccountID string) (Account, error) {
-	return cca.base.Account(ctx, homeAccountID)
+func (cca Client) Account(ctx context.Context, accountID string) (Account, error) {
+	return cca.base.Account(ctx, accountID)
 }
 
 // RemoveAccount signs the account out and forgets account from token cache.

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -739,27 +739,11 @@ func (cca Client) AcquireTokenOnBehalfOf(ctx context.Context, userAssertion stri
 }
 
 // Account gets the account in the token cache with the specified homeAccountID.
-func (cca Client) AccountCtx(ctx context.Context, homeAccountID string) Account {
-	return cca.base.AccountCtx(ctx, homeAccountID)
-}
-
-// RemoveAccountCtx signs the account out and forgets account from token cache.
-func (cca Client) RemoveAccountCtx(ctx context.Context, account Account) error {
-	cca.base.RemoveAccountCtx(ctx, account)
-	return nil
-}
-
-// Account gets the account in the token cache with the specified homeAccountID.
-//
-// Deprecated: This function is replaced with AccountCtx().
-func (cca Client) Account(homeAccountID string) Account {
-	return cca.base.AccountCtx(context.Background(), homeAccountID)
+func (cca Client) Account(ctx context.Context, homeAccountID string) (Account, error) {
+	return cca.base.Account(ctx, homeAccountID)
 }
 
 // RemoveAccount signs the account out and forgets account from token cache.
-//
-// Deprecated: This function is replaced with AccountCtx().
-func (cca Client) RemoveAccount(account Account) error {
-	cca.base.RemoveAccountCtx(context.Background(), account)
-	return nil
+func (cca Client) RemoveAccount(ctx context.Context, account Account) error {
+	return cca.base.RemoveAccount(ctx, account)
 }

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -303,7 +303,10 @@ func TestAcquireTokenByAuthCode(t *testing.T) {
 			if tk.AccessToken != token {
 				t.Fatalf("unexpected access token %s", tk.AccessToken)
 			}
-			account := client.Account(tk.Account.HomeAccountID)
+			account, err := client.Account(context.Background(), tk.Account.HomeAccountID)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if params.utid == "" {
 				if actual := account.HomeAccountID; actual != "123-456.123-456" {
 					t.Fatalf("expected %q, got %q", "123-456.123-456", actual)

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -630,16 +630,20 @@ func TestTokenProviderOptions(t *testing.T) {
 // testCache is a simple in-memory cache.ExportReplace implementation
 type testCache map[string][]byte
 
-func (c testCache) Export(m cache.Marshaler, key string) {
-	if v, err := m.Marshal(); err == nil {
+func (c testCache) Export(ctx context.Context, m cache.Marshaler, key string) error {
+	v, err := m.Marshal()
+	if err == nil {
 		c[key] = v
 	}
+	return err
 }
 
-func (c testCache) Replace(u cache.Unmarshaler, key string) {
+func (c testCache) Replace(ctx context.Context, u cache.Unmarshaler, key string) error {
+	var err error
 	if v, has := c[key]; has {
-		_ = u.Unmarshal(v)
+		err = u.Unmarshal(v)
 	}
+	return err
 }
 
 func TestWithCache(t *testing.T) {

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -45,8 +45,12 @@ type partitionedManager interface {
 
 type noopCacheAccessor struct{}
 
-func (n noopCacheAccessor) Replace(cache cache.Unmarshaler, key string) {}
-func (n noopCacheAccessor) Export(cache cache.Marshaler, key string)    {}
+func (n noopCacheAccessor) Replace(ctx context.Context, cache cache.Unmarshaler, key string) error {
+	return nil
+}
+func (n noopCacheAccessor) Export(ctx context.Context, cache cache.Marshaler, key string) error {
+	return nil
+}
 
 // AcquireTokenSilentParameters contains the parameters to acquire a token silently (from cache).
 type AcquireTokenSilentParameters struct {
@@ -296,8 +300,8 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 	if authParams.AuthorizationType == authority.ATOnBehalfOf {
 		if s, ok := b.pmanager.(cache.Serializer); ok {
 			suggestedCacheKey := authParams.CacheKey(silent.IsAppCache)
-			b.replace(ctx, s, suggestedCacheKey)
-			defer b.export(ctx, s, suggestedCacheKey)
+			b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+			defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
 		}
 		storageTokenResponse, err = b.pmanager.Read(ctx, authParams)
 		if err != nil {
@@ -306,8 +310,8 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 	} else {
 		if s, ok := b.manager.(cache.Serializer); ok {
 			suggestedCacheKey := authParams.CacheKey(silent.IsAppCache)
-			b.replace(ctx, s, suggestedCacheKey)
-			defer b.export(ctx, s, suggestedCacheKey)
+			b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+			defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
 		}
 		authParams.AuthorizationType = authority.ATRefreshToken
 		storageTokenResponse, err = b.manager.Read(ctx, authParams, silent.Account)
@@ -411,8 +415,8 @@ func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.Au
 	if authParams.AuthorizationType == authority.ATOnBehalfOf {
 		if s, ok := b.pmanager.(cache.Serializer); ok {
 			suggestedCacheKey := token.CacheKey(authParams)
-			b.replace(ctx, s, suggestedCacheKey)
-			defer b.export(ctx, s, suggestedCacheKey)
+			b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+			defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
 		}
 		account, err = b.pmanager.Write(authParams, token)
 		if err != nil {
@@ -421,8 +425,8 @@ func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.Au
 	} else {
 		if s, ok := b.manager.(cache.Serializer); ok {
 			suggestedCacheKey := token.CacheKey(authParams)
-			b.replace(ctx, s, suggestedCacheKey)
-			defer b.export(ctx, s, suggestedCacheKey)
+			b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+			defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
 		}
 		account, err = b.manager.Write(authParams, token)
 		if err != nil {
@@ -435,8 +439,8 @@ func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.Au
 func (b Client) AllAccountsCtx(ctx context.Context) []shared.Account {
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
-		b.replace(ctx, s, suggestedCacheKey)
-		defer b.export(ctx, s, suggestedCacheKey)
+		b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+		defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
 	}
 
 	accounts := b.manager.AllAccounts()
@@ -454,8 +458,8 @@ func (b Client) AccountCtx(ctx context.Context, homeAccountID string) shared.Acc
 	authParams.HomeAccountID = homeAccountID
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
-		b.replace(ctx, s, suggestedCacheKey)
-		defer b.export(ctx, s, suggestedCacheKey)
+		b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+		defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
 	}
 	account := b.manager.Account(homeAccountID)
 	return account
@@ -470,8 +474,8 @@ func (b Client) Account(homeAccountID string) shared.Account {
 func (b Client) RemoveAccountCtx(ctx context.Context, account shared.Account) {
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
-		b.replace(ctx, s, suggestedCacheKey)
-		defer b.export(ctx, s, suggestedCacheKey)
+		b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+		defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
 	}
 	b.manager.RemoveAccount(account, b.AuthParams.ClientID)
 }
@@ -479,24 +483,4 @@ func (b Client) RemoveAccountCtx(ctx context.Context, account shared.Account) {
 // Deprecated: Use RemoveAccountCtx().
 func (b Client) RemoveAccount(account shared.Account) {
 	b.RemoveAccountCtx(context.Background(), account)
-}
-
-// replace is a wrapper around our ExportReplace interface that detects if we are using the newer ExportReplaceCtx
-// or the original ExportReplace for Replace() and handles it appropriately.
-func (b Client) replace(ctx context.Context, unmarshal cache.Unmarshaler, key string) error {
-	if ca, ok := b.cacheAccessor.(cache.ExportReplaceCtx); ok {
-		return ca.ReplaceCtx(ctx, unmarshal, key)
-	}
-	b.cacheAccessor.Replace(unmarshal, key)
-	return nil
-}
-
-// export is a wrapper around our ExportReplace interface that detects if we are using the newer ExportReplaceCtx
-// or the orignal ExportReplace for Export() and handles it appropriately.
-func (b Client) export(ctx context.Context, marshal cache.Marshaler, key string) error {
-	if ca, ok := b.cacheAccessor.(cache.ExportReplaceCtx); ok {
-		return ca.ExportCtx(ctx, marshal, key)
-	}
-	b.cacheAccessor.Export(marshal, key)
-	return nil
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -432,7 +432,7 @@ func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.Au
 	return NewAuthResult(token, account)
 }
 
-func (b Client) AllAccounts(ctx context.Context) []shared.Account {
+func (b Client) AllAccountsCtx(ctx context.Context) []shared.Account {
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
 		b.replace(ctx, s, suggestedCacheKey)
@@ -443,7 +443,12 @@ func (b Client) AllAccounts(ctx context.Context) []shared.Account {
 	return accounts
 }
 
-func (b Client) Account(ctx context.Context, homeAccountID string) shared.Account {
+// Deprecated: Use AllAccountsCtx().
+func (b Client) AllAccounts() []shared.Account {
+	return b.AllAccountsCtx(context.Background())
+}
+
+func (b Client) AccountCtx(ctx context.Context, homeAccountID string) shared.Account {
 	authParams := b.AuthParams // This is a copy, as we dont' have a pointer receiver and .AuthParams is not a pointer.
 	authParams.AuthorizationType = authority.AccountByID
 	authParams.HomeAccountID = homeAccountID
@@ -456,14 +461,24 @@ func (b Client) Account(ctx context.Context, homeAccountID string) shared.Accoun
 	return account
 }
 
-// RemoveAccount removes all the ATs, RTs and IDTs from the cache associated with this account.
-func (b Client) RemoveAccount(ctx context.Context, account shared.Account) {
+// Deprecated: Use AccountCtx().
+func (b Client) Account(homeAccountID string) shared.Account {
+	return b.AccountCtx(context.Background(), homeAccountID)
+}
+
+// RemoveAccountCtx removes all the ATs, RTs and IDTs from the cache associated with this account.
+func (b Client) RemoveAccountCtx(ctx context.Context, account shared.Account) {
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
 		b.replace(ctx, s, suggestedCacheKey)
 		defer b.export(ctx, s, suggestedCacheKey)
 	}
 	b.manager.RemoveAccount(account, b.AuthParams.ClientID)
+}
+
+// Deprecated: Use RemoveAccountCtx().
+func (b Client) RemoveAccount(account shared.Account) {
+	b.RemoveAccountCtx(context.Background(), account)
 }
 
 // replace is a wrapper around our ExportReplace interface that detects if we are using the newer ExportReplaceCtx

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -436,7 +436,7 @@ func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.Au
 	return NewAuthResult(token, account)
 }
 
-func (b Client) AllAccountsCtx(ctx context.Context) []shared.Account {
+func (b Client) AllAccounts(ctx context.Context) ([]shared.Account, error) {
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
 		b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
@@ -444,15 +444,10 @@ func (b Client) AllAccountsCtx(ctx context.Context) []shared.Account {
 	}
 
 	accounts := b.manager.AllAccounts()
-	return accounts
+	return accounts, nil
 }
 
-// Deprecated: Use AllAccountsCtx().
-func (b Client) AllAccounts() []shared.Account {
-	return b.AllAccountsCtx(context.Background())
-}
-
-func (b Client) AccountCtx(ctx context.Context, homeAccountID string) shared.Account {
+func (b Client) Account(ctx context.Context, homeAccountID string) (shared.Account, error) {
 	authParams := b.AuthParams // This is a copy, as we dont' have a pointer receiver and .AuthParams is not a pointer.
 	authParams.AuthorizationType = authority.AccountByID
 	authParams.HomeAccountID = homeAccountID
@@ -462,25 +457,16 @@ func (b Client) AccountCtx(ctx context.Context, homeAccountID string) shared.Acc
 		defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
 	}
 	account := b.manager.Account(homeAccountID)
-	return account
+	return account, nil
 }
 
-// Deprecated: Use AccountCtx().
-func (b Client) Account(homeAccountID string) shared.Account {
-	return b.AccountCtx(context.Background(), homeAccountID)
-}
-
-// RemoveAccountCtx removes all the ATs, RTs and IDTs from the cache associated with this account.
-func (b Client) RemoveAccountCtx(ctx context.Context, account shared.Account) {
+// RemoveAccount removes all the ATs, RTs and IDTs from the cache associated with this account.
+func (b Client) RemoveAccount(ctx context.Context, account shared.Account) error {
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
 		b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
 		defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
 	}
 	b.manager.RemoveAccount(account, b.AuthParams.ClientID)
-}
-
-// Deprecated: Use RemoveAccountCtx().
-func (b Client) RemoveAccount(account shared.Account) {
-	b.RemoveAccountCtx(context.Background(), account)
+	return nil
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -283,12 +283,12 @@ func (b Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, s
 	return baseURL.String(), nil
 }
 
-func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilentParameters) (AuthResult, error) {
+func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilentParameters) (ar AuthResult, err error) {
 	// when tenant == "", the caller didn't specify a tenant and WithTenant will use the client's configured tenant
 	tenant := silent.TenantID
 	authParams, err := b.AuthParams.WithTenant(tenant)
 	if err != nil {
-		return AuthResult{}, err
+		return
 	}
 	authParams.Scopes = silent.Scopes
 	authParams.HomeAccountID = silent.Account.HomeAccountID
@@ -300,37 +300,44 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 	if authParams.AuthorizationType == authority.ATOnBehalfOf {
 		if s, ok := b.pmanager.(cache.Serializer); ok {
 			suggestedCacheKey := authParams.CacheKey(silent.IsAppCache)
-			b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
-			defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
+			err = b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+			if err != nil {
+				return
+			}
+			defer b.export(ctx, s, suggestedCacheKey, &err)
 		}
 		storageTokenResponse, err = b.pmanager.Read(ctx, authParams)
 		if err != nil {
-			return AuthResult{}, err
+			return
 		}
 	} else {
 		if s, ok := b.manager.(cache.Serializer); ok {
 			suggestedCacheKey := authParams.CacheKey(silent.IsAppCache)
-			b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
-			defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
+			err = b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+			if err != nil {
+				return
+			}
+			defer b.export(ctx, s, suggestedCacheKey, &err)
 		}
 		authParams.AuthorizationType = authority.ATRefreshToken
 		storageTokenResponse, err = b.manager.Read(ctx, authParams, silent.Account)
 		if err != nil {
-			return AuthResult{}, err
+			return
 		}
 	}
 
 	// ignore cached access tokens when given claims
 	if silent.Claims == "" {
-		result, err := AuthResultFromStorage(storageTokenResponse)
+		ar, err = AuthResultFromStorage(storageTokenResponse)
 		if err == nil {
-			return result, nil
+			return
 		}
 	}
 
 	// redeem a cached refresh token, if available
 	if reflect.ValueOf(storageTokenResponse.RefreshToken).IsZero() {
-		return AuthResult{}, errors.New("no token found")
+		err = errors.New("no token found")
+		return
 	}
 	var cc *accesstokens.Credential
 	if silent.RequestType == accesstokens.ATConfidential {
@@ -339,10 +346,11 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 
 	token, err := b.Token.Refresh(ctx, silent.RequestType, authParams, cc, storageTokenResponse.RefreshToken)
 	if err != nil {
-		return AuthResult{}, err
+		return
 	}
 
-	return b.AuthResultFromToken(ctx, authParams, token, true)
+	ar, err = b.AuthResultFromToken(ctx, authParams, token, true)
+	return
 }
 
 func (b Client) AcquireTokenByAuthCode(ctx context.Context, authCodeParams AcquireTokenAuthCodeParameters) (AuthResult, error) {
@@ -405,68 +413,95 @@ func (b Client) AcquireTokenOnBehalfOf(ctx context.Context, onBehalfOfParams Acq
 	return ar, err
 }
 
-func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.AuthParams, token accesstokens.TokenResponse, cacheWrite bool) (AuthResult, error) {
+func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.AuthParams, token accesstokens.TokenResponse, cacheWrite bool) (ar AuthResult, err error) {
 	if !cacheWrite {
 		return NewAuthResult(token, shared.Account{})
 	}
 
 	var account shared.Account
-	var err error
 	if authParams.AuthorizationType == authority.ATOnBehalfOf {
 		if s, ok := b.pmanager.(cache.Serializer); ok {
 			suggestedCacheKey := token.CacheKey(authParams)
-			b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
-			defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
+			err = b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+			if err != nil {
+				return
+			}
+			defer b.export(ctx, s, suggestedCacheKey, &err)
 		}
 		account, err = b.pmanager.Write(authParams, token)
 		if err != nil {
-			return AuthResult{}, err
+			return
 		}
 	} else {
 		if s, ok := b.manager.(cache.Serializer); ok {
 			suggestedCacheKey := token.CacheKey(authParams)
-			b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
-			defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
+			err = b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+			if err != nil {
+				return
+			}
+			defer b.export(ctx, s, suggestedCacheKey, &err)
 		}
 		account, err = b.manager.Write(authParams, token)
 		if err != nil {
-			return AuthResult{}, err
+			return
 		}
 	}
-	return NewAuthResult(token, account)
+	ar, err = NewAuthResult(token, account)
+	return
 }
 
-func (b Client) AllAccounts(ctx context.Context) ([]shared.Account, error) {
+func (b Client) AllAccounts(ctx context.Context) (accts []shared.Account, err error) {
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
-		b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
-		defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
+		err = b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+		if err != nil {
+			return
+		}
+		defer b.export(ctx, s, suggestedCacheKey, &err)
 	}
 
-	accounts := b.manager.AllAccounts()
-	return accounts, nil
+	accts = b.manager.AllAccounts()
+	return
 }
 
-func (b Client) Account(ctx context.Context, homeAccountID string) (shared.Account, error) {
+func (b Client) Account(ctx context.Context, homeAccountID string) (acct shared.Account, err error) {
 	authParams := b.AuthParams // This is a copy, as we dont' have a pointer receiver and .AuthParams is not a pointer.
 	authParams.AuthorizationType = authority.AccountByID
 	authParams.HomeAccountID = homeAccountID
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
-		b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
-		defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
+		err = b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+		if err != nil {
+			return
+		}
+		defer b.export(ctx, s, suggestedCacheKey, &err)
 	}
-	account := b.manager.Account(homeAccountID)
-	return account, nil
+	acct = b.manager.Account(homeAccountID)
+	return
 }
 
 // RemoveAccount removes all the ATs, RTs and IDTs from the cache associated with this account.
-func (b Client) RemoveAccount(ctx context.Context, account shared.Account) error {
+func (b Client) RemoveAccount(ctx context.Context, account shared.Account) (err error) {
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
-		b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
-		defer b.cacheAccessor.Export(ctx, s, suggestedCacheKey)
+		err = b.cacheAccessor.Replace(ctx, s, suggestedCacheKey)
+		if err != nil {
+			return
+		}
+		defer b.export(ctx, s, suggestedCacheKey, &err)
 	}
 	b.manager.RemoveAccount(account, b.AuthParams.ClientID)
-	return nil
+	return
+}
+
+// export is a helper for returning errors from the cache accessor's Export method. This helper
+// assigns errors returned by that method to *err if and only if *err is nil. This helps callers
+// swallow Export errors when they have a more important error to return, but return them when
+// an operation otherwise succeeded.
+//
+// TODO: use errors.Join from Go 1.20 to return both errors instead
+func (b Client) export(ctx context.Context, marshal cache.Marshaler, key string, err *error) {
+	if e := b.cacheAccessor.Export(ctx, marshal, key); e != nil && *err == nil {
+		*err = e
+	}
 }

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -87,7 +87,6 @@ func TestIsMatchingScopes(t *testing.T) {
 }
 
 func TestAllAccounts(t *testing.T) {
-	ctx := context.Background()
 	testAccOne := shared.NewAccount("hid", "env", "realm", "lid", accAuth, "username")
 	testAccTwo := shared.NewAccount("HID", "ENV", "REALM", "LID", accAuth, "USERNAME")
 	cache := &Contract{
@@ -100,8 +99,8 @@ func TestAllAccounts(t *testing.T) {
 	storageManager := Manager{}
 	storageManager.update(cache)
 
-	actualAccounts := storageManager.AllAccountsCtx(ctx)
-	// AllAccountsCtx() is unstable in that the order can be reversed between calls.
+	actualAccounts := storageManager.AllAccounts()
+	// AllAccounts() is unstable in that the order can be reversed between calls.
 	// This fixes that.
 	sort.Slice(
 		actualAccounts,

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -87,6 +87,7 @@ func TestIsMatchingScopes(t *testing.T) {
 }
 
 func TestAllAccounts(t *testing.T) {
+	ctx := context.Background()
 	testAccOne := shared.NewAccount("hid", "env", "realm", "lid", accAuth, "username")
 	testAccTwo := shared.NewAccount("HID", "ENV", "REALM", "LID", accAuth, "USERNAME")
 	cache := &Contract{
@@ -99,8 +100,8 @@ func TestAllAccounts(t *testing.T) {
 	storageManager := Manager{}
 	storageManager.update(cache)
 
-	actualAccounts := storageManager.AllAccounts()
-	// AllAccounts() is unstable in that the order can be reversed between calls.
+	actualAccounts := storageManager.AllAccountsCtx(ctx)
+	// AllAccountsCtx() is unstable in that the order can be reversed between calls.
 	// This fixes that.
 	sort.Slice(
 		actualAccounts,

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -473,32 +473,15 @@ func (pca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redir
 	return pca.base.AcquireTokenByAuthCode(ctx, params)
 }
 
-// AccountsCtx gets all the accounts in the token cache.
-// If there are no accounts in the cache the returned slice is empty.
-func (pca Client) AccountsCtx(ctx context.Context) []Account {
-	return pca.base.AllAccountsCtx(ctx)
-}
-
-// RemoveAccountCtx signs the account out and forgets account from token cache.
-func (pca Client) RemoveAccountCtx(ctx context.Context, account Account) error {
-	pca.base.RemoveAccountCtx(ctx, account)
-	return nil
-}
-
 // Accounts gets all the accounts in the token cache.
 // If there are no accounts in the cache the returned slice is empty.
-//
-// Deprecated: This method is deprecated for AccountsCtx().
-func (pca Client) Accounts() []Account {
-	return pca.base.AllAccountsCtx(context.Background())
+func (pca Client) Accounts(ctx context.Context) ([]Account, error) {
+	return pca.base.AllAccounts(ctx)
 }
 
 // RemoveAccount signs the account out and forgets account from token cache.
-//
-// Deprecated: This method is deprecated for RemoveAccountCtx().
-func (pca Client) RemoveAccount(account Account) error {
-	pca.base.RemoveAccountCtx(context.Background(), account)
-	return nil
+func (pca Client) RemoveAccount(ctx context.Context, account Account) error {
+	return pca.base.RemoveAccount(ctx, account)
 }
 
 // InteractiveAuthOptions contains the optional parameters used to acquire an access token for interactive auth code flow.

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -476,12 +476,12 @@ func (pca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redir
 // AccountsCtx gets all the accounts in the token cache.
 // If there are no accounts in the cache the returned slice is empty.
 func (pca Client) AccountsCtx(ctx context.Context) []Account {
-	return pca.base.AllAccounts(ctx)
+	return pca.base.AllAccountsCtx(ctx)
 }
 
 // RemoveAccountCtx signs the account out and forgets account from token cache.
 func (pca Client) RemoveAccountCtx(ctx context.Context, account Account) error {
-	pca.base.RemoveAccount(ctx, account)
+	pca.base.RemoveAccountCtx(ctx, account)
 	return nil
 }
 
@@ -490,14 +490,14 @@ func (pca Client) RemoveAccountCtx(ctx context.Context, account Account) error {
 //
 // Deprecated: This method is deprecated for AccountsCtx().
 func (pca Client) Accounts() []Account {
-	return pca.base.AllAccounts(context.Background())
+	return pca.base.AllAccountsCtx(context.Background())
 }
 
 // RemoveAccount signs the account out and forgets account from token cache.
 //
 // Deprecated: This method is deprecated for RemoveAccountCtx().
 func (pca Client) RemoveAccount(account Account) error {
-	pca.base.RemoveAccount(context.Background(), account)
+	pca.base.RemoveAccountCtx(context.Background(), account)
 	return nil
 }
 

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -473,15 +473,31 @@ func (pca Client) AcquireTokenByAuthCode(ctx context.Context, code string, redir
 	return pca.base.AcquireTokenByAuthCode(ctx, params)
 }
 
+// AccountsCtx gets all the accounts in the token cache.
+// If there are no accounts in the cache the returned slice is empty.
+func (pca Client) AccountsCtx(ctx context.Context) []Account {
+	return pca.base.AllAccounts(ctx)
+}
+
+// RemoveAccountCtx signs the account out and forgets account from token cache.
+func (pca Client) RemoveAccountCtx(ctx context.Context, account Account) error {
+	pca.base.RemoveAccount(ctx, account)
+	return nil
+}
+
 // Accounts gets all the accounts in the token cache.
 // If there are no accounts in the cache the returned slice is empty.
+//
+// Deprecated: This method is deprecated for AccountsCtx().
 func (pca Client) Accounts() []Account {
-	return pca.base.AllAccounts()
+	return pca.base.AllAccounts(context.Background())
 }
 
 // RemoveAccount signs the account out and forgets account from token cache.
+//
+// Deprecated: This method is deprecated for RemoveAccountCtx().
 func (pca Client) RemoveAccount(account Account) error {
-	pca.base.RemoveAccount(account)
+	pca.base.RemoveAccount(context.Background(), account)
 	return nil
 }
 

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -363,16 +363,18 @@ type testCache struct {
 	store map[string][]byte
 }
 
-func (c *testCache) Export(m cache.Marshaler, key string) {
+func (c *testCache) Export(ctx context.Context, m cache.Marshaler, key string) error {
 	if v, err := m.Marshal(); err == nil {
 		c.store[key] = v
 	}
+	return nil
 }
 
-func (c *testCache) Replace(u cache.Unmarshaler, key string) {
+func (c *testCache) Replace(ctx context.Context, u cache.Unmarshaler, key string) error {
 	if v, has := c.store[key]; has {
 		_ = u.Unmarshal(v)
 	}
+	return nil
 }
 
 func TestWithCache(t *testing.T) {

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -368,15 +368,16 @@ type testCache struct {
 }
 
 func (c *testCache) Export(ctx context.Context, m cache.Marshaler, key string) error {
-	if v, err := m.Marshal(); err == nil {
+	v, err := m.Marshal()
+	if err == nil {
 		c.store[key] = v
 	}
-	return nil
+	return err
 }
 
 func (c *testCache) Replace(ctx context.Context, u cache.Unmarshaler, key string) error {
 	if v, has := c.store[key]; has {
-		_ = u.Unmarshal(v)
+		return u.Unmarshal(v)
 	}
 	return nil
 }

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -146,8 +146,12 @@ func TestAcquireTokenSilentWithTenantID(t *testing.T) {
 
 	// cache should return the correct access token for each tenant
 	var account Account
-	if accounts := client.Accounts(); len(accounts) == 2 {
-		// expecting one account for each tenant we authenticated in above
+	accounts, err := client.Accounts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// expecting one account for each tenant we authenticated in above
+	if len(accounts) == 2 {
 		account = accounts[0]
 	} else {
 		t.Fatalf("expected 2 accounts but got %d", len(accounts))
@@ -410,7 +414,10 @@ func TestWithCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	accounts := client.Accounts()
+	accounts, err := client.Accounts(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if actual := len(accounts); actual != 1 {
 		t.Fatalf("expected 1 account but cache contains %d", actual)
 	}

--- a/apps/tests/devapps/confidential_auth_code_sample.go
+++ b/apps/tests/devapps/confidential_auth_code_sample.go
@@ -77,7 +77,7 @@ func acquireByAuthorizationCodeConfidential(ctx context.Context) {
 		log.Fatal(err)
 	}
 	var userAccount shared.Account
-	for _, account := range app.AccountsCtx(ctx) {
+	for _, account := range app.Accounts(ctx) {
 		if account.PreferredUsername == confidentialConfig.Username {
 			userAccount = account
 		}

--- a/apps/tests/devapps/confidential_auth_code_sample.go
+++ b/apps/tests/devapps/confidential_auth_code_sample.go
@@ -58,7 +58,7 @@ func getTokenConfidential(w http.ResponseWriter, r *http.Request) {
 // TODO(msal): Needs to use an x509 certificate like the other now that we are not using a
 // thumbprint directly.
 /*
-func acquireByAuthorizationCodeConfidential() {
+func acquireByAuthorizationCodeConfidential(ctx context.Context) {
 	key, err := os.ReadFile(confidentialConfig.KeyFile)
 	if err != nil {
 		log.Fatal(err)
@@ -77,7 +77,7 @@ func acquireByAuthorizationCodeConfidential() {
 		log.Fatal(err)
 	}
 	var userAccount shared.Account
-	for _, account := range app.Accounts() {
+	for _, account := range app.AccountsCtx(ctx) {
 		if account.PreferredUsername == confidentialConfig.Username {
 			userAccount = account
 		}

--- a/apps/tests/devapps/device_code_flow_sample.go
+++ b/apps/tests/devapps/device_code_flow_sample.go
@@ -21,7 +21,10 @@ func acquireTokenDeviceCode() {
 
 	// look in the cache to see if the account to use has been cached
 	var userAccount public.Account
-	accounts := app.Accounts()
+	accounts, err := app.Accounts(context.Background())
+	if err != nil {
+		panic("failed to read the cache")
+	}
 	for _, account := range accounts {
 		if account.PreferredUsername == config.Username {
 			userAccount = account

--- a/apps/tests/devapps/main.go
+++ b/apps/tests/devapps/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 )
 
@@ -10,6 +11,8 @@ var (
 )
 
 func main() {
+	ctx := context.Background()
+
 	// TODO(msal): This is pretty yikes. At least we should use the flag package.
 	exampleType := os.Args[1]
 	if exampleType == "1" {
@@ -18,7 +21,7 @@ func main() {
 		acquireByAuthorizationCodePublic()
 		*/
 	} else if exampleType == "3" {
-		acquireByUsernamePasswordPublic()
+		acquireByUsernamePasswordPublic(ctx)
 	} else if exampleType == "4" {
 		panic("currently not implemented")
 		//acquireByAuthorizationCodeConfidential()

--- a/apps/tests/devapps/main.go
+++ b/apps/tests/devapps/main.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	//config        = CreateConfig("config.json")
-	cacheAccessor = &TokenCache{"serialized_cache.json"}
+	cacheAccessor = &TokenCache{file: "serialized_cache.json"}
 )
 
 func main() {

--- a/apps/tests/devapps/sample_cache_accessor.go
+++ b/apps/tests/devapps/sample_cache_accessor.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 
@@ -12,9 +13,14 @@ import (
 
 type TokenCache struct {
 	file string
+
+	// This will satisfy the ExportReplace and ExportReplaceCtx interfaces.
+	// We do not need to implement the Replace() or Export() methods as
+	// ReplaceCtx() and ExportCtx() will be chosen on each call.
+	cache.ExportReplaceCtx
 }
 
-func (t *TokenCache) Replace(cache cache.Unmarshaler, key string) {
+func (t *TokenCache) ReplaceCtx(ctx context.Context, cache cache.Unmarshaler, key string) {
 	data, err := os.ReadFile(t.file)
 	if err != nil {
 		log.Println(err)
@@ -25,7 +31,7 @@ func (t *TokenCache) Replace(cache cache.Unmarshaler, key string) {
 	}
 }
 
-func (t *TokenCache) Export(cache cache.Marshaler, key string) {
+func (t *TokenCache) ExportCtx(ctx context.Context, cache cache.Marshaler, key string) {
 	data, err := cache.Marshal()
 	if err != nil {
 		log.Println(err)

--- a/apps/tests/devapps/sample_cache_accessor.go
+++ b/apps/tests/devapps/sample_cache_accessor.go
@@ -13,31 +13,20 @@ import (
 
 type TokenCache struct {
 	file string
-
-	// This will satisfy the ExportReplace and ExportReplaceCtx interfaces.
-	// We do not need to implement the Replace() or Export() methods as
-	// ReplaceCtx() and ExportCtx() will be chosen on each call.
-	cache.ExportReplaceCtx
 }
 
-func (t *TokenCache) ReplaceCtx(ctx context.Context, cache cache.Unmarshaler, key string) {
+func (t *TokenCache) Replace(ctx context.Context, cache cache.Unmarshaler, key string) error {
 	data, err := os.ReadFile(t.file)
 	if err != nil {
 		log.Println(err)
 	}
-	err = cache.Unmarshal(data)
-	if err != nil {
-		log.Println(err)
-	}
+	return cache.Unmarshal(data)
 }
 
-func (t *TokenCache) ExportCtx(ctx context.Context, cache cache.Marshaler, key string) {
+func (t *TokenCache) Export(ctx context.Context, cache cache.Marshaler, key string) error {
 	data, err := cache.Marshal()
 	if err != nil {
 		log.Println(err)
 	}
-	err = os.WriteFile(t.file, data, 0600)
-	if err != nil {
-		log.Println(err)
-	}
+	return os.WriteFile(t.file, data, 0600)
 }

--- a/apps/tests/devapps/username_password_sample.go
+++ b/apps/tests/devapps/username_password_sample.go
@@ -20,7 +20,10 @@ func acquireByUsernamePasswordPublic(ctx context.Context) {
 
 	// look in the cache to see if the account to use has been cached
 	var userAccount public.Account
-	accounts := app.AccountsCtx(ctx)
+	accounts, err := app.Accounts(ctx)
+	if err != nil {
+		panic("failed to read the cache")
+	}
 	for _, account := range accounts {
 		if account.PreferredUsername == config.Username {
 			userAccount = account

--- a/apps/tests/devapps/username_password_sample.go
+++ b/apps/tests/devapps/username_password_sample.go
@@ -11,7 +11,7 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 )
 
-func acquireByUsernamePasswordPublic() {
+func acquireByUsernamePasswordPublic(ctx context.Context) {
 	config := CreateConfig("config.json")
 	app, err := public.New(config.ClientID, public.WithCache(cacheAccessor), public.WithAuthority(config.Authority))
 	if err != nil {
@@ -20,7 +20,7 @@ func acquireByUsernamePasswordPublic() {
 
 	// look in the cache to see if the account to use has been cached
 	var userAccount public.Account
-	accounts := app.Accounts()
+	accounts := app.AccountsCtx(ctx)
 	for _, account := range accounts {
 		if account.PreferredUsername == config.Username {
 			userAccount = account

--- a/apps/tests/integration/integration_test.go
+++ b/apps/tests/integration/integration_test.go
@@ -390,12 +390,12 @@ func TestRemoveAccount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestRemoveAccount: on AcquireTokenByUsernamePassword(): got err == %s, want err == nil", errors.Verbose(err))
 	}
-	accounts := app.Accounts()
+	accounts := app.AccountsCtx(ctx)
 	if len(accounts) == 0 {
 		t.Fatal("TestRemoveAccount: No user accounts found in cache")
 	}
 	testAccount := accounts[0] // Only one account is populated and that is what we will remove.
-	err = app.RemoveAccount(testAccount)
+	err = app.RemoveAccountCtx(ctx, testAccount)
 	if err != nil {
 		t.Fatalf("TestRemoveAccount: on RemoveAccount(): got err == %s, want err == nil", errors.Verbose(err))
 	}

--- a/apps/tests/integration/integration_test.go
+++ b/apps/tests/integration/integration_test.go
@@ -390,12 +390,15 @@ func TestRemoveAccount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestRemoveAccount: on AcquireTokenByUsernamePassword(): got err == %s, want err == nil", errors.Verbose(err))
 	}
-	accounts := app.AccountsCtx(ctx)
+	accounts, err := app.Accounts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(accounts) == 0 {
 		t.Fatal("TestRemoveAccount: No user accounts found in cache")
 	}
 	testAccount := accounts[0] // Only one account is populated and that is what we will remove.
-	err = app.RemoveAccountCtx(ctx, testAccount)
+	err = app.RemoveAccount(ctx, testAccount)
 	if err != nil {
 		t.Fatalf("TestRemoveAccount: on RemoveAccount(): got err == %s, want err == nil", errors.Verbose(err))
 	}


### PR DESCRIPTION
This PR adds support for the Context object in caches that are implementing a cache.

We cannot update ExportReplace without breaking implementors, so we are introducing an ExportReplaceCtx as a superset.

Calls that use methods from ExportReplace will now check for the existence of ExportReplaceCtx and use those superset methods instead if available.
