### PR TITLE
Added a new error InvalidJsonErr

### DIFF
--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -436,7 +436,6 @@ func TestInvalidJsonErrFromResponse(t *testing.T) {
 		`{"access_token": "%s","expires_in": %d,"expires_on": %d,"token_type": "Bearer"`,
 		tenant, 3600, time.Now().Add(time.Duration(3600)*time.Second).Unix(),
 	)
-	//	body += "}"
 	mockClient.AppendResponse(mock.WithBody([]byte(body)))
 	_, err = client.AcquireTokenByCredential(ctx, tokenScope, WithTenantID(tenant))
 	if err == nil {

--- a/apps/errors/errors.go
+++ b/apps/errors/errors.go
@@ -64,8 +64,17 @@ type CallErr struct {
 	Err  error
 }
 
+type InvalidJsonErr struct {
+	Err error
+}
+
 // Errors implements error.Error().
 func (e CallErr) Error() string {
+	return e.Err.Error()
+}
+
+// Errors implements error.Error().
+func (e InvalidJsonErr) Error() string {
 	return e.Err.Error()
 }
 

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -262,11 +262,7 @@ func (c Client) FromClientSecret(ctx context.Context, authParameters authority.A
 	qv.Set(clientID, authParameters.ClientID)
 	addScopeQueryParam(qv, authParameters)
 
-	token, err := c.doTokenResp(ctx, authParameters, qv)
-	if err != nil {
-		return token, fmt.Errorf("FromClientSecret(): %w", err)
-	}
-	return token, nil
+	return c.doTokenResp(ctx, authParameters, qv)
 }
 
 func (c Client) FromAssertion(ctx context.Context, authParameters authority.AuthParams, assertion string) (TokenResponse, error) {
@@ -281,11 +277,7 @@ func (c Client) FromAssertion(ctx context.Context, authParameters authority.Auth
 	qv.Set(clientInfo, clientInfoVal)
 	addScopeQueryParam(qv, authParameters)
 
-	token, err := c.doTokenResp(ctx, authParameters, qv)
-	if err != nil {
-		return token, fmt.Errorf("FromAssertion(): %w", err)
-	}
-	return token, nil
+	return c.doTokenResp(ctx, authParameters, qv)
 }
 
 func (c Client) FromUserAssertionClientSecret(ctx context.Context, authParameters authority.AuthParams, userAssertion string, clientSecret string) (TokenResponse, error) {

--- a/apps/internal/oauth/ops/internal/comm/comm.go
+++ b/apps/internal/oauth/ops/internal/comm/comm.go
@@ -98,7 +98,7 @@ func (c *Client) JSONCall(ctx context.Context, endpoint string, headers http.Hea
 
 	if resp != nil {
 		if err := unmarshal(data, resp); err != nil {
-			return fmt.Errorf("json decode error: %w\njson message bytes were: %s", err, string(data))
+			return errors.InvalidJsonErr{Err: fmt.Errorf("json decode error: %w\njson message bytes were: %s", err, string(data))}
 		}
 	}
 	return nil
@@ -221,7 +221,7 @@ func (c *Client) URLFormCall(ctx context.Context, endpoint string, qv url.Values
 	}
 	if resp != nil {
 		if err := unmarshal(data, resp); err != nil {
-			return fmt.Errorf("json decode error: %w\nraw message was: %s", err, string(data))
+			return errors.InvalidJsonErr{Err: fmt.Errorf("json decode error: %w\nraw message was: %s", err, string(data))}
 		}
 	}
 	return nil

--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -523,6 +523,11 @@ func (c Client) getTokenForRequest(req *http.Request, resource string) (accessto
 	}
 
 	err = json.Unmarshal(responseBytes, &r)
+	if err != nil {
+		return r, errors.InvalidJsonErr{
+			Err: fmt.Errorf("error parsing the json error: %s", err),
+		}
+	}
 	r.GrantedScopes.Slice = append(r.GrantedScopes.Slice, resource)
 
 	return r, err


### PR DESCRIPTION
### PR Description: Add Support for `InvalidJsonErr` Type

#### **Overview:**
This PR introduces the `InvalidJsonErr` type, designed to wrap an underlying error related to invalid JSON parsing. This will provide a more specific error type when dealing with JSON errors, allowing for better error handling and context.
Also resolved issue https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/549
#### **Changes:**
- **New Error Type**: Added `InvalidJsonErr` struct that wraps the original error.
  
  ```go
  type InvalidJsonErr struct {
      Err error
  }
  ```

- **Error Handling**: `InvalidJsonErr` can now be used to indicate JSON-related issues, providing better clarity when dealing with invalid JSON parsing errors.

#### **Usage Example:**

```go
func someJsonProcessingFunction() error {
    return InvalidJsonErr{Err: fmt.Errorf("invalid JSON format")}
}
```

- The `InvalidJsonErr` type wraps the error, providing more detailed information about invalid JSON issues.
  
