### PR TITLE
Support authnscheme in AcquireTokenByUsernamePassword flow

### DIFF
--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -217,11 +217,13 @@ func WithClaims(claims string) interface {
 func WithAuthenticationScheme(authnScheme AuthenticationScheme) interface {
 	AcquireSilentOption
 	AcquireInteractiveOption
+	AcquireByUsernamePasswordOption
 	options.CallOption
 } {
 	return struct {
 		AcquireSilentOption
 		AcquireInteractiveOption
+		AcquireByUsernamePasswordOption
 		options.CallOption
 	}{
 		CallOption: options.NewCallOption(
@@ -230,6 +232,8 @@ func WithAuthenticationScheme(authnScheme AuthenticationScheme) interface {
 				case *acquireTokenSilentOptions:
 					t.authnScheme = authnScheme
 				case *interactiveAuthOptions:
+					t.authnScheme = authnScheme
+				case *acquireTokenByUsernamePasswordOptions:
 					t.authnScheme = authnScheme
 				default:
 					return fmt.Errorf("unexpected options type %T", a)
@@ -349,6 +353,7 @@ func (pca Client) AcquireTokenSilent(ctx context.Context, scopes []string, opts 
 // acquireTokenByUsernamePasswordOptions contains optional configuration for AcquireTokenByUsernamePassword
 type acquireTokenByUsernamePasswordOptions struct {
 	claims, tenantID string
+	authnScheme      AuthenticationScheme
 }
 
 // AcquireByUsernamePasswordOption is implemented by options for AcquireTokenByUsernamePassword
@@ -374,6 +379,9 @@ func (pca Client) AcquireTokenByUsernamePassword(ctx context.Context, scopes []s
 	authParams.Claims = o.claims
 	authParams.Username = username
 	authParams.Password = password
+	if o.authnScheme != nil {
+		authParams.AuthnScheme = o.authnScheme
+	}
 
 	token, err := pca.base.Token.UsernamePassword(ctx, authParams)
 	if err != nil {

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -891,4 +891,14 @@ func TestWithAuthenticationScheme(t *testing.T) {
 		t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
 	}
 
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(mock.WithBody([]byte(`{"account_type":"Managed","cloud_audience_urn":"urn","cloud_instance_name":"...","domain_name":"..."}`)))
+	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody(accessToken, idToken, refreshToken, clientInfo, 3600)))
+	ar, err = client.AcquireTokenByUsernamePassword(ctx, tokenScope, "username", "password", WithAuthenticationScheme(authScheme))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ar.AccessToken != fmt.Sprintf(mock.Authnschemeformat, accessToken) {
+		t.Fatalf(`unexpected access token "%s"`, ar.AccessToken)
+	}
 }

--- a/apps/tests/devapps/client_certificate_sample.go
+++ b/apps/tests/devapps/client_certificate_sample.go
@@ -28,8 +28,8 @@ func createAppWithCert() *confidential.Client {
 
 	// This extracts our public certificates and private key from the PEM file. If it is
 	// encrypted, the second argument must be password to decode.
-	// IMPORTANT SECURITY NOTICE: never store passwords in code. The recommended pattern is to keep the certificate in a vault (e.g. Azure KeyVault) 
-	// and to download it when the application starts. 
+	// IMPORTANT SECURITY NOTICE: never store passwords in code. The recommended pattern is to keep the certificate in a vault (e.g. Azure KeyVault)
+	// and to download it when the application starts.
 	certs, privateKey, err := confidential.CertFromPEM(pemData, "")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## What is the change?
Adds support for `authnScheme` in `AcquireTokenByUsernamePassword` flow.

Currently, automated testing for AzRBAC and PoP token flow relies on SPN login, which uses the msal `confidential` client. However, most customers will be using the interactive login flow which uses msal's `public` client. In order to enable better testing of the customer scenario, this change enables PoP token support for username/password flow so that automated testing can be conducted for the `public` client.

## How was the change tested?
Vendored this commit on `msal` into my local branch of `kubelogin`. Was able to successfully build `kubelogin` and get a PoP token using ropc (username/password flow):

```
./kubelogin get-token -l ropc --client-id <clientid> --server-id <serverid> --tenant-id <msft-tenant-id> --username k8connectsa@microsoft.com --password <redacted> --pop-enabled --pop-claims "u=/subscriptions/91d1cf86-13c9-4318-b47a-e536e3533061/resourceGroups/rharpavat-test/providers/Microsoft.Kubernetes/connectedClusters/e2et1"
```

Outputted token is in correct format:

```
{
  "typ": "pop",
  "alg": "RS256",
  "kid": "<kid>"
}.{
  "at": "<redacted>",
  "ts": 1707327222,
  "u": "/subscriptions/91d1cf86-13c9-4318-b47a-e536e3533061/resourceGroups/rharpavat-test/providers/Microsoft.Kubernetes/connectedClusters/e2et1",
  "cnf": {
    "jwk": {
      "e": "AQAB",
      "kty": "RSA",
      "n": "<n>",
      "alg": "RS256",
      "kid": "<kid>"
    }
  },
  "nonce": "014adc9d8a974430b6f5200e6801026f"
}.[Signature]
```