### PR TITLE
Rename confidential.WithAccessor to WithCache

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -256,7 +256,7 @@ type Client struct {
 // returning Option calls.
 type Options struct {
 	// Accessor controls cache persistence.
-	// By default there is no cache persistence. This can be set using the WithAccessor() option.
+	// By default there is no cache persistence. This can be set using the WithCache() option.
 	Accessor cache.ExportReplace
 
 	// The host of the Azure Active Directory authority.
@@ -300,9 +300,8 @@ func WithAuthority(authority string) Option {
 	}
 }
 
-// WithAccessor provides a cache accessor that will read and write to some externally managed cache
-// that may or may not be shared with other applications.
-func WithAccessor(accessor cache.ExportReplace) Option {
+// WithCache provides an accessor that will read and write authentication data to an externally managed cache.
+func WithCache(accessor cache.ExportReplace) Option {
 	return func(o *Options) {
 		o.Accessor = accessor
 	}

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -32,11 +32,6 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 )
 
-const (
-	authorityFmt = "https://%s/%s"
-	localhost    = "http://localhost"
-)
-
 // errorClient is an HTTP client for tests that should fail when confidential.Client sends a request
 type errorClient struct{}
 
@@ -69,10 +64,12 @@ func TestCertFromPEM(t *testing.T) {
 }
 
 const (
+	authorityFmt      = "https://%s/%s"
 	fakeClientID      = "fake_client_id"
 	fakeTokenEndpoint = "https://fake_authority/fake/token"
-	token             = "fake_token"
+	localhost         = "http://localhost"
 	refresh           = "fake_refresh"
+	token             = "fake_token"
 )
 
 var tokenScope = []string{"the_scope"}
@@ -617,7 +614,7 @@ func TestTokenProviderOptions(t *testing.T) {
 		}
 		return TokenProviderResult{AccessToken: accessToken, ExpiresInSeconds: 3600}, nil
 	})
-	client, err := New("id", cred, WithHTTPClient(&errorClient{}))
+	client, err := New(fakeClientID, cred, WithHTTPClient(&errorClient{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -659,7 +656,7 @@ func TestWithCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client, err := New("client-id", cred, WithAuthority(authorityA), WithCache(&cache), WithHTTPClient(&mockClient))
+	client, err := New(fakeClientID, cred, WithAuthority(authorityA), WithCache(&cache), WithHTTPClient(&mockClient))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -677,7 +674,7 @@ func TestWithCache(t *testing.T) {
 	}
 
 	// a client configured for a different tenant should be able to authenticate silently with the shared cache's data
-	client, err = New("client-id", cred, WithAuthority(authorityB), WithCache(&cache), WithHTTPClient(&mockClient))
+	client, err = New(fakeClientID, cred, WithAuthority(authorityB), WithCache(&cache), WithHTTPClient(&mockClient))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -786,7 +783,7 @@ func TestWithClaims(t *testing.T) {
 					ar, err = client.AcquireTokenByAuthCode(ctx, "code", localhost, tokenScope, WithClaims(test.claims))
 				case "authcodeURL":
 					u := ""
-					if u, err = client.AuthCodeURL(ctx, "client-id", localhost, tokenScope, WithClaims(test.claims)); err == nil {
+					if u, err = client.AuthCodeURL(ctx, fakeClientID, localhost, tokenScope, WithClaims(test.claims)); err == nil {
 						var parsed *url.URL
 						if parsed, err = url.Parse(u); err == nil {
 							validate(t, parsed.Query())
@@ -902,7 +899,7 @@ func TestWithTenantID(t *testing.T) {
 				case "authcode":
 					ar, err = client.AcquireTokenByAuthCode(ctx, "auth code", localhost, tokenScope, WithTenantID(test.tenant))
 				case "authcodeURL":
-					URL, err = client.AuthCodeURL(ctx, "client-id", localhost, tokenScope, WithTenantID(test.tenant))
+					URL, err = client.AuthCodeURL(ctx, fakeClientID, localhost, tokenScope, WithTenantID(test.tenant))
 				case "credential":
 					ar, err = client.AcquireTokenByCredential(ctx, tokenScope, WithTenantID(test.tenant))
 				case "obo":

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -87,7 +87,7 @@ func WithAuthority(authority string) Option {
 	}
 }
 
-// WithCache allows you to set some type of cache for storing authentication tokens.
+// WithCache provides an accessor that will read and write authentication data to an externally managed cache.
 func WithCache(accessor cache.ExportReplace) Option {
 	return func(o *Options) {
 		o.Accessor = accessor

--- a/apps/tests/devapps/client_certificate_sample.go
+++ b/apps/tests/devapps/client_certificate_sample.go
@@ -37,7 +37,7 @@ func acquireTokenClientCertificate() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	app, err := confidential.New(config.ClientID, cred, confidential.WithAuthority(config.Authority), confidential.WithAccessor(cacheAccessor))
+	app, err := confidential.New(config.ClientID, cred, confidential.WithAuthority(config.Authority), confidential.WithCache(cacheAccessor))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/apps/tests/devapps/client_secret_sample.go
+++ b/apps/tests/devapps/client_secret_sample.go
@@ -17,7 +17,7 @@ func acquireTokenClientSecret() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	app, err := confidential.New(config.ClientID, cred, confidential.WithAuthority(config.Authority), confidential.WithAccessor(cacheAccessor))
+	app, err := confidential.New(config.ClientID, cred, confidential.WithAuthority(config.Authority), confidential.WithCache(cacheAccessor))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Part of #380. Confidential client has `WithAccessor`, public client has `WithCache`, but both should have the same name because they do same thing. `WithCache` looks better to me because it indicates more clearly what the option does.