### PR TITLE
fix: empty cache key in client.Account

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -479,7 +479,7 @@ func (b Client) Account(ctx context.Context, homeAccountID string) (acct shared.
 	authParams.AuthorizationType = authority.AccountByID
 	authParams.HomeAccountID = homeAccountID
 	if s, ok := b.manager.(cache.Serializer); ok {
-		suggestedCacheKey := b.AuthParams.CacheKey(false)
+		suggestedCacheKey := authParams.CacheKey(false)
 		err = b.cacheAccessor.Replace(ctx, s, cache.ReplaceHints{PartitionKey: suggestedCacheKey})
 		if err != nil {
 			return acct, err


### PR DESCRIPTION
The `CacheKey` method in `Account` is called on the wrong receiver. The `AuthParams` struct is correctly copied at the beginning of the method but then not used to call the `CacheKey` method.

This leads to `CacheKey` always returning an empty string.