### PR TITLE
Added a new variable in AuthRepsonse "IsFromCache"

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -83,13 +83,13 @@ type AcquireTokenOnBehalfOfParameters struct {
 // AuthResult contains the results of one token acquisition operation in PublicClientApplication
 // or ConfidentialClientApplication. For details see https://aka.ms/msal-net-authenticationresult
 type AuthResult struct {
-	Account            shared.Account
-	IDToken            accesstokens.IDToken
-	AccessToken        string
-	ExpiresOn          time.Time
-	GrantedScopes      []string
-	DeclinedScopes     []string
-	AuthResultMetadata AuthResultMetadata
+	Account        shared.Account
+	IDToken        accesstokens.IDToken
+	AccessToken    string
+	ExpiresOn      time.Time
+	GrantedScopes  []string
+	DeclinedScopes []string
+	Metadata       AuthResultMetadata
 }
 
 // AuthResultMetadata which contains meta data for the AuthResult
@@ -101,8 +101,9 @@ type TokenSource int
 
 // These are all the types of token flows.
 const (
-	IdentityProvider TokenSource = 0
-	Cache            TokenSource = 1
+	SourceUnknown    TokenSource = 0
+	IdentityProvider TokenSource = 1
+	Cache            TokenSource = 2
 )
 
 // AuthResultFromStorage creates an AuthResult from a storage token response (which is generated from the cache).
@@ -130,7 +131,7 @@ func AuthResultFromStorage(storageTokenResponse storage.TokenResponse) (AuthResu
 		ExpiresOn:      storageTokenResponse.AccessToken.ExpiresOn.T,
 		GrantedScopes:  grantedScopes,
 		DeclinedScopes: nil,
-		AuthResultMetadata: AuthResultMetadata{
+		Metadata: AuthResultMetadata{
 			TokenSource: Cache,
 		},
 	}, nil
@@ -147,7 +148,7 @@ func NewAuthResult(tokenResponse accesstokens.TokenResponse, account shared.Acco
 		AccessToken:   tokenResponse.AccessToken,
 		ExpiresOn:     tokenResponse.ExpiresOn.T,
 		GrantedScopes: tokenResponse.GrantedScopes.Slice,
-		AuthResultMetadata: AuthResultMetadata{
+		Metadata: AuthResultMetadata{
 			TokenSource: IdentityProvider,
 		},
 	}, nil

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -83,14 +83,27 @@ type AcquireTokenOnBehalfOfParameters struct {
 // AuthResult contains the results of one token acquisition operation in PublicClientApplication
 // or ConfidentialClientApplication. For details see https://aka.ms/msal-net-authenticationresult
 type AuthResult struct {
-	Account        shared.Account
-	IDToken        accesstokens.IDToken
-	AccessToken    string
-	ExpiresOn      time.Time
-	GrantedScopes  []string
-	DeclinedScopes []string
-	IsFromCache    bool
+	Account            shared.Account
+	IDToken            accesstokens.IDToken
+	AccessToken        string
+	ExpiresOn          time.Time
+	GrantedScopes      []string
+	DeclinedScopes     []string
+	AuthResultMetadata AuthResultMetadata
 }
+
+// AuthResultMetadata which contains meta data for the AuthResult
+type AuthResultMetadata struct {
+	TokenSource TokenSource
+}
+
+type TokenSource int
+
+// These are all the types of token flows.
+const (
+	IdentityProvider TokenSource = 0
+	Cache            TokenSource = 1
+)
 
 // AuthResultFromStorage creates an AuthResult from a storage token response (which is generated from the cache).
 func AuthResultFromStorage(storageTokenResponse storage.TokenResponse) (AuthResult, error) {
@@ -117,7 +130,10 @@ func AuthResultFromStorage(storageTokenResponse storage.TokenResponse) (AuthResu
 		ExpiresOn:      storageTokenResponse.AccessToken.ExpiresOn.T,
 		GrantedScopes:  grantedScopes,
 		DeclinedScopes: nil,
-		IsFromCache:    true}, nil
+		AuthResultMetadata: AuthResultMetadata{
+			TokenSource: Cache,
+		},
+	}, nil
 }
 
 // NewAuthResult creates an AuthResult.
@@ -131,6 +147,9 @@ func NewAuthResult(tokenResponse accesstokens.TokenResponse, account shared.Acco
 		AccessToken:   tokenResponse.AccessToken,
 		ExpiresOn:     tokenResponse.ExpiresOn.T,
 		GrantedScopes: tokenResponse.GrantedScopes.Slice,
+		AuthResultMetadata: AuthResultMetadata{
+			TokenSource: IdentityProvider,
+		},
 	}, nil
 }
 

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -110,7 +110,14 @@ func AuthResultFromStorage(storageTokenResponse storage.TokenResponse) (AuthResu
 			return AuthResult{}, fmt.Errorf("problem decoding JWT token: %w", err)
 		}
 	}
-	return AuthResult{account, idToken, accessToken, storageTokenResponse.AccessToken.ExpiresOn.T, grantedScopes, nil, true}, nil
+	return AuthResult{
+		Account:        account,
+		IDToken:        idToken,
+		AccessToken:    accessToken,
+		ExpiresOn:      storageTokenResponse.AccessToken.ExpiresOn.T,
+		GrantedScopes:  grantedScopes,
+		DeclinedScopes: nil,
+		IsFromCache:    true}, nil
 }
 
 // NewAuthResult creates an AuthResult.
@@ -124,7 +131,6 @@ func NewAuthResult(tokenResponse accesstokens.TokenResponse, account shared.Acco
 		AccessToken:   tokenResponse.AccessToken,
 		ExpiresOn:     tokenResponse.ExpiresOn.T,
 		GrantedScopes: tokenResponse.GrantedScopes.Slice,
-		IsFromCache:   false,
 	}, nil
 }
 

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -89,6 +89,7 @@ type AuthResult struct {
 	ExpiresOn      time.Time
 	GrantedScopes  []string
 	DeclinedScopes []string
+	IsFromCache    bool
 }
 
 // AuthResultFromStorage creates an AuthResult from a storage token response (which is generated from the cache).
@@ -109,7 +110,7 @@ func AuthResultFromStorage(storageTokenResponse storage.TokenResponse) (AuthResu
 			return AuthResult{}, fmt.Errorf("problem decoding JWT token: %w", err)
 		}
 	}
-	return AuthResult{account, idToken, accessToken, storageTokenResponse.AccessToken.ExpiresOn.T, grantedScopes, nil}, nil
+	return AuthResult{account, idToken, accessToken, storageTokenResponse.AccessToken.ExpiresOn.T, grantedScopes, nil, true}, nil
 }
 
 // NewAuthResult creates an AuthResult.
@@ -123,6 +124,7 @@ func NewAuthResult(tokenResponse accesstokens.TokenResponse, account shared.Acco
 		AccessToken:   tokenResponse.AccessToken,
 		ExpiresOn:     tokenResponse.ExpiresOn.T,
 		GrantedScopes: tokenResponse.GrantedScopes.Slice,
+		IsFromCache:   false,
 	}, nil
 }
 

--- a/apps/internal/base/base_test.go
+++ b/apps/internal/base/base_test.go
@@ -344,7 +344,7 @@ func TestCreateAuthenticationResult(t *testing.T) {
 				ExpiresOn:      future,
 				GrantedScopes:  []string{"user.read"},
 				DeclinedScopes: nil,
-				AuthResultMetadata: AuthResultMetadata{
+				Metadata: AuthResultMetadata{
 					TokenSource: IdentityProvider,
 				},
 			},
@@ -419,7 +419,7 @@ func TestAuthResultFromStorage(t *testing.T) {
 				},
 				ExpiresOn:     future,
 				GrantedScopes: []string{"profile", "openid", "user.read"},
-				AuthResultMetadata: AuthResultMetadata{
+				Metadata: AuthResultMetadata{
 					TokenSource: Cache,
 				},
 			},

--- a/apps/internal/base/base_test.go
+++ b/apps/internal/base/base_test.go
@@ -344,6 +344,7 @@ func TestCreateAuthenticationResult(t *testing.T) {
 				ExpiresOn:      future,
 				GrantedScopes:  []string{"user.read"},
 				DeclinedScopes: nil,
+				IsFromCache:    false,
 			},
 		},
 		{
@@ -416,6 +417,7 @@ func TestAuthResultFromStorage(t *testing.T) {
 				},
 				ExpiresOn:     future,
 				GrantedScopes: []string{"profile", "openid", "user.read"},
+				IsFromCache:   true,
 			},
 		},
 	}

--- a/apps/internal/base/base_test.go
+++ b/apps/internal/base/base_test.go
@@ -344,7 +344,9 @@ func TestCreateAuthenticationResult(t *testing.T) {
 				ExpiresOn:      future,
 				GrantedScopes:  []string{"user.read"},
 				DeclinedScopes: nil,
-				IsFromCache:    false,
+				AuthResultMetadata: AuthResultMetadata{
+					TokenSource: IdentityProvider,
+				},
 			},
 		},
 		{
@@ -417,7 +419,9 @@ func TestAuthResultFromStorage(t *testing.T) {
 				},
 				ExpiresOn:     future,
 				GrantedScopes: []string{"profile", "openid", "user.read"},
-				IsFromCache:   true,
+				AuthResultMetadata: AuthResultMetadata{
+					TokenSource: Cache,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
# Add `AuthResultMetadata` and `TokenSource` to `AuthResult`

## Description

This pull request introduces two main changes to the authentication result:

1. **`AuthResultMetadata` Struct**: A new struct, `AuthResultMetadata`, has been added to the `AuthResult` struct. This struct will be responsible for holding additional metadata related to authentication results.

2. **`TokenSource` Property**: A new property, `TokenSource`, has been introduced in the `AuthResultMetadata` struct. The `TokenSource` property indicates the origin of the token, with two possible values:
   - `IdentityProvider`: The token was obtained directly from an identity provider.
   - `Cached`: The token was retrieved from a cache.

## Changes

- **Added**: `AuthResultMetadata` class to the `AuthResult` struct.
- **Added**: `TokenSource` within `AuthResultMetadata` with possible values of `IdentityProvider` and `Cached`.
- **Updated**: `AuthResult` class to include the `AuthResultMetadata` instance.

## How to Test

1. Run the authentication process and inspect the `AuthResult` object.
2. Verify that the `AuthResultMetadata` object is correctly populated.
3. Check the `TokenSource` value to ensure it accurately reflects whether the token was retrieved from the `IdentityProvider` or from `Cached`.
