### PR TITLE
Fix ADFS token caching

### DIFF
--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -384,7 +384,7 @@ func TestADFSTokenCaching(t *testing.T) {
 		AccessToken: accesstokens.TokenResponse{
 			AccessToken:   "at1",
 			RefreshToken:  "rt",
-			TokenType:     "Bearer",
+			TokenType:     "bearer",
 			ExpiresOn:     internalTime.DurationTime{T: time.Now().Add(time.Hour)},
 			ExtExpiresOn:  internalTime.DurationTime{T: time.Now().Add(time.Hour)},
 			GrantedScopes: accesstokens.Scopes{Slice: tokenScope},
@@ -415,7 +415,7 @@ func TestADFSTokenCaching(t *testing.T) {
 
 	// simulate authenticating a different user
 	fakeAT.AccessToken.AccessToken = "at2"
-	fakeAT.AccessToken.TokenType = "Bearer"
+	fakeAT.AccessToken.TokenType = "bearer"
 	fakeAT.AccessToken.IDToken.Name = "B"
 	fakeAT.AccessToken.IDToken.PreferredUsername = "B"
 	fakeAT.AccessToken.IDToken.Subject = "B"

--- a/apps/internal/base/internal/storage/storage.go
+++ b/apps/internal/base/internal/storage/storage.go
@@ -293,7 +293,7 @@ func (m *Manager) readAccessToken(homeID string, envAliases []string, realm, cli
 	// an issue, however if it does become a problem then we know where to look.
 	for k, at := range m.contract.AccessTokens {
 		if at.HomeAccountID == homeID && at.Realm == realm && at.ClientID == clientID {
-			if (at.TokenType == tokenType && at.AuthnSchemeKeyID == authnSchemeKeyID) || (at.TokenType == "" && (tokenType == "" || tokenType == "Bearer")) {
+			if (strings.EqualFold(at.TokenType, tokenType) && at.AuthnSchemeKeyID == authnSchemeKeyID) || (at.TokenType == "" && (tokenType == "" || tokenType == "Bearer")) {
 				if checkAlias(at.Environment, envAliases) && isMatchingScopes(scopes, at.Scopes) {
 					m.contractMu.RUnlock()
 					if needsUpgrade(k) {


### PR DESCRIPTION
#451 assumed "**B**earer" is always the `token_type` of bearer tokens. It turns out some hosts return "**b**earer" instead, so that assumption broke token caching in some cases. I went with the easiest solution here--compare token types case-insensitively--but if that isn't safe in general I suppose we'll have to special-case [Bb]earer.