### PR TITLE
Revert WithTenantID("adfs") regression

### DIFF
--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -380,8 +380,9 @@ func NewInfoFromAuthorityURI(authority string, validateAuthority bool, instanceD
 		return Info{}, errors.New(`authority must be an URL such as "https://login.microsoftonline.com/<your tenant>"`)
 	}
 
-	var authorityType, tenant string
-	switch pathParts[1] {
+	authorityType := AAD
+	tenant := pathParts[1]
+	switch tenant {
 	case "adfs":
 		authorityType = ADFS
 	case "dstsv2":
@@ -393,9 +394,6 @@ func NewInfoFromAuthorityURI(authority string, validateAuthority bool, instanceD
 		}
 		authorityType = DSTS
 		tenant = DSTSTenant
-	default:
-		authorityType = AAD
-		tenant = pathParts[1]
 	}
 
 	// u.Host includes the port, if any, which is required for private cloud deployments

--- a/apps/internal/oauth/ops/authority/authority_test.go
+++ b/apps/internal/oauth/ops/authority/authority_test.go
@@ -330,8 +330,8 @@ func TestAuthorityParsing(t *testing.T) {
 	}{
 		"AAD with slash":     {"https://login.microsoftonline.com/common/", "MSSTS", "https://login.microsoftonline.com/common/", "common"},
 		"AAD without slash":  {"https://login.microsoftonline.com/common", "MSSTS", "https://login.microsoftonline.com/common/", "common"},
-		"ADFS with slash":    {"https://adfs.example.com/adfs/", "ADFS", "https://adfs.example.com/adfs/", ""},
-		"ADFS without slash": {"https://adfs.example.com/adfs", "ADFS", "https://adfs.example.com/adfs/", ""},
+		"ADFS with slash":    {"https://adfs.example.com/adfs/", "ADFS", "https://adfs.example.com/adfs/", "adfs"},
+		"ADFS without slash": {"https://adfs.example.com/adfs", "ADFS", "https://adfs.example.com/adfs/", "adfs"},
 		"dSTS with slash":    {dSTSWithSlash, "DSTS", dSTSWithSlash, DSTSTenant},
 		"dSTS without slash": {dSTSNoSlash, "DSTS", dSTSWithSlash, DSTSTenant},
 	}
@@ -364,6 +364,7 @@ func TestAuthParamsWithTenant(t *testing.T) {
 	}{
 		"do nothing if tenant override is empty":          {authority: host + uuid1, tenant: "", expectedAuthority: host + uuid1},
 		"do nothing if tenant override is empty for ADFS": {authority: host + "adfs", tenant: "", expectedAuthority: host + "adfs"},
+		`do nothing if tenant override is adfs for ADFS`:  {authority: host + "adfs", tenant: "adfs", expectedAuthority: host + "adfs"},
 		"do nothing if tenant override equals tenant":     {authority: host + uuid1, tenant: uuid1, expectedAuthority: host + uuid1},
 
 		"override common to tenant":        {authority: host + "common", tenant: uuid1, expectedAuthority: host + uuid1},


### PR DESCRIPTION
In v1.3.0, calls like this against an ADFS authority return an error "ADFS authority doesn't support tenants":
```go
client.AcquireTokenSilent(ctx, scopes, confidential.WithTenantID("adfs"))
```
This happens because #482 made the tenant of an ADFS authority `""`. In prior versions, that tenant was "adfs", making `WithTenantID("adfs")` a no-op.