### PR TITLE
Updating github.com/golang-jwt/jwt/v5 to v5

### DIFF
--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/fake"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -464,8 +464,8 @@ func TestNewCredFromCert(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					if err = tk.Claims.Valid(); err != nil {
-						t.Fatal(err)
+					if !tk.Valid {
+						t.Fatal("token not valid")
 					}
 					// x5c header should be set iff the sendX5c is true
 					if x5c, ok := tk.Header["x5c"]; ok != sendX5c {

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -30,7 +30,7 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/internal/grant"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/wstrust"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/AzureAD/microsoft-authentication-library-for-go
 go 1.18
 
 require (
-	github.com/golang-jwt/jwt/v4 v4.4.3
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/uuid v1.3.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/montanaflynn/stats v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
-github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
This PR updates github.com/golang-jwt/jwt/v5 to its next major version, v5.
