### PR TITLE
Do not MERGE: MSI v2 Sample: working example for MSIv2 

### DIFF
--- a/apps/managedidentity/managedidentityv2.go
+++ b/apps/managedidentity/managedidentityv2.go
@@ -1,0 +1,347 @@
+package managedidentity
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem" // Import for pemEncodeCert
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net/http"
+	"net/url"
+
+	// "os"
+	"time"
+)
+
+const (
+	searchSubject   = "CN=devicecert.mtlsauth.local"                                             // Existing cert to look for (PowerShell: $searchSubject)
+	newCertSubject  = "CN=mtls-auth"                                                             // Subject for new self-signed cert (PowerShell: $newCertSubject)
+	certStorePath   = "/tmp/certs"                                                               // Example path for storing self-signed cert on Linux (adjust as needed)
+	certFileName    = "mtls-auth.pem"                                                            // Filename for the self-signed cert
+	imdsEndpoint    = "http://169.254.169.254/metadata/identity/credential?cred-api-version=1.0" // IMDS Endpoint
+	managementScope = "https://management.azure.com/.default"                                    // Management Scope for Azure Token
+)
+
+// Define JWK struct for JSON payload
+type JWK struct {
+	Kty string   `json:"kty"`
+	Use string   `json:"use"`
+	Alg string   `json:"alg"`
+	Kid string   `json:"kid"`
+	X5c []string `json:"x5c"`
+}
+
+// Define CNF struct for JSON payload
+type CNF struct {
+	JWK JWK `json:"jwk"`
+}
+
+// Define RequestBody struct for JSON payload
+type RequestBody struct {
+	CNF      CNF  `json:"cnf"`
+	LatchKey bool `json:"latch_key"`
+}
+
+// IMDSResponse struct to unmarshal IMDS response
+type IMDSResponse struct {
+	RegionalTokenURL string `json:"regional_token_url"`
+	TenantID         string `json:"tenant_id"`
+	ClientID         string `json:"client_id"`
+	Credential       string `json:"credential"`
+}
+
+// AzureTokenResponse struct to unmarshal Azure token response
+type AzureTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	ExtExpiresIn int    `json:"ext_expires_in"`
+}
+
+func main() {
+	var cert *x509.Certificate
+	var err error
+	var tempKey *rsa.PrivateKey
+	// Step 1 & 2: Search for an existing certificate (Simplified for Linux - Implement actual search if needed)
+	// In Linux, certificate management is different from Windows.
+	// This example skips searching and directly creates a new cert for simplicity.
+	// For real-world Linux scenarios, you might need to integrate with system certificate stores
+	// or use specific paths to search for certificates.
+	fmt.Println("🔍 Searching for existing certificate... (Skipped in this example for Linux)")
+	cert = nil // In a real implementation, search logic would be here and assign to 'cert' if found.
+
+	// Step 3: If found, use it, else create a new self-signed cert
+	if cert != nil {
+		fmt.Printf("✅ Found valid certificate: %s\n", cert.Subject.String()) // If certificate search was implemented
+	} else {
+		fmt.Println("❌ No valid certificate found. Creating a new self-signed certificate...")
+		cert, tempKey, err = createSelfSignedCertificate()
+		if err != nil {
+			log.Fatalf("❌ Failed to create self-signed certificate: %v", err)
+		}
+		fmt.Printf("✅ Created certificate: %s\n", cert.Subject.String())
+	}
+
+	// Ensure cert is valid (already checked in createSelfSignedCertificate, but double check in a real search scenario)
+	if cert == nil {
+		log.Fatal("❌ No certificate found or created. Exiting.")
+	}
+
+	// Step 5: Compute SHA-256 of the Public Key for kid
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
+	if err != nil {
+		log.Fatalf("❌ Failed to marshal public key: %v", err)
+	}
+	sha256Hash := sha256.Sum256(publicKeyBytes)
+	certSha256 := hex.EncodeToString(sha256Hash[:])
+	fmt.Printf("🔐 Using SHA-256 Certificate Identifier (kid): %s\n", certSha256)
+
+	// Step 6: Convert certificate to Base64 for JWT (x5c field)
+	x5c := base64.StdEncoding.EncodeToString(cert.Raw)
+	fmt.Printf("📜 x5c: %s\n", x5c)
+
+	// Step 7: Construct the JSON body
+	bodyObject := RequestBody{
+		CNF: CNF{
+			JWK: JWK{
+				Kty: "RSA",
+				Use: "sig",
+				Alg: "RS256",
+				Kid: certSha256,
+				X5c: []string{x5c}, // Ensure correct array formatting
+			},
+		},
+		LatchKey: false, // Final version should not have this.
+	}
+
+	bodyBytes, err := json.Marshal(bodyObject)
+	if err != nil {
+		log.Fatalf("❌ Failed to marshal JSON body: %v", err)
+	}
+	body := string(bodyBytes)
+	fmt.Printf("🔹 JSON Payload: %s\n", body)
+
+	// Step 8: Request MSI credential
+	headers := map[string][]string{
+		"Metadata":               {"true"},
+		"X-ms-Client-Request-id": {generateGUID()},
+		"Content-Type":           {"application/json"}, // Important: Set Content-Type to application/json
+	}
+
+	imdsResponse, err := makeHTTPRequest("POST", imdsEndpoint, headers, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		log.Fatalf("❌ Failed to request MSI credential: %v", err)
+	}
+
+	var jsonContent IMDSResponse
+	err = json.Unmarshal(imdsResponse, &jsonContent)
+	if err != nil {
+		log.Fatalf("❌ Failed to unmarshal IMDS response: %v", err)
+	}
+
+	regionalEndpoint := jsonContent.RegionalTokenURL + "/" + jsonContent.TenantID + "/oauth2/v2.0/token"
+	fmt.Printf("✅ Using Regional Endpoint: %s\n", regionalEndpoint)
+	println(regionalEndpoint)
+	// Step 9: Authenticate with Azure
+	tokenHeaders := map[string][]string{
+		"Content-Type": {"application/x-www-form-urlencoded"},
+		"Accept":       {"application/json"},
+	}
+
+	tokenRequestBody := url.Values{}
+	tokenRequestBody.Set("grant_type", "client_credentials")
+	tokenRequestBody.Set("scope", managementScope)
+	tokenRequestBody.Set("client_id", jsonContent.ClientID)
+	tokenRequestBody.Set("client_assertion", jsonContent.Credential)
+	tokenRequestBody.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+
+	tokenResponse, err := makeHTTPRequestCert("POST", regionalEndpoint, tokenHeaders, bytes.NewBufferString(tokenRequestBody.Encode()), cert, tempKey)
+	if err != nil {
+		log.Fatalf("❌ Failed to retrieve access token: %v", err)
+	}
+
+	var tokenJson AzureTokenResponse
+	err = json.Unmarshal(tokenResponse, &tokenJson)
+	if err != nil {
+		log.Fatalf("❌ Failed to unmarshal token response: %v", err)
+	}
+
+	fmt.Printf("🔑 Access Token:  %s\n", tokenJson.AccessToken)
+	fmt.Printf("🔑 Access Token: %s\n", tokenJson.ExpiresIn)
+	fmt.Printf("🔑 Access Token: %s\n", tokenJson.TokenType)
+
+}
+
+// createSelfSignedCertificate generates a self-signed certificate
+func createSelfSignedCertificate() (*x509.Certificate, *rsa.PrivateKey, error) {
+	// Generate private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	// Serial Number
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	// Validity period
+	notBefore := time.Now()
+	notAfter := notBefore.Add(time.Hour * 24 * 90) // 90 days
+
+	// Subject
+	subject := pkix.Name{
+		CommonName: newCertSubject, // Assuming newCertSubject is defined globally
+	}
+
+	// Certificate Template
+	template := x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               subject,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	// Add Text Extension for Extended Key Usage (OID 1.3.6.1.5.5.7.3.2 - id-kp-clientAuth)
+	oidEKUClientAuth := []int{1, 3, 6, 1, 5, 5, 7, 3, 2} // id-kp-clientAuth
+	template.UnknownExtKeyUsage = append(template.UnknownExtKeyUsage, oidEKUClientAuth)
+
+	// Create certificate
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	return cert, privateKey, nil
+}
+
+// makeHTTPRequest makes a HTTP request and returns the response body
+func makeHTTPRequest(method, url string, headers map[string][]string, body io.Reader) ([]byte, error) {
+	client := &http.Client{}
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP error: %s, Body: %s", resp.Status, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+// makeHTTPRequest makes a HTTP request and returns the response body
+func makeHTTPRequestCert(method, url string, headers map[string][]string, body io.Reader, cert *x509.Certificate, key *rsa.PrivateKey) ([]byte, error) {
+
+	// --- Create TLS Config with Client Certificate ---
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{cert.Raw}, // Raw DER-encoded certificate
+		PrivateKey:  key,                // Private key
+		Leaf:        cert,               // *x509.Certificate (important to include the parsed cert)
+	}
+
+	// // --- Create HTTP Client with TLS Config ---
+	// transport := &http.Transport{
+	// 	TLSClientConfig: tlsConfig,
+	// }
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
+	if err != nil {
+		log.Fatalf("❌ Failed to marshal public key: %v", err)
+	}
+	sha256Hash := sha256.Sum256(publicKeyBytes)
+	certSha256 := hex.EncodeToString(sha256Hash[:])
+	fmt.Printf("🔐 Generated Certificate SHA-256 (kid): %s\n", certSha256)
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{tlsCert}, // Use the in-memory tlsCert
+	}
+
+	// --- 5. Create HTTP Client with TLS Config ---
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+	client := &http.Client{Transport: transport}
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP error: %s, Body: %s", resp.Status, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+// generateGUID generates a GUID string
+func generateGUID() string {
+	guid := make([]byte, 16)
+	if _, err := rand.Read(guid); err != nil {
+		return "error-generating-guid" // Fallback in case of error
+	}
+	return fmt.Sprintf("%x-%x-%x-%x-%x",
+		guid[0:4], guid[4:6], guid[6:8], guid[8:10], guid[10:])
+}
+
+// pemEncodeCert encodes certificate to PEM format
+func pemEncodeCert(w io.Writer, cert *x509.Certificate) error {
+	if err := pem.Encode(w, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Goals

The primary objective is to enable seamless token acquisition in MSI V2 for VM/VMSS, utilizing the `/credential` endpoint.

- Define the **MSI V2 token acquisition process**.
- Describe how MSAL interacts with the `/credential` and the ESTS regional token endpoint.
- Ensure compatibility with **Windows and Linux** VMs and VMSS.

## Token Acquisition Process

In **MSI V1**, IMDS or any other Managed Identity Resource Provider (MIRP) directly returns an **access token**. However, in **MSI V2**, the process involves two steps:

```mermaid
sequenceDiagram
    participant Application
    participant MSAL
    participant IMDS
    participant ESTS

    Application ->> MSAL: 1. Request token using Managed Identity
    MSAL ->> IMDS: 2. Probe for `/credential` endpoint availability
    IMDS -->> MSAL: 3. Response (200 OK / 404 Not Found)

    alt `/credential` endpoint available
        MSAL ->> IMDS: 4. Request Short-Lived Credential (SLC) via `/credential`
        IMDS -->> MSAL: 5. Return SLC
        MSAL ->> ESTS: 6. Exchange SLC for Access Token via MTLS
        ESTS -->> MSAL: 7. Return Access Token
        MSAL ->> Application: 8. Return Access Token
    else `/credential` endpoint not available
        MSAL ->> IMDS: 4a. Fallback to legacy `/token` endpoint
        IMDS -->> MSAL: 5a. Return Access Token
        MSAL ->> Application: 6a. Return Access Token
    end
```

### Short-Lived Credential Retrieval from `/credential` Endpoint

- Azure Managed Identity Resource Providers host the `/credential` endpoint.
- The client (MSAL) calls the `/credential` endpoint to retrieve a **short-lived credential (SLC)**.
- This credential is valid for a short duration and must be used promptly in the next step.

### Access Token Acquisition via ESTS

- The client presents the **short-lived credential** to **ESTS** over **MTLS** as an assertion.
- ESTS validates the credential and issues an **access token**.
- The access token is then used to authenticate with Azure services.

### Retry Logic

MSAL uses the **default Managed Identity [retry](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/651b71c7d1dcaf3261e598e01e017dfd3672bb25/src/client/Microsoft.Identity.Client/Http/HttpManagerFactory.cs#L28) policy** for MSI V2 credential/token requests, whether calling the ESTS endpoint or the new `/credential` endpoint. i.e. MSAL performs 3 retries with a 1 second pause between each retry. Retries are performed on certain error [codes](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/651b71c7d1dcaf3261e598e01e017dfd3672bb25/src/client/Microsoft.Identity.Client/Http/HttpRetryCondition.cs#L12) only.

## Steps for MSI V2 Authentication

This section outlines the necessary steps to acquire an access token using the MSI V2 `/credential` endpoint. 

### 1. Check for an Existing (Platform) Certificate (Windows only)
- Search for a specific certificate (`devicecert.mtlsauth.local`) in `(Cert:\LocalMachine\My)`.
- If the certificate is not found in Local Machine, check Current User's certificate store `(Cert:\CurrentUser\My)`.

### 2. Generate a New Certificate (if platform certificate is not found)
- If no valid platform certificate is found in Cert:\LocalMachine\My or Cert:\CurrentUser\My, create a new in-memory self-signed certificate.
- This applies especially to Linux VMs, where platform certificates are not pre-configured, and MSAL must always generate an in-memory certificate for MTLS authentication.

#### Certificate Creation Requirements
- **Subject Name:** CN=mtls-auth (subject name not final).
- **Validity Period:** 90 days.
- **Key Export Policy:** Private key must be exportable to allow use for MTLS authentication.
- **Key Usage must include:** Digital Signature, Key Encipherment and TLS Client Authentication.
- **Storage:** The certificate should exist only in memory. It is not stored in the certificate store. It is discarded when the process exits.

#### Certificate Rotation Strategy
- **Track Expiry:** The expiration of the certificate must be monitored at runtime.
- **Rotation Trigger:** 5 days before expiry, generate a new in-memory certificate.

### 3. Extract Certificate Data
- Convert the certificate to a Base64-encoded string (`x5c`).
- Format the JSON payload containing the certificate details for request authentication.

### 4. Request MSI Credential
- Send a POST request to the IMDS `/credential` endpoint with the certificate details.
- The request must include:
  - `Metadata: true` header.
  - `X-ms-Client-Request-id` header with a GUID.
  - JSON body containing the certificate's public key in `jwk` format. [RFC](https://datatracker.ietf.org/doc/html/rfc7517#appendix-B) 
- Parse the response to extract:
  - `regional_token_url`
  - `tenant_id`
  - `client_id`
  - `credential` (short-lived credential).

### 5. Request Access Token from ESTS
- Construct the OAuth2 request body, including:
  - `grant_type=client_credentials`
  - `scope=https://management.azure.com/.default`
  - `client_id` from the MSI response.
  - `client_assertion` containing the short-lived credential.
  - `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
- Send a POST request to the `regional_token_url` with the certificate for mutual TLS (mTLS) authentication.

### 6. Retrieve and Use Access Token
- Parse the response to extract the `access_token`.
- Use the access token to authenticate requests to Azure services.
- Handle any errors that may occur during the token request.

## End-to-End Script

```powershell
# Define certificate subject names
$searchSubject = "CN=devicecert.mtlsauth.local"  # Existing cert to look for
$newCertSubject = "CN=mtls-auth"  # Subject for new self-signed cert

# Step 1: Search for an existing certificate in LocalMachine\My
$cert = Get-ChildItem -Path "Cert:\LocalMachine\My" | Where-Object { $_.Subject -eq $searchSubject -and $_.NotAfter -gt (Get-Date) }

# Step 2: If not found, search in CurrentUser\My
if (-not $cert) {
    Write-Output "🔍 No valid certificate found in LocalMachine\My. Checking CurrentUser\My..."
    $cert = Get-ChildItem -Path "Cert:\CurrentUser\My" | Where-Object { $_.Subject -eq $searchSubject -and $_.NotAfter -gt (Get-Date) }
}

# Step 3: If found, use it
if ($cert) {
    Write-Output "✅ Found valid certificate: $($cert.Subject)"
} else {
    Write-Output "❌ No valid certificate found in both stores. Creating a new self-signed certificate in `CurrentUser\My`..."

    # Step 4: Generate a new self-signed certificate in `CurrentUser\My`
    # For POC we are creating the cert in the user store. But in Product this will be a in-memory cert
    $cert = New-SelfSignedCertificate `
        -Subject $newCertSubject `
        -CertStoreLocation "Cert:\CurrentUser\My" `
        -KeyExportPolicy Exportable `
        -KeySpec Signature `
        -KeyUsage DigitalSignature, KeyEncipherment `
        -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.2") `
        -NotAfter (Get-Date).AddDays(90)

    Write-Output "✅ Created certificate in CurrentUser\My: $($cert.Thumbprint)"
}

# Ensure `$cert` is valid
if (-not $cert) {
    Write-Error "❌ No certificate found or created. Exiting."
    exit
}

# Step 5: Compute SHA-256 of the Public Key for `kid`
$publicKeyBytes = $cert.GetPublicKey()
$sha256 = New-Object System.Security.Cryptography.SHA256Managed
$certSha256 = [BitConverter]::ToString($sha256.ComputeHash($publicKeyBytes)) -replace "-", ""

Write-Output "🔐 Using SHA-256 Certificate Identifier (kid): $certSha256"

# Step 6: Convert certificate to Base64 for JWT (x5c field)
$x5c = [System.Convert]::ToBase64String($cert.RawData)
Write-Output "📜 x5c: $x5c"

# Step 7: Construct the JSON body properly
$bodyObject = @{
    cnf = @{
        jwk = @{
            kty = "RSA"
            use = "sig"
            alg = "RS256"
            kid = $certSha256  # Use SHA-256 instead of Thumbprint
            x5c = @($x5c)  # Ensures correct array formatting
        }
    }
    latch_key = $false  # Final version of the product should not have this. IMDS team is working on removing this. 
}

# Convert JSON object to a string
$body = $bodyObject | ConvertTo-Json -Depth 10 -Compress
Write-Output "🔹 JSON Payload: $body"

# Step 8: Request MSI credential
$headers = @{
    "Metadata" = "true"
    "X-ms-Client-Request-id" = [guid]::NewGuid().ToString()
}

$imdsResponse = Invoke-WebRequest -Uri "http://169.254.169.254/metadata/identity/credential?cred-api-version=1.0" `
    -Method POST `
    -Headers $headers `
    -Body $body

$jsonContent = $imdsResponse.Content | ConvertFrom-Json

$regionalEndpoint = $jsonContent.regional_token_url + "/" + $jsonContent.tenant_id + "/oauth2/v2.0/token"
Write-Output "✅ Using Regional Endpoint: $regionalEndpoint"

# Step 9: Authenticate with Azure
$tokenHeaders = @{
    "Content-Type" = "application/x-www-form-urlencoded"
    "Accept" = "application/json"
}

$tokenRequestBody = "grant_type=client_credentials&scope=https://management.azure.com/.default&client_id=$($jsonContent.client_id)&client_assertion=$($jsonContent.credential)&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"

try {
    $tokenResponse = Invoke-WebRequest -Uri $regionalEndpoint `
        -Method POST `
        -Headers $tokenHeaders `
        -Body $tokenRequestBody `
        -Certificate $cert  # Use the full certificate object

    $tokenJson = $tokenResponse.Content | ConvertFrom-Json
    Write-Output "🔑 Access Token: $($tokenJson.access_token)"
} catch {
    Write-Error "❌ Failed to retrieve access token. Error: $_"
}
```

This is just replication of what is in the .ps script. 

