### PR TITLE
Quietly ignore any "offline_access" scopes not being returned

### DIFF
--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -238,7 +238,9 @@ func (tr *TokenResponse) CacheKey(authParams authority.AuthParams) string {
 
 func findDeclinedScopes(requestedScopes []string, grantedScopes []string) []string {
 	declined := []string{}
-	grantedMap := map[string]bool{}
+	grantedMap := map[string]bool{
+		"offline_access": true, // This will never be returned, so just assume that it's there.
+	}
 	for _, s := range grantedScopes {
 		grantedMap[strings.ToLower(s)] = true
 	}


### PR DESCRIPTION
According to the Microsoft docs, they'll never be returned anyway. See: https://learn.microsoft.com/en-us/answers/questions/806413/scope-offline-access-isnt-being-returned-in-the-to

This fixes #416 