### PR TITLE
Azure ML Support

### DIFF
--- a/apps/managedidentity/azure_ml.go
+++ b/apps/managedidentity/azure_ml.go
@@ -5,7 +5,6 @@ package managedidentity
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 )
@@ -20,13 +19,9 @@ func createAzureMLAuthRequest(ctx context.Context, id ID, resource string) (*htt
 	q := req.URL.Query()
 	q.Set(apiVersionQueryParameterName, azureMLAPIVersion)
 	q.Set(resourceQueryParameterName, resource)
-
-	switch t := id.(type) {
-	case UserAssignedClientID:
-		q.Set("clientid", string(t))
-	case systemAssignedValue:
-	default:
-		return nil, fmt.Errorf("unsupported type %T", id)
+	q.Set("clientid", os.Getenv("DEFAULT_IDENTITY_CLIENT_ID"))
+	if cid, ok := id.(UserAssignedClientID); ok {
+		q.Set("clientid", string(cid))
 	}
 	req.URL.RawQuery = q.Encode()
 	return req, nil

--- a/apps/managedidentity/azure_ml.go
+++ b/apps/managedidentity/azure_ml.go
@@ -18,16 +18,12 @@ func createAzureMLAuthRequest(ctx context.Context, id ID, resource string) (*htt
 
 	req.Header.Set("secret", os.Getenv(msiSecretEnvVar))
 	q := req.URL.Query()
-	q.Set(apiVersionQueryParameterName, azureMlApiVersion)
+	q.Set(apiVersionQueryParameterName, azureMLAPIVersion)
 	q.Set(resourceQueryParameterName, resource)
 
 	switch t := id.(type) {
 	case UserAssignedClientID:
-		q.Set(miQueryParameterClientId, string(t))
-	case UserAssignedResourceID:
-		return nil, fmt.Errorf("unsupported type %T", id)
-	case UserAssignedObjectID:
-		return nil, fmt.Errorf("unsupported type %T", id)
+		q.Set("clientid", string(t))
 	case systemAssignedValue:
 	default:
 		return nil, fmt.Errorf("unsupported type %T", id)

--- a/apps/managedidentity/azure_ml.go
+++ b/apps/managedidentity/azure_ml.go
@@ -11,16 +11,15 @@ import (
 )
 
 func createAzureMLAuthRequest(ctx context.Context, id ID, resource string) (*http.Request, error) {
-	msiSecretEndpoint := os.Getenv(msiSecretEnvVar)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, msiSecretEndpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, os.Getenv(msiEndpointEnvVar), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("secret", os.Getenv(msiSecretEndpoint))
+	req.Header.Set("secret", os.Getenv(msiSecretEnvVar))
 	q := req.URL.Query()
-	q.Set("api-version", azureMLAPIVersion)
-	q.Set("resource", resource)
+	q.Set(apiVersionQueryParameterName, azureMlApiVersion)
+	q.Set(resourceQueryParameterName, resource)
 
 	switch t := id.(type) {
 	case UserAssignedClientID:

--- a/apps/managedidentity/azure_ml.go
+++ b/apps/managedidentity/azure_ml.go
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package managedidentity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+func createAzureMLAuthRequest(ctx context.Context, id ID, resource string) (*http.Request, error) {
+	msiSecretEndpoint := os.Getenv(msiSecretEnvVar)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, msiSecretEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("secret", os.Getenv(msiSecretEndpoint))
+	q := req.URL.Query()
+	q.Set("api-version", azureMLAPIVersion)
+	q.Set("resource", resource)
+
+	switch t := id.(type) {
+	case UserAssignedClientID:
+		q.Set(miQueryParameterClientId, string(t))
+	case UserAssignedResourceID:
+		return nil, fmt.Errorf("unsupported type %T", id)
+	case UserAssignedObjectID:
+		return nil, fmt.Errorf("unsupported type %T", id)
+	case systemAssignedValue:
+	default:
+		return nil, fmt.Errorf("unsupported type %T", id)
+	}
+	req.URL.RawQuery = q.Encode()
+	return req, nil
+}

--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -73,7 +73,7 @@ const (
 	appServiceAPIVersion = "2019-08-01"
 
 	// AzureML
-	azureMlApiVersion = "2017-09-01"
+	azureMLAPIVersion = "2017-09-01"
 
 	// Environment Variables
 	identityEndpointEnvVar              = "IDENTITY_ENDPOINT"

--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -72,6 +72,9 @@ const (
 	// App Service
 	appServiceAPIVersion = "2019-08-01"
 
+	// AzureML
+	azureMLAPIVersion = "2017-09-01"
+
 	// Environment Variables
 	identityEndpointEnvVar              = "IDENTITY_ENDPOINT"
 	identityHeaderEnvVar                = "IDENTITY_HEADER"
@@ -323,6 +326,8 @@ func (c Client) AcquireToken(ctx context.Context, resource string, options ...Ac
 	switch c.source {
 	case AzureArc:
 		return c.acquireTokenForAzureArc(ctx, resource)
+	case AzureML:
+		return c.acquireTokenForAzureML(ctx, resource)
 	case CloudShell:
 		return c.acquireTokenForCloudShell(ctx, resource)
 	case DefaultToIMDS:
@@ -360,6 +365,18 @@ func (c Client) acquireTokenForIMDS(ctx context.Context, resource string) (base.
 
 func (c Client) acquireTokenForCloudShell(ctx context.Context, resource string) (base.AuthResult, error) {
 	req, err := createCloudShellAuthRequest(ctx, resource)
+	if err != nil {
+		return base.AuthResult{}, err
+	}
+	tokenResponse, err := c.getTokenForRequest(req, resource)
+	if err != nil {
+		return base.AuthResult{}, err
+	}
+	return authResultFromToken(c.authParams, tokenResponse)
+}
+
+func (c Client) acquireTokenForAzureML(ctx context.Context, resource string) (base.AuthResult, error) {
+	req, err := createAzureMLAuthRequest(ctx, c.miType, resource)
 	if err != nil {
 		return base.AuthResult{}, err
 	}

--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -73,7 +73,7 @@ const (
 	appServiceAPIVersion = "2019-08-01"
 
 	// AzureML
-	azureMLAPIVersion = "2017-09-01"
+	azureMlApiVersion = "2017-09-01"
 
 	// Environment Variables
 	identityEndpointEnvVar              = "IDENTITY_ENDPOINT"

--- a/apps/managedidentity/managedidentity_test.go
+++ b/apps/managedidentity/managedidentity_test.go
@@ -710,10 +710,19 @@ func TestAzureMLAcquireTokenReturnsTokenSuccess(t *testing.T) {
 				t.Fatal("suffix /.default was not removed.")
 			}
 			if result.Metadata.TokenSource != base.IdentityProvider {
-				t.Fatalf("expected IndenityProvider tokensource, got %d", result.Metadata.TokenSource)
+				t.Fatalf("expected IdentityProvider tokensource, got %d", result.Metadata.TokenSource)
 			}
 			if result.AccessToken != token {
 				t.Fatalf("wanted %q, got %q", token, result.AccessToken)
+			}
+			if testCase.miType.value() == "clientId" {
+				if query.Get("clientid") != "clientId" {
+					t.Fatalf("expected clientid to be set to clientId, got %s", query.Get("clientid"))
+				}
+			} else {
+				if query.Get("clientid") != os.Getenv("DEFAULT_IDENTITY_CLIENT_ID") {
+					t.Fatalf("expected clientid to be set to default identity client id, got %s", query.Get("clientid"))
+				}
 			}
 			result, err = client.AcquireToken(context.Background(), testCase.resource)
 			if err != nil {

--- a/apps/managedidentity/managedidentity_test.go
+++ b/apps/managedidentity/managedidentity_test.go
@@ -698,15 +698,13 @@ func TestAzureMLAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			println(localUrl.String())
-			println(endpoint)
 			if localUrl == nil || !strings.HasPrefix(localUrl.String(), endpoint) {
 				t.Fatalf("url request is not on %s got %s", endpoint, localUrl)
 			}
 			query := localUrl.Query()
 
-			if query.Get(apiVersionQueryParameterName) != azureMlApiVersion {
-				t.Fatalf("api-version not on %s got %s", azureMlApiVersion, query.Get(apiVersionQueryParameterName))
+			if query.Get(apiVersionQueryParameterName) != azureMLAPIVersion {
+				t.Fatalf("api-version not on %s got %s", azureMLAPIVersion, query.Get(apiVersionQueryParameterName))
 			}
 			if r := query.Get(resourceQueryParameterName); strings.HasSuffix(r, "/.default") {
 				t.Fatal("suffix /.default was not removed.")

--- a/apps/managedidentity/managedidentity_test.go
+++ b/apps/managedidentity/managedidentity_test.go
@@ -661,10 +661,8 @@ func TestAppServiceAcquireTokenReturnsTokenSuccess(t *testing.T) {
 }
 
 func TestAzureMLAcquireTokenReturnsTokenSuccess(t *testing.T) {
-	// Set the DEFAULT_IDENTITY_CLIENT_ID environment variable
 	defaultClientID := "A"
-	os.Setenv("DEFAULT_IDENTITY_CLIENT_ID", defaultClientID)
-	defer os.Unsetenv("DEFAULT_IDENTITY_CLIENT_ID")
+	t.Setenv("DEFAULT_IDENTITY_CLIENT_ID", defaultClientID)
 
 	setEnvVars(t, AzureML)
 	testCases := []struct {
@@ -721,8 +719,8 @@ func TestAzureMLAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if result.AccessToken != token {
 				t.Fatalf("wanted %q, got %q", token, result.AccessToken)
 			}
-			if query.Get("clientid") != testCase.expectedClientID {
-				t.Fatalf("expected clientid to be set to %s, got %s", testCase.expectedClientID, query.Get("clientid"))
+			if actual := query.Get("clientid"); actual != testCase.expectedClientID {
+				t.Fatalf("expected clientid to be set to %s, got %s", testCase.expectedClientID, actual)
 			}
 
 			result, err = client.AcquireToken(context.Background(), testCase.resource)

--- a/apps/tests/devapps/managedidentity/managedidentity_sample.go
+++ b/apps/tests/devapps/managedidentity/managedidentity_sample.go
@@ -23,7 +23,7 @@ func runIMDSSystemAssigned() {
 }
 
 func runIMDSUserAssigned() {
-	miUserAssigned, err := mi.New(mi.UserAssignedClientID("YOUR_CLIENT_ID"))
+	miUserAssigned, err := mi.New(mi.UserAssignedClientID("fd0f0256-9a81-412b-a8dc-d745498b580b"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/apps/tests/devapps/managedidentity/managedidentity_sample.go
+++ b/apps/tests/devapps/managedidentity/managedidentity_sample.go
@@ -36,7 +36,7 @@ func runIMDSUserAssigned() {
 }
 
 func main() {
-	exampleType := "1"
+	exampleType := "2"
 
 	if exampleType == "1" {
 		runIMDSSystemAssigned()

--- a/apps/tests/devapps/managedidentity/managedidentity_sample.go
+++ b/apps/tests/devapps/managedidentity/managedidentity_sample.go
@@ -23,7 +23,7 @@ func runIMDSSystemAssigned() {
 }
 
 func runIMDSUserAssigned() {
-	miUserAssigned, err := mi.New(mi.UserAssignedClientID("fd0f0256-9a81-412b-a8dc-d745498b580b"))
+	miUserAssigned, err := mi.New(mi.UserAssignedClientID("YOUR_CLIENT_ID"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func runIMDSUserAssigned() {
 }
 
 func main() {
-	exampleType := "2"
+	exampleType := "1"
 
 	if exampleType == "1" {
 		runIMDSSystemAssigned()


### PR DESCRIPTION
Feature - Add support for AzureML (Machine Learning)

Description:
This PR adds the ability for AzureML to be used as a Managed Identity source.

Changes:
* Update logic for GetSource so we can detect when AzureML should be used
* Add AuthRequest of making an AzureML request. Similar to AppService, but with the addition to having the msiSecretEnvVar in the request header
* Updates GetSource tests to allow AzureML and AppService to be detected (was missing before)
* Adds general tests for AzureML for getting a successful response and also returning error when resource and object id are used