### PR TITLE
Replace NewCredFromCert with NewCredFromCertChain

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -63,7 +63,7 @@ type AuthResult = base.AuthResult
 
 type Account = shared.Account
 
-// CertFromPEM converts a PEM file (.pem or .key) for use with NewCredFromCert(). The file
+// CertFromPEM converts a PEM file (.pem or .key) for use with [NewCredFromCert]. The file
 // must contain the public certificate and the private key. If a PEM block is encrypted and
 // password is not an empty string, it attempts to decrypt the PEM blocks using the password.
 // Multiple certs are due to certificate chaining for use cases like TLS that sign from root to leaf.
@@ -185,16 +185,9 @@ func NewCredFromAssertionCallback(callback func(context.Context, AssertionReques
 	return Credential{assertionCallback: callback}
 }
 
-// NewCredFromCert creates a Credential from an x509.Certificate and an RSA private key.
-// CertFromPEM() can be used to get these values from a PEM file.
-func NewCredFromCert(cert *x509.Certificate, key crypto.PrivateKey) Credential {
-	cred, _ := NewCredFromCertChain([]*x509.Certificate{cert}, key)
-	return cred
-}
-
-// NewCredFromCertChain creates a Credential from a chain of x509.Certificates and an RSA private key
-// as returned by CertFromPEM().
-func NewCredFromCertChain(certs []*x509.Certificate, key crypto.PrivateKey) (Credential, error) {
+// NewCredFromCert creates a Credential from a certificate or chain of certificates and an RSA private key
+// as returned by [CertFromPEM].
+func NewCredFromCert(certs []*x509.Certificate, key crypto.PrivateKey) (Credential, error) {
 	cred := Credential{key: key}
 	k, ok := key.(*rsa.PrivateKey)
 	if !ok {

--- a/apps/confidential/examples_test.go
+++ b/apps/confidential/examples_test.go
@@ -24,32 +24,9 @@ func ExampleNewCredFromCert_pem() {
 		log.Fatal(err)
 	}
 
-	// PEM files can have multiple certs. This is usually for certificate chaining where roots
-	// sign to leafs. Useful for TLS, not for this use case.
-	if len(certs) > 1 {
-		log.Fatal("too many certificates in PEM file")
+	cred, err := confidential.NewCredFromCert(certs, priv)
+	if err != nil {
+		log.Fatal(err)
 	}
-
-	cred := confidential.NewCredFromCert(certs[0], priv)
 	fmt.Println(cred) // Simply here so cred is used, otherwise won't compile.
-}
-
-func ExampleNewCredFromCertChain() {
-	b, err := os.ReadFile("key.pem")
-	if err != nil {
-		// TODO: handle error
-	}
-
-	// CertFromPEM loads certificates and a private key from the PEM content. If
-	// the content is encrypted, the second argument must be the password.
-	certs, priv, err := confidential.CertFromPEM(b, "")
-	if err != nil {
-		// TODO: handle error
-	}
-
-	cred, err := confidential.NewCredFromCertChain(certs, priv)
-	if err != nil {
-		// TODO: handle error
-	}
-	_ = cred
 }

--- a/apps/tests/devapps/client_certificate_sample.go
+++ b/apps/tests/devapps/client_certificate_sample.go
@@ -26,14 +26,7 @@ func acquireTokenClientCertificate() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// PEM files can have multiple certs. This is usually for certificate chaining where roots
-	// sign to leafs. Useful for TLS, not for this use case.
-	if len(certs) > 1 {
-		log.Fatal("too many certificates in PEM file")
-	}
-
-	cred := confidential.NewCredFromCert(certs[0], privateKey)
+	cred, err := confidential.NewCredFromCert(certs, privateKey)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Part of #380. We added `NewCredFromCertChain` to fully support SNI auth. It has an awkward name and makes the single cert constructor `NewCredFromCert` redundant. `NewCredFromCertChain` is also more ergonomic because it pairs better with the cert loading helper and can return an error (bad input to `NewCredFromCert` isn't reported until authentication fails). So, deleting the worse constructor and giving the good name to the better constructor makes the API better overall.