### PR TITLE
Fix Bug: Prevent Empty Region in WithAzureRegion from Overriding MSAL_FORCE_REGION

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -305,7 +305,9 @@ func WithInstanceDiscovery(enabled bool) Option {
 // If an invalid region name is provided, the non-regional endpoint MIGHT be used or the token request MIGHT fail.
 func WithAzureRegion(val string) Option {
 	return func(o *clientOptions) {
-		o.azureRegion = val
+		if val != "" {
+			o.azureRegion = val
+		}
 	}
 }
 

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -235,13 +235,8 @@ func TestRegionAutoEnable_SpecifiedEmptyRegion_EnvRegion(t *testing.T) {
 				t.Fatal(err)
 			}
 			if test.envRegion != "" {
-				err = os.Setenv("MSAL_FORCE_REGION", test.envRegion)
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer os.Unsetenv("MSAL_FORCE_REGION")
+				t.Setenv("MSAL_FORCE_REGION", test.envRegion)
 			}
-
 			lmo := "login.microsoftonline.com"
 			tenant := "tenant"
 			mockClient := mock.Client{}
@@ -256,7 +251,6 @@ func TestRegionAutoEnable_SpecifiedEmptyRegion_EnvRegion(t *testing.T) {
 				if client.base.AuthParams.AuthorityInfo.Region != "" {
 					t.Fatalf("wanted %q, got %q", test.resultRegion, client.base.AuthParams.AuthorityInfo.Region)
 				}
-				return
 			} else {
 				if client.base.AuthParams.AuthorityInfo.Region != test.resultRegion {
 					t.Fatalf("wanted %q, got %q", test.resultRegion, client.base.AuthParams.AuthorityInfo.Region)

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -247,17 +247,10 @@ func TestRegionAutoEnable_SpecifiedEmptyRegion_EnvRegion(t *testing.T) {
 			mockClient := mock.Client{}
 
 			var client Client
-			// if test.region != "" {
 			client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(test.region))
 			if err != nil {
 				t.Fatal(err)
 			}
-			// } else {
-			// 	client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient))
-			// 	if err != nil {
-			// 		t.Fatal(err)
-			// 	}
-			// }
 
 			if test.resultRegion == "DisableMsalForceRegion" {
 				if client.base.AuthParams.AuthorityInfo.Region != "" {

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -241,8 +241,7 @@ func TestRegionAutoEnable_SpecifiedEmptyRegion_EnvRegion(t *testing.T) {
 			tenant := "tenant"
 			mockClient := mock.Client{}
 
-			var client Client
-			client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(test.region))
+			client, err := New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(test.region))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -251,10 +250,8 @@ func TestRegionAutoEnable_SpecifiedEmptyRegion_EnvRegion(t *testing.T) {
 				if client.base.AuthParams.AuthorityInfo.Region != "" {
 					t.Fatalf("wanted %q, got %q", test.resultRegion, client.base.AuthParams.AuthorityInfo.Region)
 				}
-			} else {
-				if client.base.AuthParams.AuthorityInfo.Region != test.resultRegion {
-					t.Fatalf("wanted %q, got %q", test.resultRegion, client.base.AuthParams.AuthorityInfo.Region)
-				}
+			} else if client.base.AuthParams.AuthorityInfo.Region != test.resultRegion {
+				t.Fatalf("wanted %q, got %q", test.resultRegion, client.base.AuthParams.AuthorityInfo.Region)
 			}
 		})
 	}

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -195,50 +195,81 @@ func TestRegionAutoEnable_EmptyRegion_EnvRegion(t *testing.T) {
 	}
 }
 
-func TestRegionAutoEnable_SpecifiedRegion_EnvRegion(t *testing.T) {
-	cred, err := NewCredFromSecret(fakeSecret)
-	if err != nil {
-		t.Fatal(err)
+func TestRegionAutoEnable_SpecifiedEmptyRegion_EnvRegion(t *testing.T) {
+	tests := []struct {
+		name         string
+		envRegion    string
+		region       string
+		resultRegion string
+	}{
+		{
+			name:         "Region is empty, envRegion is set",
+			envRegion:    "region",
+			region:       "",
+			resultRegion: "region",
+		},
+		{
+			name:         "Region is set, envRegion is set",
+			envRegion:    "region",
+			region:       "setRegion",
+			resultRegion: "setRegion",
+		},
+		{
+			name:         "Region is set, envRegion is empty",
+			envRegion:    "",
+			region:       "setRegion",
+			resultRegion: "setRegion",
+		},
+		{
+			name:         "Disable region is set, envRegion is set",
+			envRegion:    "region",
+			region:       "DisableMsalForceRegion",
+			resultRegion: "",
+		},
 	}
 
-	envRegion := "envRegion"
-	err = os.Setenv("MSAL_FORCE_REGION", envRegion)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Unsetenv("MSAL_FORCE_REGION")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cred, err := NewCredFromSecret(fakeSecret)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.envRegion != "" {
+				err = os.Setenv("MSAL_FORCE_REGION", test.envRegion)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.Unsetenv("MSAL_FORCE_REGION")
+			}
 
-	lmo := "login.microsoftonline.com"
-	tenant := "tenant"
-	mockClient := mock.Client{}
-	testRegion := "region"
-	client, err := New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(testRegion))
-	if err != nil {
-		t.Fatal(err)
-	}
+			lmo := "login.microsoftonline.com"
+			tenant := "tenant"
+			mockClient := mock.Client{}
 
-	if client.base.AuthParams.AuthorityInfo.Region != testRegion {
-		t.Fatalf("wanted %q, got %q", testRegion, client.base.AuthParams.AuthorityInfo.Region)
-	}
-}
+			var client Client
+			if test.region != "" {
+				client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(test.region))
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
 
-func TestRegionAutoEnable_DisableMsalForceRegion(t *testing.T) {
-	cred, err := NewCredFromSecret(fakeSecret)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	lmo := "login.microsoftonline.com"
-	tenant := "tenant"
-	mockClient := mock.Client{}
-	testRegion := "DisableMsalForceRegion"
-	client, err := New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(testRegion))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if client.base.AuthParams.AuthorityInfo.Region != "" {
-		t.Fatalf("wanted empty, got %q", client.base.AuthParams.AuthorityInfo.Region)
+			if test.resultRegion == "DisableMsalForceRegion" {
+				if client.base.AuthParams.AuthorityInfo.Region != "" {
+					t.Fatalf("wanted %q, got %q", test.resultRegion, client.base.AuthParams.AuthorityInfo.Region)
+				}
+				return
+			} else {
+				if client.base.AuthParams.AuthorityInfo.Region != test.resultRegion {
+					t.Fatalf("wanted %q, got %q", test.resultRegion, client.base.AuthParams.AuthorityInfo.Region)
+				}
+			}
+		})
 	}
 }
 

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -247,17 +247,17 @@ func TestRegionAutoEnable_SpecifiedEmptyRegion_EnvRegion(t *testing.T) {
 			mockClient := mock.Client{}
 
 			var client Client
-			if test.region != "" {
-				client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(test.region))
-				if err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient))
-				if err != nil {
-					t.Fatal(err)
-				}
+			// if test.region != "" {
+			client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient), WithAzureRegion(test.region))
+			if err != nil {
+				t.Fatal(err)
 			}
+			// } else {
+			// 	client, err = New(fmt.Sprintf(authorityFmt, lmo, tenant), fakeClientID, cred, WithHTTPClient(&mockClient))
+			// 	if err != nil {
+			// 		t.Fatal(err)
+			// 	}
+			// }
 
 			if test.resultRegion == "DisableMsalForceRegion" {
 				if client.base.AuthParams.AuthorityInfo.Region != "" {


### PR DESCRIPTION
### **Title:** Fix Bug: Prevent Empty Region in `WithAzureRegion` from Overriding `MSAL_FORCE_REGION`

### **Description:**

This PR addresses a bug where passing an empty region (`""`) to the `WithAzureRegion` function would unintentionally override the value of the `MSAL_FORCE_REGION` environment variable, even when `MSAL_FORCE_REGION` was explicitly set. The correct behavior is that if `MSAL_FORCE_REGION` is defined, it should always take precedence over any empty region passed through `WithAzureRegion`.

### **Bug Details:**

- **Issue:** If the `MSAL_FORCE_REGION` environment variable is set, and an empty region (`""`) is passed to `WithAzureRegion`, the empty value would override the region specified by `MSAL_FORCE_REGION`. This is not the expected behavior.
- **Expected Behavior:** The value of `MSAL_FORCE_REGION` should not be overridden by an empty string passed via `WithAzureRegion`. If `MSAL_FORCE_REGION` is set, it should always take precedence.
- **Cause:** The current logic did not properly check if `WithAzureRegion` not being checked if it was assigning empty string or not. This resulted in the empty string incorrectly taking precedence over the environment variable.

### **Solution:**

The fix ensures that if `MSAL_FORCE_REGION` is set in the environment, it will always be used, and the region passed through `WithAzureRegion` will only be considered if it is not empty. This prevents accidental overrides when `MSAL_FORCE_REGION` is explicitly set.

### **Changes:**

- **Logic Update:** Updated the logic in `WithAzureRegion` to first check if value passed via `WithAzureRegion` is empty or not.
- **Unit Test:** Added tests to cover scenarios where both `MSAL_FORCE_REGION` and an empty region are provided, ensuring that the environment variable always takes precedence.