### PR TITLE
Prevent persistent cache data races

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -137,8 +137,8 @@ func NewAuthResult(tokenResponse accesstokens.TokenResponse, account shared.Acco
 // Client is a base client that provides access to common methods and primatives that
 // can be used by multiple clients.
 type Client struct {
-	Token    *oauth.Client
-	manager  accountManager // *storage.Manager or fakeManager in tests
+	Token   *oauth.Client
+	manager accountManager // *storage.Manager or fakeManager in tests
 	// pmanager is a partitioned cache for OBO authentication. *storage.PartitionedManager or fakeManager in tests
 	pmanager manager
 

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -458,38 +458,29 @@ func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.Au
 	return ar, err
 }
 
-func (b Client) AllAccounts(ctx context.Context) (accts []shared.Account, err error) {
+func (b Client) AllAccounts(ctx context.Context) ([]shared.Account, error) {
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
-		err = b.cacheAccessor.Replace(ctx, s, cache.ReplaceHints{PartitionKey: suggestedCacheKey})
+		err := b.cacheAccessor.Replace(ctx, s, cache.ReplaceHints{PartitionKey: suggestedCacheKey})
 		if err != nil {
-			return accts, err
+			return nil, err
 		}
-		defer func() {
-			err = b.export(ctx, s, suggestedCacheKey, err)
-		}()
 	}
-
-	accts = b.manager.AllAccounts()
-	return accts, err
+	return b.manager.AllAccounts(), nil
 }
 
-func (b Client) Account(ctx context.Context, homeAccountID string) (acct shared.Account, err error) {
+func (b Client) Account(ctx context.Context, homeAccountID string) (shared.Account, error) {
 	authParams := b.AuthParams // This is a copy, as we dont' have a pointer receiver and .AuthParams is not a pointer.
 	authParams.AuthorizationType = authority.AccountByID
 	authParams.HomeAccountID = homeAccountID
 	if s, ok := b.manager.(cache.Serializer); ok {
 		suggestedCacheKey := b.AuthParams.CacheKey(false)
-		err = b.cacheAccessor.Replace(ctx, s, cache.ReplaceHints{PartitionKey: suggestedCacheKey})
+		err := b.cacheAccessor.Replace(ctx, s, cache.ReplaceHints{PartitionKey: suggestedCacheKey})
 		if err != nil {
-			return acct, err
+			return shared.Account{}, err
 		}
-		defer func() {
-			err = b.export(ctx, s, suggestedCacheKey, err)
-		}()
 	}
-	acct = b.manager.Account(homeAccountID)
-	return acct, err
+	return b.manager.Account(homeAccountID), nil
 }
 
 // RemoveAccount removes all the ATs, RTs and IDTs from the cache associated with this account.

--- a/apps/internal/base/base_test.go
+++ b/apps/internal/base/base_test.go
@@ -133,6 +133,7 @@ func TestAcquireTokenSilentScopes(t *testing.T) {
 				},
 				accesstokens.TokenResponse{
 					AccessToken:   fakeAccessToken,
+					ClientInfo:    accesstokens.ClientInfo{UID: "uid", UTID: "utid"},
 					ExpiresOn:     internalTime.DurationTime{T: time.Now().Add(-time.Hour)},
 					GrantedScopes: accesstokens.Scopes{Slice: test.cachedTokenScopes},
 					IDToken:       fakeIDToken,

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -494,6 +494,8 @@ func (m *Manager) update(cache *Contract) {
 
 // Marshal implements cache.Marshaler.
 func (m *Manager) Marshal() ([]byte, error) {
+	m.contractMu.RLock()
+	defer m.contractMu.RUnlock()
 	return json.Marshal(m.contract)
 }
 

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -83,7 +83,7 @@ func isMatchingScopes(scopesOne []string, scopesTwo string) bool {
 }
 
 // Read reads a storage token from the cache if it exists.
-func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams, account shared.Account) (TokenResponse, error) {
+func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams) (TokenResponse, error) {
 	tr := TokenResponse{}
 	homeAccountID := authParameters.HomeAccountID
 	realm := authParameters.AuthorityInfo.Tenant
@@ -103,7 +103,8 @@ func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams,
 	accessToken := m.readAccessToken(homeAccountID, aliases, realm, clientID, scopes)
 	tr.AccessToken = accessToken
 
-	if account.IsZero() {
+	if homeAccountID == "" {
+		// caller didn't specify a user, so there's no reason to search for an ID or refresh token
 		return tr, nil
 	}
 	// errors returned by read* methods indicate a cache miss and are therefore non-fatal. We continue populating
@@ -122,7 +123,7 @@ func (m *Manager) Read(ctx context.Context, authParameters authority.AuthParams,
 		}
 	}
 
-	account, err = m.readAccount(homeAccountID, aliases, realm)
+	account, err := m.readAccount(homeAccountID, aliases, realm)
 	if err == nil {
 		tr.Account = account
 	}

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -792,7 +792,7 @@ func TestRead(t *testing.T) {
 		manager := newForTest(responder)
 		manager.update(contract)
 
-		got, err := manager.Read(context.Background(), authParameters, testAccount)
+		got, err := manager.Read(context.Background(), authParameters)
 		switch {
 		case err == nil && test.err:
 			t.Errorf("TestRead(%s): got err == nil, want err != nil", test.desc)


### PR DESCRIPTION
Concurrent authentication causes data loss when using a persistent cache because `base.Client` doesn't synchronize its access. The data flow of authentication looks like this:
1. load persistent cache into memory (clobber data in memory)
1. authenticate
1. store authentication data in memory
1. write in-memory data to persistent cache (clobber persisted data)

When multiple goroutines authenticate concurrently, one may execute step 1 while another is between steps 3 and 4, deleting new data in memory before it's persisted. My solution in this PR is simply to lock around accessing the persistent cache.

To prevent repetition, I simplified several methods by consolidating the (internal) interfaces for partitioned and flat caches. These interfaces had almost the same Read/Write API; the difference was an unnecessary parameter. While I was at it, I also eliminated unnecessary writes to persistence--methods that don't write the in-memory cache no longer export it to the persistent cache.