### PR TITLE
Wrap ResolveEndpoints error

### DIFF
--- a/apps/internal/oauth/oauth.go
+++ b/apps/internal/oauth/oauth.go
@@ -331,7 +331,7 @@ func (t *Client) DeviceCode(ctx context.Context, authParams authority.AuthParams
 func (t *Client) resolveEndpoint(ctx context.Context, authParams *authority.AuthParams, userPrincipalName string) error {
 	endpoints, err := t.Resolver.ResolveEndpoints(ctx, authParams.AuthorityInfo, userPrincipalName)
 	if err != nil {
-		return fmt.Errorf("unable to resolve an endpoint: %s", err)
+		return fmt.Errorf("unable to resolve an endpoint: %w", err)
 	}
 	authParams.Endpoints = endpoints
 	return nil


### PR DESCRIPTION
This PR changes the endpoint resolve error formatting to use wrapping instead of stringifying the error. ATM it's not possible for a caller to convert the underlying error to a `CallErr` which makes it hard to do programmatic error handling. 