### PR TITLE
Normalize cache keys

### DIFF
--- a/apps/internal/base/internal/storage/items.go
+++ b/apps/internal/base/internal/storage/items.go
@@ -97,10 +97,11 @@ func NewAccessToken(homeID, env, realm, clientID string, cachedAt, expiresOn, ex
 
 // Key outputs the key that can be used to uniquely look up this entry in a map.
 func (a AccessToken) Key() string {
-	return strings.Join(
+	key := strings.Join(
 		[]string{a.HomeAccountID, a.Environment, a.CredentialType, a.ClientID, a.Realm, a.Scopes},
 		shared.CacheKeySeparator,
 	)
+	return strings.ToLower(key)
 }
 
 // FakeValidate enables tests to fake access token validation
@@ -167,10 +168,11 @@ func NewIDToken(homeID, env, realm, clientID, idToken string) IDToken {
 
 // Key outputs the key that can be used to uniquely look up this entry in a map.
 func (id IDToken) Key() string {
-	return strings.Join(
+	key := strings.Join(
 		[]string{id.HomeAccountID, id.Environment, id.CredentialType, id.ClientID, id.Realm},
 		shared.CacheKeySeparator,
 	)
+	return strings.ToLower(key)
 }
 
 // AppMetaData is the JSON representation of application metadata for encoding to storage.
@@ -193,8 +195,9 @@ func NewAppMetaData(familyID, clientID, environment string) AppMetaData {
 
 // Key outputs the key that can be used to uniquely look up this entry in a map.
 func (a AppMetaData) Key() string {
-	return strings.Join(
+	key := strings.Join(
 		[]string{"AppMetaData", a.Environment, a.ClientID},
 		shared.CacheKeySeparator,
 	)
+	return strings.ToLower(key)
 }

--- a/apps/internal/base/internal/storage/items_test.go
+++ b/apps/internal/base/internal/storage/items_test.go
@@ -61,7 +61,7 @@ func TestCreateAccessToken(t *testing.T) {
 }
 
 func TestKeyForAccessToken(t *testing.T) {
-	const want = "testHID-env-AccessToken-clientID-realm-user.read"
+	const want = "testhid-env-accesstoken-clientid-realm-user.read"
 	got := atCacheEntity.Key()
 	if got != want {
 		t.Errorf("TestKeyForAccessToken: got %s, want %s", got, want)
@@ -133,7 +133,7 @@ var (
 )
 
 func TestKeyForAppMetaData(t *testing.T) {
-	want := "AppMetaData-env-cid"
+	want := "appmetadata-env-cid"
 	got := appMeta.Key()
 	if want != got {
 		t.Errorf("actual key %v differs from expected key %v", want, got)
@@ -387,7 +387,7 @@ var idToken = IDToken{
 }
 
 func TestKeyForIDToken(t *testing.T) {
-	want := "HID-env-IdToken-clientID-realm"
+	want := "hid-env-idtoken-clientid-realm"
 	if idToken.Key() != want {
 		t.Errorf("actual key %v differs from expected key %v", idToken.Key(), want)
 	}
@@ -475,7 +475,7 @@ func TestNewRefreshToken(t *testing.T) {
 }
 
 func TestKeyForRefreshToken(t *testing.T) {
-	want := "HID-env-accesstokens.RefreshToken-clientID"
+	want := "hid-env-accesstokens.refreshtoken-clientid"
 	got := rt.Key()
 	if want != got {
 		t.Errorf("Actual key %v differs from expected key %v", got, want)

--- a/apps/internal/base/internal/storage/storage_test.go
+++ b/apps/internal/base/internal/storage/storage_test.go
@@ -87,8 +87,8 @@ func TestIsMatchingScopes(t *testing.T) {
 }
 
 func TestAllAccounts(t *testing.T) {
-	testAccOne := shared.NewAccount("hid", "env", "realm", "lid", accAuth, "username")
-	testAccTwo := shared.NewAccount("HID", "ENV", "REALM", "LID", accAuth, "USERNAME")
+	testAccOne := shared.NewAccount("oid1.tid", "env", "realm", "lid", accAuth, "username")
+	testAccTwo := shared.NewAccount("oid2.tid", "ENV", "REALM", "LID", accAuth, "USERNAME")
 	cache := &Contract{
 		Accounts: map[string]shared.Account{
 			testAccOne.Key(): testAccOne,
@@ -105,7 +105,7 @@ func TestAllAccounts(t *testing.T) {
 	sort.Slice(
 		actualAccounts,
 		func(i, j int) bool {
-			return actualAccounts[i].HomeAccountID > actualAccounts[j].HomeAccountID
+			return actualAccounts[i].HomeAccountID < actualAccounts[j].HomeAccountID
 		},
 	)
 

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -294,10 +294,11 @@ func (rt RefreshToken) Key() string {
 		fourth = rt.ClientID
 	}
 
-	return strings.Join(
+	key := strings.Join(
 		[]string{rt.HomeAccountID, rt.Environment, rt.CredentialType, fourth},
 		shared.CacheKeySeparator,
 	)
+	return strings.ToLower(key)
 }
 
 func (rt RefreshToken) GetSecret() string {

--- a/apps/internal/shared/shared.go
+++ b/apps/internal/shared/shared.go
@@ -46,7 +46,8 @@ func NewAccount(homeAccountID, env, realm, localAccountID, authorityType, userna
 
 // Key creates the key for storing accounts in the cache.
 func (acc Account) Key() string {
-	return strings.Join([]string{acc.HomeAccountID, acc.Environment, acc.Realm}, CacheKeySeparator)
+	key := strings.Join([]string{acc.HomeAccountID, acc.Environment, acc.Realm}, CacheKeySeparator)
+	return strings.ToLower(key)
 }
 
 // IsZero checks the zero value of account.


### PR DESCRIPTION
...according to the [schema](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/SSO/Schema.md&_a=preview&version=GBdev&anchor=key-case-sensitivity). This is a compatible change because MSAL Go uses these keys only when writing the cache. (Cache data is stored in maps but when searching, we iterate these rather than index them ([for example](https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/27c98c8f9db6bc564c5be43677f3e6276b7c4fef/apps/internal/base/internal/storage/storage.go#L258))).

Closes #367