### PR TITLE
Update broken tests

### DIFF
--- a/apps/internal/base/base_test.go
+++ b/apps/internal/base/base_test.go
@@ -235,16 +235,16 @@ func TestCacheIOErrors(t *testing.T) {
 				if !errors.Is(actual, expected) {
 					t.Fatalf(`expected "%v", got "%v"`, expected, actual)
 				}
-				_, actual = client.AcquireTokenSilent(ctx, AcquireTokenSilentParameters{})
+				_, actual = client.AcquireTokenSilent(ctx, AcquireTokenSilentParameters{Scopes: testScopes})
 				if cache.replaceErr != nil && !errors.Is(actual, expected) {
 					t.Fatalf(`expected "%v", got "%v"`, expected, actual)
 				}
 			}
-			_, actual := client.AcquireTokenByAuthCode(ctx, AcquireTokenAuthCodeParameters{AppType: accesstokens.ATConfidential})
+			_, actual := client.AcquireTokenByAuthCode(ctx, AcquireTokenAuthCodeParameters{AppType: accesstokens.ATConfidential, Scopes: testScopes})
 			if !errors.Is(actual, expected) {
 				t.Fatalf(`expected "%v", got "%v"`, expected, actual)
 			}
-			_, actual = client.AcquireTokenOnBehalfOf(ctx, AcquireTokenOnBehalfOfParameters{Credential: &accesstokens.Credential{Secret: "..."}})
+			_, actual = client.AcquireTokenOnBehalfOf(ctx, AcquireTokenOnBehalfOfParameters{Credential: &accesstokens.Credential{Secret: "..."}, Scopes: testScopes})
 			if !errors.Is(actual, expected) {
 				t.Fatalf(`expected "%v", got "%v"`, expected, actual)
 			}

--- a/apps/internal/oauth/oauth_test.go
+++ b/apps/internal/oauth/oauth_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
 )
 
+var testScopes = []string{"scope"}
+
 func TestAuthCode(t *testing.T) {
 	tests := []struct {
 		desc string
@@ -56,7 +58,7 @@ func TestAuthCode(t *testing.T) {
 		token.AccessTokens = test.at
 		token.Resolver = test.re
 
-		_, err := token.AuthCode(context.Background(), accesstokens.AuthCodeRequest{})
+		_, err := token.AuthCode(context.Background(), accesstokens.AuthCodeRequest{AuthParams: authority.AuthParams{Scopes: testScopes}})
 		switch {
 		case err == nil && test.err:
 			t.Errorf("TestAuthCode(%s): got err == nil, want err != nil", test.desc)
@@ -183,7 +185,7 @@ func TestRefresh(t *testing.T) {
 		_, err := token.Refresh(
 			context.Background(),
 			accesstokens.ATPublic,
-			authority.AuthParams{},
+			authority.AuthParams{Scopes: testScopes},
 			&accesstokens.Credential{},
 			accesstokens.RefreshToken{},
 		)
@@ -263,7 +265,7 @@ func TestUsernamePassword(t *testing.T) {
 		token.Resolver = test.re
 		token.WSTrust = test.ws
 
-		_, err := token.UsernamePassword(context.Background(), authority.AuthParams{})
+		_, err := token.UsernamePassword(context.Background(), authority.AuthParams{Scopes: testScopes})
 		switch {
 		case err == nil && test.err:
 			t.Errorf("TestUsernamePassword(%s): got err == nil, want err != nil", test.desc)
@@ -382,7 +384,7 @@ func TestDeviceCodeToken(t *testing.T) {
 		token.AccessTokens = test.at
 		token.Resolver = test.re
 
-		dc, err := token.DeviceCode(context.Background(), authority.AuthParams{})
+		dc, err := token.DeviceCode(context.Background(), authority.AuthParams{Scopes: testScopes})
 		switch {
 		case err == nil && test.err:
 			t.Errorf("TestDeviceCodeToken(%s): got err == nil, want err != nil", test.desc)


### PR DESCRIPTION
This updates tests to specify at least one scope (failing to do so became an error with #403). CI could be much more helpful in catching problems like this before PRs merge; see #393.