### PR TITLE
Upgrade CI tools

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ["1.19", "1.18"]
+        go: ["1.19", "1.20"]
 
     steps:
       - name: Set up Go 1.x

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.49
+          version: v1.51
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/apps/internal/oauth/oauth.go
+++ b/apps/internal/oauth/oauth.go
@@ -212,7 +212,6 @@ func (d DeviceCode) Token(ctx context.Context) (accesstokens.TokenResponse, erro
 	}
 
 	var cancel context.CancelFunc
-	d.Result.ExpiresOn.Sub(time.Now().UTC())
 	if deadline, ok := ctx.Deadline(); !ok || d.Result.ExpiresOn.Before(deadline) {
 		ctx, cancel = context.WithDeadline(ctx, d.Result.ExpiresOn)
 	} else {


### PR DESCRIPTION
Upgrading CI to use the latest version of Go and linter. The upgraded linter flagged a method call that has no side effect and whose return value is discarded i.e., the call has no effect. I deleted this call because it's unnecessary in any case--there's no reason to update `DeviceCodeResult.ExpiresOn` because it's the moment at which the code expires, not the amount of time remaining until the code expires.