### PR TITLE
Quick fix for Azure AD B2C

### DIFF
--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -51,6 +51,12 @@ func TrustedHost(host string) bool {
 	if _, ok := aadTrustedHostList[host]; ok {
 		return true
 	}
+
+	// default Azure AD B2C authority domain
+	if strings.HasSuffix(host, ".b2clogin.com") {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
Fix CanonicalAuthorityURI handling and add default Azure AD B2C domain (.b2clogin.com) as trusted authority host domain.
Theese two changes makes the library works with Azure AD B2C (and user flows).

Maybe not this is the best way to fix the problem, but other solutions would require significant refactor in code.
