### PR TITLE
Consider scopes when searching cache

### DIFF
--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -150,7 +150,6 @@ func createIMDSAuthRequest(ctx context.Context, id ID, resource string, claims s
 	}
 	msiParameters := msiEndpoint.Query()
 	msiParameters.Set(apiVersionQuerryParameterName, imdsAPIVersion)
-	resource = strings.TrimSuffix(resource, "/.default")
 	msiParameters.Set(resourceQuerryParameterName, resource)
 
 	if len(claims) > 0 {
@@ -220,6 +219,7 @@ func (client Client) getTokenForRequest(req *http.Request) (accesstokens.TokenRe
 // Resource: scopes application is requesting access to
 // Options: [WithClaims]
 func (client Client) AcquireToken(ctx context.Context, resource string, options ...AcquireTokenOption) (base.AuthResult, error) {
+	resource = strings.TrimSuffix(resource, "/.default")
 	o := AcquireTokenOptions{}
 
 	for _, option := range options {

--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -230,23 +230,24 @@ func (client Client) AcquireToken(ctx context.Context, resource string, options 
 		return base.AuthResult{}, err
 	}
 
-	fakeAuthInfo, err := authority.NewInfoFromAuthorityURI("https://login.microsoftonline.com/managed_identity", false, true)
+	authInfo, err := authority.NewInfoFromAuthorityURI("https://login.microsoftonline.com/managed_identity", false, true)
 	if err != nil {
 		return base.AuthResult{}, err
 	}
-	fakeAuthParams := authority.NewAuthParams(client.miType.value(), fakeAuthInfo)
+	authParams := authority.NewAuthParams(client.miType.value(), authInfo)
+	authParams.Scopes = []string{resource}
 	// ignore cached access tokens when given claims
 	if o.claims == "" {
 		if cacheManager == nil {
 			return base.AuthResult{}, errors.New("cache instance is nil")
 		}
-		storageTokenResponse, err := cacheManager.Read(ctx, fakeAuthParams)
+		storageTokenResponse, err := cacheManager.Read(ctx, authParams)
 		if err != nil {
 			return base.AuthResult{}, err
 		}
 		ar, err := base.AuthResultFromStorage(storageTokenResponse)
 		if err == nil {
-			ar.AccessToken, err = fakeAuthParams.AuthnScheme.FormatAccessToken(ar.AccessToken)
+			ar.AccessToken, err = authParams.AuthnScheme.FormatAccessToken(ar.AccessToken)
 			return ar, err
 		}
 	}
@@ -254,7 +255,7 @@ func (client Client) AcquireToken(ctx context.Context, resource string, options 
 	if err != nil {
 		return base.AuthResult{}, err
 	}
-	return authResultFromToken(fakeAuthParams, tokenResponse)
+	return authResultFromToken(authParams, tokenResponse)
 }
 
 func authResultFromToken(authParams authority.AuthParams, token accesstokens.TokenResponse) (base.AuthResult, error) {

--- a/apps/managedidentity/managedidentity_test.go
+++ b/apps/managedidentity/managedidentity_test.go
@@ -128,6 +128,35 @@ func Test_SystemAssigned_Returns_AcquireToken_Failure(t *testing.T) {
 	}
 }
 
+func TestCacheScopes(t *testing.T) {
+	before := cacheManager
+	defer func() { cacheManager = before }()
+	cacheManager = storage.New(nil)
+
+	const (
+		a = "A"
+		b = "B/.default"
+	)
+	mc := mock.Client{}
+	client, err := New(SystemAssigned(), WithHTTPClient(&mc))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range []string{a, b} {
+		mc.AppendResponse(mock.WithBody(mock.GetAccessTokenBody(r, "", "", "", 3600)))
+		for i := 0; i < 2; i++ {
+			ar, err := client.AcquireToken(context.Background(), r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ar.AccessToken != r {
+				t.Fatalf("expected %q, got %q", r, ar.AccessToken)
+			}
+		}
+	}
+}
+
 func Test_SystemAssigned_Returns_Token_Success(t *testing.T) {
 	testCases := []resourceTestData{
 		{source: DefaultToIMDS, endpoint: imdsEndpoint, resource: resource, miType: SystemAssigned()},

--- a/apps/managedidentity/managedidentity_test.go
+++ b/apps/managedidentity/managedidentity_test.go
@@ -133,17 +133,13 @@ func TestCacheScopes(t *testing.T) {
 	defer func() { cacheManager = before }()
 	cacheManager = storage.New(nil)
 
-	const (
-		a = "A"
-		b = "B/.default"
-	)
 	mc := mock.Client{}
 	client, err := New(SystemAssigned(), WithHTTPClient(&mc))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, r := range []string{a, b} {
+	for _, r := range []string{"A", "B/.default"} {
 		mc.AppendResponse(mock.WithBody(mock.GetAccessTokenBody(r, "", "", "", 3600)))
 		for i := 0; i < 2; i++ {
 			ar, err := client.AcquireToken(context.Background(), r)


### PR DESCRIPTION
`AcquireToken` never sets `AuthParams.Scopes`, so `Scopes` is always an empty slice, which happens to match any access token in the cache. Arguably, `Read` should return an error when no scopes are specified, but we can leave that to another PR.