### PR TITLE
Confidential client requires authority

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -18,7 +18,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"net/url"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/base"
@@ -250,26 +249,8 @@ type clientOptions struct {
 	httpClient                        ops.HTTPClient
 }
 
-func (o clientOptions) validate() error {
-	u, err := url.Parse(o.authority)
-	if err != nil {
-		return fmt.Errorf("the Authority(%s) does not parse as a valid URL", o.authority)
-	}
-	if u.Scheme != "https" {
-		return fmt.Errorf("the Authority(%s) does not appear to use https", o.authority)
-	}
-	return nil
-}
-
 // Option is an optional argument to New().
 type Option func(o *clientOptions)
-
-// WithAuthority allows you to provide a custom authority for use in the client.
-func WithAuthority(authority string) Option {
-	return func(o *clientOptions) {
-		o.authority = authority
-	}
-}
 
 // WithCache provides an accessor that will read and write authentication data to an externally managed cache.
 func WithCache(accessor cache.ExportReplace) Option {
@@ -325,37 +306,30 @@ func WithAzureRegion(val string) Option {
 	}
 }
 
-// New is the constructor for Client. userID is the unique identifier of the user this client
-// will store credentials for (a Client is per user). clientID is the Azure clientID and cred is
-// the type of credential to use.
-func New(clientID string, cred Credential, options ...Option) (Client, error) {
+// New is the constructor for Client. authority is the URL of a token authority such as "https://login.microsoftonline.com/<your tenant>".
+// If the Client will connect directly to AD FS, use "adfs" for the tenant. clientID is the application's client ID (also called its
+// "application ID").
+func New(authority, clientID string, cred Credential, options ...Option) (Client, error) {
 	internalCred, err := cred.toInternal()
 	if err != nil {
 		return Client{}, err
 	}
 
 	opts := clientOptions{
-		authority:  base.AuthorityPublicCloud,
-		httpClient: shared.DefaultClient,
+		authority: authority,
+		// if the caller specified a token provider, it will handle all details of authentication, using Client only as a token cache
+		disableInstanceDiscovery: cred.tokenProvider != nil,
+		httpClient:               shared.DefaultClient,
 	}
-
 	for _, o := range options {
 		o(&opts)
 	}
-	if err := opts.validate(); err != nil {
-		return Client{}, err
-	}
-
 	baseOpts := []base.Option{
 		base.WithCacheAccessor(opts.accessor),
 		base.WithClientCapabilities(opts.capabilities),
+		base.WithInstanceDiscovery(!opts.disableInstanceDiscovery),
 		base.WithRegionDetection(opts.azureRegion),
 		base.WithX5C(opts.sendX5C),
-		base.WithInstanceDiscovery(!opts.disableInstanceDiscovery),
-	}
-	if cred.tokenProvider != nil {
-		// The caller will handle all details of authentication, using Client only as a token cache.
-		baseOpts = append(baseOpts, base.WithInstanceDiscovery(false))
 	}
 	base, err := base.New(clientID, opts.authority, oauth.New(opts.httpClient), baseOpts...)
 	if err != nil {
@@ -481,7 +455,7 @@ func WithClaims(claims string) interface {
 	}
 }
 
-// WithTenantID specifies a tenant for a single authentication. It may be different than the tenant set in [New] by [WithAuthority].
+// WithTenantID specifies a tenant for a single authentication. It may be different than the tenant set in [New].
 // This option is valid for any token acquisition method.
 func WithTenantID(tenantID string) interface {
 	AcquireByAuthCodeOption

--- a/apps/tests/devapps/client_certificate_sample.go
+++ b/apps/tests/devapps/client_certificate_sample.go
@@ -30,7 +30,7 @@ func acquireTokenClientCertificate() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	app, err := confidential.New(config.ClientID, cred, confidential.WithAuthority(config.Authority), confidential.WithCache(cacheAccessor))
+	app, err := confidential.New(config.Authority, config.ClientID, cred, confidential.WithCache(cacheAccessor))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/apps/tests/devapps/client_secret_sample.go
+++ b/apps/tests/devapps/client_secret_sample.go
@@ -17,7 +17,7 @@ func acquireTokenClientSecret() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	app, err := confidential.New(config.ClientID, cred, confidential.WithAuthority(config.Authority), confidential.WithCache(cacheAccessor))
+	app, err := confidential.New(config.Authority, config.ClientID, cred, confidential.WithCache(cacheAccessor))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/apps/tests/integration/integration_test.go
+++ b/apps/tests/integration/integration_test.go
@@ -290,7 +290,7 @@ func TestOnBehalfOf(t *testing.T) {
 	if err != nil {
 		panic(errors.Verbose(err))
 	}
-	cca, err := confidential.New(microsoftAuthority, ccaClientID, cred)
+	cca, err := confidential.New("https://login.microsoftonline.com/common", ccaClientID, cred)
 	if err != nil {
 		panic(errors.Verbose(err))
 	}

--- a/apps/tests/integration/integration_test.go
+++ b/apps/tests/integration/integration_test.go
@@ -97,7 +97,7 @@ func newLabClient() (*labClient, error) {
 		return nil, fmt.Errorf("could not create a cred from a secret: %w", err)
 	}
 
-	app, err := confidential.New(clientID, cred, confidential.WithAuthority(microsoftAuthority))
+	app, err := confidential.New(microsoftAuthority, clientID, cred)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func TestConfidentialClientwithSecret(t *testing.T) {
 		panic(errors.Verbose(err))
 	}
 
-	app, err := confidential.New(clientID, cred, confidential.WithAuthority(microsoftAuthority))
+	app, err := confidential.New(microsoftAuthority, clientID, cred)
 	if err != nil {
 		panic(errors.Verbose(err))
 	}
@@ -290,7 +290,7 @@ func TestOnBehalfOf(t *testing.T) {
 	if err != nil {
 		panic(errors.Verbose(err))
 	}
-	cca, err := confidential.New(ccaClientID, cred)
+	cca, err := confidential.New(microsoftAuthority, ccaClientID, cred)
 	if err != nil {
 		panic(errors.Verbose(err))
 	}


### PR DESCRIPTION
This makes authority a required parameter of the confidential client constructor (closes #348). The value must be a valid HTTPS URL with at least one path segment; anything else is a runtime error. Something that makes me hesitant here is that we have two scenarios in which authority really is optional: specifying a tenant for every authentication, and using Client with a custom token provider. I doubt these are common scenarios but it's unfortunate that this change requires their users to pass some value, possibly a bogus one.