### PR TITLE
Added Region auto enable

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -18,6 +18,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/base"
@@ -315,16 +317,21 @@ func New(authority, clientID string, cred Credential, options ...Option) (Client
 	if err != nil {
 		return Client{}, err
 	}
-
+	region := os.Getenv("MSAL_FORCE_REGION")
 	opts := clientOptions{
 		authority: authority,
 		// if the caller specified a token provider, it will handle all details of authentication, using Client only as a token cache
 		disableInstanceDiscovery: cred.tokenProvider != nil,
 		httpClient:               shared.DefaultClient,
+		azureRegion:              region,
 	}
 	for _, o := range options {
 		o(&opts)
 	}
+	if strings.EqualFold(opts.azureRegion, "DisableMsalForceRegion") {
+		opts.azureRegion = ""
+	}
+
 	baseOpts := []base.Option{
 		base.WithCacheAccessor(opts.accessor),
 		base.WithClientCapabilities(opts.capabilities),

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -317,13 +317,13 @@ func New(authority, clientID string, cred Credential, options ...Option) (Client
 	if err != nil {
 		return Client{}, err
 	}
-	region := os.Getenv("MSAL_FORCE_REGION")
+	autoEnabledRegion := os.Getenv("MSAL_FORCE_REGION")
 	opts := clientOptions{
 		authority: authority,
 		// if the caller specified a token provider, it will handle all details of authentication, using Client only as a token cache
 		disableInstanceDiscovery: cred.tokenProvider != nil,
 		httpClient:               shared.DefaultClient,
-		azureRegion:              region,
+		azureRegion:              autoEnabledRegion,
 	}
 	for _, o := range options {
 		o(&opts)

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -164,73 +164,76 @@ func TestAcquireTokenByCredential(t *testing.T) {
 	}
 }
 
-func TestRegionAutoEnable(t *testing.T) {
+func TestRegionAutoEnable_EmptyRegion_EnvRegion(t *testing.T) {
 	cred, err := NewCredFromSecret(fakeSecret)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tests := []struct {
-		region    string
-		envRegion string
-	}{
-		{
-			region:    "",
-			envRegion: "envRegion",
-		},
-		{
-			region:    "region",
-			envRegion: "envRegion",
-		},
-		{
-			region:    "DisableMsalForceRegion",
-			envRegion: "envRegion",
-		},
+
+	envRegion := "envRegion"
+	err = os.Setenv("MSAL_FORCE_REGION", envRegion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Unsetenv("MSAL_FORCE_REGION")
+
+	lmo := "login.microsoftonline.com"
+	tenant := "tenant"
+	mockClient := mock.Client{}
+	client, err := New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient))
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	for _, test := range tests {
-		lmo := "login.microsoftonline.com"
-		tenant := "tenant"
-		mockClient := mock.Client{}
-		if test.envRegion != "" {
-			err := os.Setenv("MSAL_FORCE_REGION", test.envRegion)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		var client Client
-		if test.region != "" {
-			client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(test.region))
-			if err != nil {
-				t.Fatal(err)
-			}
-		} else {
-			client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient))
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
+	if client.base.AuthParams.AuthorityInfo.Region != envRegion {
+		t.Fatalf("wanted %q, got %q", envRegion, client.base.AuthParams.AuthorityInfo.Region)
+	}
+}
 
-		t.Cleanup(func() {
-			os.Unsetenv("MSAL_FORCE_REGION")
-		})
-		if test.region == "" {
-			if test.envRegion != "" {
-				if client.base.AuthParams.AuthorityInfo.Region != test.envRegion {
-					t.Fatalf("wanted %q, got %q", test.envRegion, client.base.AuthParams.AuthorityInfo.Region)
-				}
-			}
-		} else {
-			if test.region == "DisableMsalForceRegion" {
-				if client.base.AuthParams.AuthorityInfo.Region != "" {
-					t.Fatalf("wanted empty, got %q", client.base.AuthParams.AuthorityInfo.Region)
-				}
-			} else {
+func TestRegionAutoEnable_SpecifiedRegion_EnvRegion(t *testing.T) {
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-				if client.base.AuthParams.AuthorityInfo.Region != test.region {
-					t.Fatalf("wanted %q, got %q", test.region, client.base.AuthParams.AuthorityInfo.Region)
-				}
-			}
-		}
+	envRegion := "envRegion"
+	err = os.Setenv("MSAL_FORCE_REGION", envRegion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Unsetenv("MSAL_FORCE_REGION")
+
+	lmo := "login.microsoftonline.com"
+	tenant := "tenant"
+	mockClient := mock.Client{}
+	testRegion := "region"
+	client, err := New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(testRegion))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client.base.AuthParams.AuthorityInfo.Region != testRegion {
+		t.Fatalf("wanted %q, got %q", testRegion, client.base.AuthParams.AuthorityInfo.Region)
+	}
+}
+
+func TestRegionAutoEnable_DisableMsalForceRegion(t *testing.T) {
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lmo := "login.microsoftonline.com"
+	tenant := "tenant"
+	mockClient := mock.Client{}
+	testRegion := "DisableMsalForceRegion"
+	client, err := New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(testRegion))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client.base.AuthParams.AuthorityInfo.Region != "" {
+		t.Fatalf("wanted empty, got %q", client.base.AuthParams.AuthorityInfo.Region)
 	}
 }
 


### PR DESCRIPTION
# Pull Request: Added Region Auto Enable

## Related Issue
This PR addresses [Issue #507](https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/507) which discusses the need for automatic region enablement based on specific conditions.

## Summary
This pull request introduces functionality to automatically enable the region setting when certain criteria are met. This enhancement simplifies configuration management and improves user experience by reducing the need for manual adjustments.

## Changes Made in Confidential Client
- Implemented logic to auto-enable the region based on environment variables and existing configurations.
- Updated the configuration validation to ensure compatibility with custom instance discovery metadata.
- Added unit tests to verify the new behavior.


