### PR TITLE
Fix AcquireTokenSilent for ADFS users

### DIFF
--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -370,6 +370,73 @@ func TestAcquireTokenSilentTenants(t *testing.T) {
 	}
 }
 
+func TestADFSTokenCaching(t *testing.T) {
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := New("https://fake_authority/adfs", "clientID", cred)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeAT := fake.AccessTokens{
+		AccessToken: accesstokens.TokenResponse{
+			AccessToken:   "at1",
+			RefreshToken:  "rt",
+			ExpiresOn:     internalTime.DurationTime{T: time.Now().Add(time.Hour)},
+			ExtExpiresOn:  internalTime.DurationTime{T: time.Now().Add(time.Hour)},
+			GrantedScopes: accesstokens.Scopes{Slice: tokenScope},
+			IDToken: accesstokens.IDToken{
+				ExpirationTime: time.Now().Add(time.Hour).Unix(),
+				Name:           "A",
+				RawToken:       "x.e30",
+				Subject:        "A",
+				TenantID:       "tenant",
+				UPN:            "A",
+			},
+		},
+	}
+	client.base.Token.AccessTokens = &fakeAT
+	client.base.Token.Authority = &fake.Authority{
+		InstanceResp: authority.InstanceDiscoveryResponse{
+			Metadata: []authority.InstanceDiscoveryMetadata{
+				{Aliases: []string{"fake_authority"}},
+			},
+		},
+	}
+	client.base.Token.Resolver = &fake.ResolveEndpoints{}
+	ctx := context.Background()
+	ar1, err := client.AcquireTokenByAuthCode(ctx, "code", "http://localhost", tokenScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// simulate authenticating a different user
+	fakeAT.AccessToken.AccessToken = "at2"
+	fakeAT.AccessToken.IDToken.Name = "B"
+	fakeAT.AccessToken.IDToken.PreferredUsername = "B"
+	fakeAT.AccessToken.IDToken.Subject = "B"
+	fakeAT.AccessToken.IDToken.UPN = "B"
+	ar2, err := client.AcquireTokenByAuthCode(ctx, "code", "http://localhost", tokenScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ar1.AccessToken == ar2.AccessToken {
+		t.Fatal("expected different access tokens")
+	}
+
+	// cache should now have an access token for each account
+	for _, ar := range []AuthResult{ar1, ar2} {
+		actual, err := client.AcquireTokenSilent(ctx, tokenScope, WithSilentAccount(ar.Account))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actual.AccessToken != ar.AccessToken {
+			t.Fatalf("expected %q, got %q", ar.AccessToken, actual.AccessToken)
+		}
+	}
+}
+
 func TestAuthorityValidation(t *testing.T) {
 	cred, err := NewCredFromSecret(fakeSecret)
 	if err != nil {

--- a/apps/internal/base/internal/storage/partitioned_storage.go
+++ b/apps/internal/base/internal/storage/partitioned_storage.go
@@ -84,7 +84,7 @@ func (m *PartitionedManager) Read(ctx context.Context, authParameters authority.
 
 // Write writes a token response to the cache and returns the account information the token is stored with.
 func (m *PartitionedManager) Write(authParameters authority.AuthParams, tokenResponse accesstokens.TokenResponse) (shared.Account, error) {
-	authParameters.HomeAccountID = tokenResponse.ClientInfo.HomeAccountID()
+	authParameters.HomeAccountID = tokenResponse.HomeAccountID()
 	homeAccountID := authParameters.HomeAccountID
 	environment := authParameters.AuthorityInfo.Host
 	realm := authParameters.AuthorityInfo.Tenant

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -134,8 +134,7 @@ const scopeSeparator = " "
 
 // Write writes a token response to the cache and returns the account information the token is stored with.
 func (m *Manager) Write(authParameters authority.AuthParams, tokenResponse accesstokens.TokenResponse) (shared.Account, error) {
-	authParameters.HomeAccountID = tokenResponse.ClientInfo.HomeAccountID()
-	homeAccountID := authParameters.HomeAccountID
+	homeAccountID := tokenResponse.HomeAccountID()
 	environment := authParameters.AuthorityInfo.Host
 	realm := authParameters.AuthorityInfo.Tenant
 	clientID := authParameters.ClientID

--- a/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens_test.go
@@ -940,30 +940,42 @@ func TestComputeScopes(t *testing.T) {
 func TestHomeAccountID(t *testing.T) {
 	tests := []struct {
 		desc string
-		ci   ClientInfo
+		tr   TokenResponse
 		want string
 	}{
 		{
-			desc: "UID and UTID is not set",
+			desc: "no UID or UTID",
+			tr:   TokenResponse{IDToken: IDToken{Subject: "subject"}},
+			want: "subject",
 		},
 		{
-			desc: "UID is not set",
-			ci:   ClientInfo{UTID: "utid"},
-		},
-		{
-			desc: "UTID is not set",
-			ci:   ClientInfo{UID: "uid"},
+			desc: "UID with no UTID",
+			tr: TokenResponse{
+				ClientInfo: ClientInfo{UID: "uid"},
+				IDToken:    IDToken{Subject: "subject"},
+			},
 			want: "uid.uid",
 		},
 		{
+			desc: "UTID with no UID",
+			tr: TokenResponse{
+				ClientInfo: ClientInfo{UTID: "utid"},
+				IDToken:    IDToken{Subject: "subject"},
+			},
+			want: "subject",
+		},
+		{
 			desc: "UID and UTID are set",
-			ci:   ClientInfo{UID: "uid", UTID: "utid"},
+			tr: TokenResponse{
+				ClientInfo: ClientInfo{UID: "uid", UTID: "utid"},
+				IDToken:    IDToken{Subject: "subject"},
+			},
 			want: "uid.utid",
 		},
 	}
 
 	for _, test := range tests {
-		got := test.ci.HomeAccountID()
+		got := test.tr.HomeAccountID()
 		if got != test.want {
 			t.Errorf("TestHomeAccountID(%s): got %q, want %q", test.desc, got, test.want)
 		}

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -195,7 +195,7 @@ func (tr *TokenResponse) ComputeScope(authParams authority.AuthParams) {
 	tr.scopesComputed = true
 }
 
-// HomeAccountID uniquely identifies the authenticated account.
+// HomeAccountID uniquely identifies the authenticated account, if any. It's "" when the token is an app token.
 func (tr *TokenResponse) HomeAccountID() string {
 	id := tr.IDToken.Subject
 	if uid := tr.ClientInfo.UID; uid != "" {

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -146,17 +146,6 @@ func (c *ClientInfo) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// HomeAccountID creates the home account ID.
-func (c ClientInfo) HomeAccountID() string {
-	if c.UID == "" {
-		return ""
-	} else if c.UTID == "" {
-		return fmt.Sprintf("%s.%s", c.UID, c.UID)
-	} else {
-		return fmt.Sprintf("%s.%s", c.UID, c.UTID)
-	}
-}
-
 // Scopes represents scopes in a TokenResponse.
 type Scopes struct {
 	Slice []string
@@ -206,6 +195,19 @@ func (tr *TokenResponse) ComputeScope(authParams authority.AuthParams) {
 	tr.scopesComputed = true
 }
 
+// HomeAccountID uniquely identifies the authenticated account.
+func (tr *TokenResponse) HomeAccountID() string {
+	id := tr.IDToken.Subject
+	if uid := tr.ClientInfo.UID; uid != "" {
+		utid := tr.ClientInfo.UTID
+		if utid == "" {
+			utid = uid
+		}
+		id = fmt.Sprintf("%s.%s", uid, utid)
+	}
+	return id
+}
+
 // Validate validates the TokenResponse has basic valid values. It must be called
 // after ComputeScopes() is called.
 func (tr *TokenResponse) Validate() error {
@@ -231,7 +233,7 @@ func (tr *TokenResponse) CacheKey(authParams authority.AuthParams) string {
 		return authParams.AppKey()
 	}
 	if authParams.IsConfidentialClient || authParams.AuthorizationType == authority.ATRefreshToken {
-		return tr.ClientInfo.HomeAccountID()
+		return tr.HomeAccountID()
 	}
 	return ""
 }

--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -5,4 +5,4 @@
 package version
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "1.0.0"
+const Version = "1.1.1"

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strconv"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
@@ -297,8 +298,8 @@ func (pca Client) AcquireTokenSilent(ctx context.Context, scopes []string, opts 
 	if err := options.ApplyOptions(&o, opts); err != nil {
 		return AuthResult{}, err
 	}
-	// a home account ID is required to find user tokens in the cache
-	if o.account.HomeAccountID == "" {
+	// an account is required to find user tokens in the cache
+	if reflect.ValueOf(o.account).IsZero() {
 		return AuthResult{}, errNoAccount
 	}
 


### PR DESCRIPTION
#426 broke silent auth for ADFS users by requiring a home account ID, which ADFS accounts don't have. This PR restores the v1.0.0 behavior for ADFS by relaxing that requirement, allowing any nonzero account for silent auth. However, I'm uncertain the prior behavior was correct. Because the home account ID for ADFS accounts and tokens is always `""`, the cache matches access tokens on realm, client ID and scope alone, effectively ignoring the user's identity. If the cache has tokens for more than one ADFS user, it will return the first token it considers regardless of the owner. @rayluo @bgavrilMS should the cache match something else in this case such as the local account ID?