### PR TITLE
Unmarshal device code verification URLs

### DIFF
--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -68,7 +68,7 @@ type DeviceCodeResponse struct {
 
 	UserCode        string `json:"user_code"`
 	DeviceCode      string `json:"device_code"`
-	VerificationURL string `json:"verification_url"`
+	VerificationURL string `json:"verification_uri"`
 	ExpiresIn       int    `json:"expires_in"`
 	Interval        int    `json:"interval"`
 	Message         string `json:"message"`


### PR DESCRIPTION
`DeviceCodeResult.VerificationURL` is always `""` because its JSON tag has an incorrect key name