### PR TITLE
Rename public client CreateAuthCodeURL -> AuthCodeURL

### DIFF
--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -144,21 +144,21 @@ func New(clientID string, options ...Option) (Client, error) {
 	return Client{base}, nil
 }
 
-// createAuthCodeURLOptions contains options for CreateAuthCodeURL
-type createAuthCodeURLOptions struct {
+// authCodeURLOptions contains options for AuthCodeURL
+type authCodeURLOptions struct {
 	claims, loginHint, tenantID, domainHint string
 }
 
-// CreateAuthCodeURLOption is implemented by options for CreateAuthCodeURL
-type CreateAuthCodeURLOption interface {
-	createAuthCodeURLOption()
+// AuthCodeURLOption is implemented by options for AuthCodeURL
+type AuthCodeURLOption interface {
+	authCodeURLOption()
 }
 
-// CreateAuthCodeURL creates a URL used to acquire an authorization code.
+// AuthCodeURL creates a URL used to acquire an authorization code.
 //
 // Options: [WithClaims], [WithDomainHint], [WithLoginHint], [WithTenantID]
-func (pca Client) CreateAuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...CreateAuthCodeURLOption) (string, error) {
-	o := createAuthCodeURLOptions{}
+func (pca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...AuthCodeURLOption) (string, error) {
+	o := authCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
 		return "", err
 	}
@@ -181,7 +181,7 @@ func WithClaims(claims string) interface {
 	AcquireByUsernamePasswordOption
 	AcquireInteractiveOption
 	AcquireSilentOption
-	CreateAuthCodeURLOption
+	AuthCodeURLOption
 	options.CallOption
 } {
 	return struct {
@@ -190,7 +190,7 @@ func WithClaims(claims string) interface {
 		AcquireByUsernamePasswordOption
 		AcquireInteractiveOption
 		AcquireSilentOption
-		CreateAuthCodeURLOption
+		AuthCodeURLOption
 		options.CallOption
 	}{
 		CallOption: options.NewCallOption(
@@ -204,7 +204,7 @@ func WithClaims(claims string) interface {
 					t.claims = claims
 				case *AcquireTokenSilentOptions:
 					t.claims = claims
-				case *createAuthCodeURLOptions:
+				case *authCodeURLOptions:
 					t.claims = claims
 				case *InteractiveAuthOptions:
 					t.claims = claims
@@ -225,7 +225,7 @@ func WithTenantID(tenantID string) interface {
 	AcquireByUsernamePasswordOption
 	AcquireInteractiveOption
 	AcquireSilentOption
-	CreateAuthCodeURLOption
+	AuthCodeURLOption
 	options.CallOption
 } {
 	return struct {
@@ -234,7 +234,7 @@ func WithTenantID(tenantID string) interface {
 		AcquireByUsernamePasswordOption
 		AcquireInteractiveOption
 		AcquireSilentOption
-		CreateAuthCodeURLOption
+		AuthCodeURLOption
 		options.CallOption
 	}{
 		CallOption: options.NewCallOption(
@@ -248,7 +248,7 @@ func WithTenantID(tenantID string) interface {
 					t.tenantID = tenantID
 				case *AcquireTokenSilentOptions:
 					t.tenantID = tenantID
-				case *createAuthCodeURLOptions:
+				case *authCodeURLOptions:
 					t.tenantID = tenantID
 				case *InteractiveAuthOptions:
 					t.tenantID = tenantID
@@ -517,18 +517,18 @@ func (InteractiveAuthOption) acquireInteractiveOption() {}
 // WithLoginHint pre-populates the login prompt with a username.
 func WithLoginHint(username string) interface {
 	AcquireInteractiveOption
-	CreateAuthCodeURLOption
+	AuthCodeURLOption
 	options.CallOption
 } {
 	return struct {
 		AcquireInteractiveOption
-		CreateAuthCodeURLOption
+		AuthCodeURLOption
 		options.CallOption
 	}{
 		CallOption: options.NewCallOption(
 			func(a any) error {
 				switch t := a.(type) {
-				case *createAuthCodeURLOptions:
+				case *authCodeURLOptions:
 					t.loginHint = username
 				case *InteractiveAuthOptions:
 					t.loginHint = username
@@ -544,18 +544,18 @@ func WithLoginHint(username string) interface {
 // WithDomainHint adds the IdP domain as domain_hint query parameter in the auth url.
 func WithDomainHint(domain string) interface {
 	AcquireInteractiveOption
-	CreateAuthCodeURLOption
+	AuthCodeURLOption
 	options.CallOption
 } {
 	return struct {
 		AcquireInteractiveOption
-		CreateAuthCodeURLOption
+		AuthCodeURLOption
 		options.CallOption
 	}{
 		CallOption: options.NewCallOption(
 			func(a any) error {
 				switch t := a.(type) {
-				case *createAuthCodeURLOptions:
+				case *authCodeURLOptions:
 					t.domainHint = domain
 				case *InteractiveAuthOptions:
 					t.domainHint = domain

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -233,7 +233,7 @@ func TestAcquireTokenWithTenantID(t *testing.T) {
 				case "authcode":
 					ar, err = client.AcquireTokenByAuthCode(ctx, "auth code", "https://localhost", tokenScope, WithTenantID(test.tenant))
 				case "authcodeURL":
-					URL, err = client.CreateAuthCodeURL(ctx, "client-id", "https://localhost", tokenScope, WithTenantID(test.tenant))
+					URL, err = client.AuthCodeURL(ctx, "client-id", "https://localhost", tokenScope, WithTenantID(test.tenant))
 				case "devicecode":
 					dc, err = client.AcquireTokenByDeviceCode(ctx, tokenScope, WithTenantID(test.tenant))
 				case "interactive":
@@ -536,7 +536,7 @@ func TestWithClaims(t *testing.T) {
 					ar, err = client.AcquireTokenByAuthCode(ctx, "auth code", "https://localhost", tokenScope, WithClaims(test.claims))
 				case "authcodeURL":
 					u := ""
-					if u, err = client.CreateAuthCodeURL(ctx, "client-id", "https://localhost", tokenScope, WithClaims(test.claims)); err == nil {
+					if u, err = client.AuthCodeURL(ctx, "client-id", "https://localhost", tokenScope, WithClaims(test.claims)); err == nil {
 						var parsed *url.URL
 						if parsed, err = url.Parse(u); err == nil {
 							validate(t, parsed.Query())
@@ -693,7 +693,7 @@ func TestWithLoginHint(t *testing.T) {
 				return fakeBrowserOpenURL(authURL)
 			}
 			acquireOpts := []AcquireInteractiveOption{}
-			urlOpts := []CreateAuthCodeURLOption{}
+			urlOpts := []AuthCodeURLOption{}
 			if expectHint {
 				acquireOpts = append(acquireOpts, WithLoginHint(upn))
 				urlOpts = append(urlOpts, WithLoginHint(upn))
@@ -705,7 +705,7 @@ func TestWithLoginHint(t *testing.T) {
 			if !called {
 				t.Fatal("browserOpenURL wasn't called")
 			}
-			u, err := client.CreateAuthCodeURL(context.Background(), "id", "https://localhost", tokenScope, urlOpts...)
+			u, err := client.AuthCodeURL(context.Background(), "id", "https://localhost", tokenScope, urlOpts...)
 			if err == nil {
 				var parsed *url.URL
 				parsed, err = url.Parse(u)
@@ -767,7 +767,7 @@ func TestWithDomainHint(t *testing.T) {
 				return fakeBrowserOpenURL(authURL)
 			}
 			var acquireOpts []AcquireInteractiveOption
-			var urlOpts []CreateAuthCodeURLOption
+			var urlOpts []AuthCodeURLOption
 			if expectHint {
 				acquireOpts = append(acquireOpts, WithDomainHint(domain))
 				urlOpts = append(urlOpts, WithDomainHint(domain))
@@ -779,7 +779,7 @@ func TestWithDomainHint(t *testing.T) {
 			if !called {
 				t.Fatal("browserOpenURL wasn't called")
 			}
-			u, err := client.CreateAuthCodeURL(context.Background(), "id", "https://localhost", tokenScope, urlOpts...)
+			u, err := client.AuthCodeURL(context.Background(), "id", "https://localhost", tokenScope, urlOpts...)
 			if err == nil {
 				var parsed *url.URL
 				parsed, err = url.Parse(u)

--- a/apps/tests/devapps/authorization_code_sample.go
+++ b/apps/tests/devapps/authorization_code_sample.go
@@ -51,7 +51,7 @@ func redirectToURL(w http.ResponseWriter, r *http.Request) {
 	authCodeURLParams := msal.CreateAuthorizationCodeURLParameters(config.ClientID, config.RedirectURI, config.Scopes)
 	authCodeURLParams.CodeChallenge = config.CodeChallenge
 	authCodeURLParams.State = config.State
-	authURL, err := publicClientApp.CreateAuthCodeURL(context.Background(), authCodeURLParams)
+	authURL, err := publicClientApp.AuthCodeURL(context.Background(), authCodeURLParams)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/apps/tests/devapps/confidential_auth_code_sample.go
+++ b/apps/tests/devapps/confidential_auth_code_sample.go
@@ -17,7 +17,7 @@ func redirectToURLConfidential(w http.ResponseWriter, r *http.Request) {
 	// Getting the URL to redirect to acquire the authorization code
 	authCodeURLParams.CodeChallenge = confidentialConfig.CodeChallenge
 	authCodeURLParams.State = confidentialConfig.State
-	authURL, err := app.CreateAuthCodeURL(context.Background(), confidentialConfig.ClientID, confidentialConfig.RedirectURI, confidentialConfig.Scopes)
+	authURL, err := app.AuthCodeURL(context.Background(), confidentialConfig.ClientID, confidentialConfig.RedirectURI, confidentialConfig.Scopes)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return


### PR DESCRIPTION
Closes #371, part of #380. Confidential client has `AuthCodeURL`, public client has `CreateAuthCodeURL`. Either name is okay but there should only be one. I chose `AuthCodeURL` because it doesn't imply creating a server-side resource and is shorter.