### PR TITLE
fix: public/browserLogin add callback path support

### DIFF
--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -648,7 +648,7 @@ func (pca Client) browserLogin(ctx context.Context, redirectURI *url.URL, params
 	}
 	defer srv.Shutdown()
 	params.Scopes = accesstokens.AppendDefaultScopes(params)
-	authURL, err := pca.base.AuthCodeURL(ctx, params.ClientID, srv.Addr, params.Scopes, params)
+	authURL, err := pca.base.AuthCodeURL(ctx, params.ClientID, redirectURI.String(), params.Scopes, params)
 	if err != nil {
 		return interactiveAuthResult{}, err
 	}
@@ -663,7 +663,7 @@ func (pca Client) browserLogin(ctx context.Context, redirectURI *url.URL, params
 	}
 	return interactiveAuthResult{
 		authCode:    res.Code,
-		redirectURI: srv.Addr,
+		redirectURI: redirectURI.String(),
 	}, nil
 }
 

--- a/apps/tests/devapps/acquire_token_interactive_code_sample.go
+++ b/apps/tests/devapps/acquire_token_interactive_code_sample.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package main
+
+// To use browser login use "Mobile and desktop applications" in your App Registration's Authentication, see:
+// https://stackoverflow.com/questions/61231144/getting-access-tokens-from-postman-tokens-issued-for-the-single-page-applicati
+
+// Be aware of the callback restrictions for localhost callbacks, see:
+// https://learn.microsoft.com/en-us/azure/active-directory/develop/reply-url#localhost-exceptions
+
+/*
+import (
+	"context"
+	"fmt"
+	msal "github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
+)
+
+const (
+	clientId    = "<client id>"
+	authority   = "https://login.microsoftonline.com/<token id>/oauth2/v2.0/authorize"
+	redirectUri = "<callback>"
+)
+
+func main() {
+	publicClientApp, err := msal.New(clientId, msal.WithAuthority(authority))
+	if err != nil {
+		panic(err)
+	}
+	ar, err := publicClientApp.AcquireTokenInteractive(context.Background(), []string{"openid"}, msal.WithRedirectURI(redirectUri))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Username: %s; accesstoken: %v\n", ar.IDToken.Name, ar.AccessToken)
+}
+*/


### PR DESCRIPTION
The current version only works with callbacks not containing URL paths.
Also added a sample using the public AcquireTokenInteractive flow.