### PR TITLE
Added optional claim ipaddr to IDToken struct

### DIFF
--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -30,6 +30,7 @@ type IDToken struct {
 	TenantID          string `json:"tid,omitempty"`
 	Subject           string `json:"sub,omitempty"`
 	UPN               string `json:"upn,omitempty"`
+	IpAddress         string `json:"ipaddr,omitempty"`
 	Email             string `json:"email,omitempty"`
 	AlternativeID     string `json:"alternative_id,omitempty"`
 	Issuer            string `json:"iss,omitempty"`


### PR DESCRIPTION
See #400 for reference. 


Since the optional claim `UPN` is already present, I thought about adding `ipaddr` as well here.