### PR TITLE
Delete vestigial option function types

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -581,11 +581,6 @@ type AcquireSilentOption interface {
 	acquireSilentOption()
 }
 
-// AcquireTokenSilentOption changes options inside AcquireTokenSilentOptions used in .AcquireTokenSilent().
-type AcquireTokenSilentOption func(a *AcquireTokenSilentOptions)
-
-func (AcquireTokenSilentOption) acquireSilentOption() {}
-
 // WithSilentAccount uses the passed account during an AcquireTokenSilent() call.
 func WithSilentAccount(account Account) interface {
 	AcquireSilentOption
@@ -645,11 +640,6 @@ type AcquireTokenByAuthCodeOptions struct {
 type AcquireByAuthCodeOption interface {
 	acquireByAuthCodeOption()
 }
-
-// AcquireTokenByAuthCodeOption changes options inside AcquireTokenByAuthCodeOptions used in .AcquireTokenByAuthCode().
-type AcquireTokenByAuthCodeOption func(a *AcquireTokenByAuthCodeOptions)
-
-func (AcquireTokenByAuthCodeOption) acquireByAuthCodeOption() {}
 
 // WithChallenge allows you to provide a challenge for the .AcquireTokenByAuthCode() call.
 func WithChallenge(challenge string) interface {

--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -5,4 +5,4 @@
 package version
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "0.8.1"
+const Version = "0.9.0"

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -499,11 +499,6 @@ type AcquireInteractiveOption interface {
 	acquireInteractiveOption()
 }
 
-// InteractiveAuthOption changes options inside InteractiveAuthOptions used in .AcquireTokenInteractive().
-type InteractiveAuthOption func(*InteractiveAuthOptions)
-
-func (InteractiveAuthOption) acquireInteractiveOption() {}
-
 // WithLoginHint pre-populates the login prompt with a username.
 func WithLoginHint(username string) interface {
 	AcquireInteractiveOption

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -275,11 +275,6 @@ type AcquireSilentOption interface {
 	acquireSilentOption()
 }
 
-// AcquireTokenSilentOption changes options inside AcquireTokenSilentOptions used in .AcquireTokenSilent().
-type AcquireTokenSilentOption func(a *AcquireTokenSilentOptions)
-
-func (AcquireTokenSilentOption) acquireSilentOption() {}
-
 // WithSilentAccount uses the passed account during an AcquireTokenSilent() call.
 func WithSilentAccount(account Account) interface {
 	AcquireSilentOption
@@ -431,11 +426,6 @@ type AcquireTokenByAuthCodeOptions struct {
 type AcquireByAuthCodeOption interface {
 	acquireByAuthCodeOption()
 }
-
-// AcquireTokenByAuthCodeOption changes options inside AcquireTokenByAuthCodeOptions used in .AcquireTokenByAuthCode().
-type AcquireTokenByAuthCodeOption func(a *AcquireTokenByAuthCodeOptions)
-
-func (AcquireTokenByAuthCodeOption) acquireByAuthCodeOption() {}
 
 // WithChallenge allows you to provide a code for the .AcquireTokenByAuthCode() call.
 func WithChallenge(challenge string) interface {


### PR DESCRIPTION
Part of #380. These types are no longer used after being superseded by the `CallOptions` API added in #343. Technically a breaking change but it would be strange for applications to reference these types.