### PR TITLE
Add `WithOpenURL` as an option for `AcquireTokenInteractive`

### DIFF
--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -473,6 +473,7 @@ func (pca Client) RemoveAccount(ctx context.Context, account Account) error {
 // interactiveAuthOptions contains the optional parameters used to acquire an access token for interactive auth code flow.
 type interactiveAuthOptions struct {
 	claims, domainHint, loginHint, redirectURI, tenantID string
+	openURL                                              func(url string) error
 }
 
 // AcquireInteractiveOption is implemented by options for AcquireTokenInteractive
@@ -558,10 +559,33 @@ func WithRedirectURI(redirectURI string) interface {
 	}
 }
 
+// WithOpenURL allows you to provide a function to open the browser to complete the interactive login, instead of launching the system default browser.
+func WithOpenURL(openURL func(url string) error) interface {
+	AcquireInteractiveOption
+	options.CallOption
+} {
+	return struct {
+		AcquireInteractiveOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *interactiveAuthOptions:
+					t.openURL = openURL
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
+
 // AcquireTokenInteractive acquires a security token from the authority using the default web browser to select the account.
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#interactive-and-non-interactive-authentication
 //
-// Options: [WithDomainHint], [WithLoginHint], [WithRedirectURI], [WithTenantID]
+// Options: [WithDomainHint], [WithLoginHint], [WithOpenURL], [WithRedirectURI], [WithTenantID]
 func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, opts ...AcquireInteractiveOption) (AuthResult, error) {
 	o := interactiveAuthOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -580,6 +604,9 @@ func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, 
 			return AuthResult{}, err
 		}
 	}
+	if o.openURL == nil {
+		o.openURL = browser.OpenURL
+	}
 	authParams, err := pca.base.AuthParams.WithTenant(o.tenantID)
 	if err != nil {
 		return AuthResult{}, err
@@ -593,7 +620,7 @@ func (pca Client) AcquireTokenInteractive(ctx context.Context, scopes []string, 
 	authParams.DomainHint = o.domainHint
 	authParams.State = uuid.New().String()
 	authParams.Prompt = "select_account"
-	res, err := pca.browserLogin(ctx, redirectURL, authParams)
+	res, err := pca.browserLogin(ctx, redirectURL, authParams, o.openURL)
 	if err != nil {
 		return AuthResult{}, err
 	}
@@ -617,11 +644,6 @@ type interactiveAuthResult struct {
 	redirectURI string
 }
 
-// provides a test hook to simulate opening a browser
-var browserOpenURL = func(authURL string) error {
-	return browser.OpenURL(authURL)
-}
-
 // parses the port number from the provided URL.
 // returns 0 if nil or no port is specified.
 func parsePort(u *url.URL) (int, error) {
@@ -636,7 +658,7 @@ func parsePort(u *url.URL) (int, error) {
 }
 
 // browserLogin launches the system browser for interactive login
-func (pca Client) browserLogin(ctx context.Context, redirectURI *url.URL, params authority.AuthParams) (interactiveAuthResult, error) {
+func (pca Client) browserLogin(ctx context.Context, redirectURI *url.URL, params authority.AuthParams, openURL func(string) error) (interactiveAuthResult, error) {
 	// start local redirect server so login can call us back
 	port, err := parsePort(redirectURI)
 	if err != nil {
@@ -653,7 +675,7 @@ func (pca Client) browserLogin(ctx context.Context, redirectURI *url.URL, params
 		return interactiveAuthResult{}, err
 	}
 	// open browser window so user can select credentials
-	if err := browserOpenURL(authURL); err != nil {
+	if err := openURL(authURL); err != nil {
 		return interactiveAuthResult{}, err
 	}
 	// now wait until the logic calls us back

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -657,7 +657,7 @@ func parsePort(u *url.URL) (int, error) {
 	return strconv.Atoi(p)
 }
 
-// browserLogin launches the system browser for interactive login
+// browserLogin calls openURL and waits for a user to log in
 func (pca Client) browserLogin(ctx context.Context, redirectURI *url.URL, params authority.AuthParams, openURL func(string) error) (interactiveAuthResult, error) {
 	// start local redirect server so login can call us back
 	port, err := parsePort(redirectURI)


### PR DESCRIPTION
This allows the caller to provide an alternate implementation of the logic to launch the web browser to preform the interactive login flow, instead of using the system default browser.

Fixes #314