### PR TITLE
Exposing necessary types from each client

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -65,6 +65,12 @@ type AuthenticationScheme = authority.AuthenticationScheme
 
 type Account = shared.Account
 
+type TokenSource = base.TokenSource
+
+const TokenSourceUnknown = base.TokenSourceUnknown
+const TokenSourceIdentityProvider = base.TokenSourceIdentityProvider
+const TokenSourceCache = base.TokenSourceCache
+
 // CertFromPEM converts a PEM file (.pem or .key) for use with [NewCredFromCert]. The file
 // must contain the public certificate and the private key. If a PEM block is encrypted and
 // password is not an empty string, it attempts to decrypt the PEM blocks using the password.

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -1097,7 +1097,7 @@ func TestRefreshIn(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if ar.Metadata.TokenSource != base.Cache && !tt.shouldGetNewToken {
+			if ar.Metadata.TokenSource != base.TokenSourceCache && !tt.shouldGetNewToken {
 				t.Fatal("should have returned from cache.")
 			}
 			if (ar.AccessToken == secondToken) != tt.shouldGetNewToken {

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -103,9 +103,9 @@ type TokenSource int
 
 // These are all the types of token flows.
 const (
-	SourceUnknown    TokenSource = 0
-	IdentityProvider TokenSource = 1
-	Cache            TokenSource = 2
+	TokenSourceUnknown          TokenSource = 0
+	TokenSourceIdentityProvider TokenSource = 1
+	TokenSourceCache            TokenSource = 2
 )
 
 // AuthResultFromStorage creates an AuthResult from a storage token response (which is generated from the cache).
@@ -133,7 +133,7 @@ func AuthResultFromStorage(storageTokenResponse storage.TokenResponse) (AuthResu
 		GrantedScopes:  grantedScopes,
 		DeclinedScopes: nil,
 		Metadata: AuthResultMetadata{
-			TokenSource: Cache,
+			TokenSource: TokenSourceCache,
 			RefreshOn:   storageTokenResponse.AccessToken.RefreshOn.T,
 		},
 	}, nil
@@ -151,7 +151,7 @@ func NewAuthResult(tokenResponse accesstokens.TokenResponse, account shared.Acco
 		ExpiresOn:     tokenResponse.ExpiresOn,
 		GrantedScopes: tokenResponse.GrantedScopes.Slice,
 		Metadata: AuthResultMetadata{
-			TokenSource: IdentityProvider,
+			TokenSource: TokenSourceIdentityProvider,
 			RefreshOn:   tokenResponse.RefreshOn.T,
 		},
 	}, nil

--- a/apps/internal/base/base_test.go
+++ b/apps/internal/base/base_test.go
@@ -344,7 +344,7 @@ func TestCreateAuthenticationResult(t *testing.T) {
 				GrantedScopes:  []string{"user.read"},
 				DeclinedScopes: nil,
 				Metadata: AuthResultMetadata{
-					TokenSource: IdentityProvider,
+					TokenSource: TokenSourceIdentityProvider,
 				},
 			},
 		},
@@ -419,7 +419,7 @@ func TestAuthResultFromStorage(t *testing.T) {
 				ExpiresOn:     future,
 				GrantedScopes: []string{"profile", "openid", "user.read"},
 				Metadata: AuthResultMetadata{
-					TokenSource: Cache,
+					TokenSource: TokenSourceCache,
 				},
 			},
 		},

--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -32,6 +32,16 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/shared"
 )
 
+// AuthResult contains the results of one token acquisition operation.
+// For details see https://aka.ms/msal-net-authenticationresult
+type AuthResult = base.AuthResult
+
+type TokenSource = base.TokenSource
+
+const TokenSourceUnknown = base.TokenSourceUnknown
+const TokenSourceIdentityProvider = base.TokenSourceIdentityProvider
+const TokenSourceCache = base.TokenSourceCache
+
 const (
 	// DefaultToIMDS indicates that the source is defaulted to IMDS when no environment variables are set.
 	DefaultToIMDS Source = "DefaultToIMDS"
@@ -304,7 +314,7 @@ var now = time.Now
 //
 // Resource: scopes application is requesting access to
 // Options: [WithClaims]
-func (c Client) AcquireToken(ctx context.Context, resource string, options ...AcquireTokenOption) (base.AuthResult, error) {
+func (c Client) AcquireToken(ctx context.Context, resource string, options ...AcquireTokenOption) (AuthResult, error) {
 	resource = strings.TrimSuffix(resource, "/.default")
 	o := AcquireTokenOptions{}
 	for _, option := range options {
@@ -316,7 +326,7 @@ func (c Client) AcquireToken(ctx context.Context, resource string, options ...Ac
 	if o.claims == "" {
 		stResp, err := cacheManager.Read(ctx, c.authParams)
 		if err != nil {
-			return base.AuthResult{}, err
+			return AuthResult{}, err
 		}
 		ar, err := base.AuthResultFromStorage(stResp)
 		if err == nil {
@@ -333,7 +343,7 @@ func (c Client) AcquireToken(ctx context.Context, resource string, options ...Ac
 	return c.getToken(ctx, resource)
 }
 
-func (c Client) getToken(ctx context.Context, resource string) (base.AuthResult, error) {
+func (c Client) getToken(ctx context.Context, resource string) (AuthResult, error) {
 	switch c.source {
 	case AzureArc:
 		return c.acquireTokenForAzureArc(ctx, resource)
@@ -348,110 +358,110 @@ func (c Client) getToken(ctx context.Context, resource string) (base.AuthResult,
 	case ServiceFabric:
 		return c.acquireTokenForServiceFabric(ctx, resource)
 	default:
-		return base.AuthResult{}, fmt.Errorf("unsupported source %q", c.source)
+		return AuthResult{}, fmt.Errorf("unsupported source %q", c.source)
 	}
 }
 
-func (c Client) acquireTokenForAppService(ctx context.Context, resource string) (base.AuthResult, error) {
+func (c Client) acquireTokenForAppService(ctx context.Context, resource string) (AuthResult, error) {
 	req, err := createAppServiceAuthRequest(ctx, c.miType, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	tokenResponse, err := c.getTokenForRequest(req, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	return authResultFromToken(c.authParams, tokenResponse)
 }
 
-func (c Client) acquireTokenForIMDS(ctx context.Context, resource string) (base.AuthResult, error) {
+func (c Client) acquireTokenForIMDS(ctx context.Context, resource string) (AuthResult, error) {
 	req, err := createIMDSAuthRequest(ctx, c.miType, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	tokenResponse, err := c.getTokenForRequest(req, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	return authResultFromToken(c.authParams, tokenResponse)
 }
 
-func (c Client) acquireTokenForCloudShell(ctx context.Context, resource string) (base.AuthResult, error) {
+func (c Client) acquireTokenForCloudShell(ctx context.Context, resource string) (AuthResult, error) {
 	req, err := createCloudShellAuthRequest(ctx, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	tokenResponse, err := c.getTokenForRequest(req, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	return authResultFromToken(c.authParams, tokenResponse)
 }
 
-func (c Client) acquireTokenForAzureML(ctx context.Context, resource string) (base.AuthResult, error) {
+func (c Client) acquireTokenForAzureML(ctx context.Context, resource string) (AuthResult, error) {
 	req, err := createAzureMLAuthRequest(ctx, c.miType, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	tokenResponse, err := c.getTokenForRequest(req, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	return authResultFromToken(c.authParams, tokenResponse)
 }
 
-func (c Client) acquireTokenForServiceFabric(ctx context.Context, resource string) (base.AuthResult, error) {
+func (c Client) acquireTokenForServiceFabric(ctx context.Context, resource string) (AuthResult, error) {
 	req, err := createServiceFabricAuthRequest(ctx, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	tokenResponse, err := c.getTokenForRequest(req, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	return authResultFromToken(c.authParams, tokenResponse)
 }
 
-func (c Client) acquireTokenForAzureArc(ctx context.Context, resource string) (base.AuthResult, error) {
+func (c Client) acquireTokenForAzureArc(ctx context.Context, resource string) (AuthResult, error) {
 	req, err := createAzureArcAuthRequest(ctx, resource, "")
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 
 	response, err := c.httpClient.Do(req)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusUnauthorized {
-		return base.AuthResult{}, fmt.Errorf("expected a 401 response, received %d", response.StatusCode)
+		return AuthResult{}, fmt.Errorf("expected a 401 response, received %d", response.StatusCode)
 	}
 
 	secret, err := c.getAzureArcSecretKey(response, runtime.GOOS)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 
 	secondRequest, err := createAzureArcAuthRequest(ctx, resource, string(secret))
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 
 	tokenResponse, err := c.getTokenForRequest(secondRequest, resource)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	return authResultFromToken(c.authParams, tokenResponse)
 }
 
-func authResultFromToken(authParams authority.AuthParams, token accesstokens.TokenResponse) (base.AuthResult, error) {
+func authResultFromToken(authParams authority.AuthParams, token accesstokens.TokenResponse) (AuthResult, error) {
 	if cacheManager == nil {
-		return base.AuthResult{}, errors.New("cache instance is nil")
+		return AuthResult{}, errors.New("cache instance is nil")
 	}
 	account, err := cacheManager.Write(authParams, token)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	// if refreshOn is not set, set it to half of the time until expiry if expiry is more than 2 hours away
 	if token.RefreshOn.T.IsZero() {
@@ -461,7 +471,7 @@ func authResultFromToken(authParams authority.AuthParams, token accesstokens.Tok
 	}
 	ar, err := base.NewAuthResult(token, account)
 	if err != nil {
-		return base.AuthResult{}, err
+		return AuthResult{}, err
 	}
 	ar.AccessToken, err = authParams.AuthnScheme.FormatAccessToken(ar.AccessToken)
 	return ar, err

--- a/apps/managedidentity/managedidentity_test.go
+++ b/apps/managedidentity/managedidentity_test.go
@@ -443,7 +443,7 @@ func TestIMDSAcquireTokenReturnsTokenSuccess(t *testing.T) {
 					t.Fatalf("resource objectid is incorrect, wanted %s got %s", i.value(), query.Get(miQueryParameterObjectId))
 				}
 			}
-			if result.Metadata.TokenSource != base.IdentityProvider {
+			if result.Metadata.TokenSource != base.TokenSourceIdentityProvider {
 				t.Fatalf("expected IndenityProvider tokensource, got %d", result.Metadata.TokenSource)
 			}
 			if result.AccessToken != token {
@@ -453,7 +453,7 @@ func TestIMDSAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if result.Metadata.TokenSource != base.Cache {
+			if result.Metadata.TokenSource != base.TokenSourceCache {
 				t.Fatalf("wanted cache token source, got %d", result.Metadata.TokenSource)
 			}
 			secondFakeClient, err := New(testCase.miType, WithHTTPClient(mockClient))
@@ -464,7 +464,7 @@ func TestIMDSAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if result.Metadata.TokenSource != base.Cache {
+			if result.Metadata.TokenSource != base.TokenSourceCache {
 				t.Fatalf("cache result wanted cache token source, got %d", result.Metadata.TokenSource)
 			}
 		})
@@ -551,7 +551,7 @@ func TestCloudShellAcquireTokenReturnsTokenSuccess(t *testing.T) {
 		t.Fatal("suffix /.default was not removed.")
 	}
 
-	if result.Metadata.TokenSource != base.IdentityProvider {
+	if result.Metadata.TokenSource != base.TokenSourceIdentityProvider {
 		t.Fatalf("expected IdentityProvider tokensource, got %d", result.Metadata.TokenSource)
 	}
 
@@ -564,7 +564,7 @@ func TestCloudShellAcquireTokenReturnsTokenSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if result.Metadata.TokenSource != base.Cache {
+	if result.Metadata.TokenSource != base.TokenSourceCache {
 		t.Fatalf("wanted cache token source, got %d", result.Metadata.TokenSource)
 	}
 
@@ -578,7 +578,7 @@ func TestCloudShellAcquireTokenReturnsTokenSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if result.Metadata.TokenSource != base.Cache {
+	if result.Metadata.TokenSource != base.TokenSourceCache {
 		t.Fatalf("cache result wanted cache token source, got %d", result.Metadata.TokenSource)
 	}
 }
@@ -669,7 +669,7 @@ func TestAppServiceAcquireTokenReturnsTokenSuccess(t *testing.T) {
 					t.Fatalf("resource objectid is incorrect, wanted %s got %s", i.value(), query.Get(miQueryParameterObjectId))
 				}
 			}
-			if result.Metadata.TokenSource != base.IdentityProvider {
+			if result.Metadata.TokenSource != base.TokenSourceIdentityProvider {
 				t.Fatalf("expected IndenityProvider tokensource, got %d", result.Metadata.TokenSource)
 			}
 			if result.AccessToken != token {
@@ -679,7 +679,7 @@ func TestAppServiceAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if result.Metadata.TokenSource != base.Cache {
+			if result.Metadata.TokenSource != base.TokenSourceCache {
 				t.Fatalf("wanted cache token source, got %d", result.Metadata.TokenSource)
 			}
 			secondFakeClient, err := New(testCase.miType, WithHTTPClient(mockClient))
@@ -690,7 +690,7 @@ func TestAppServiceAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if result.Metadata.TokenSource != base.Cache {
+			if result.Metadata.TokenSource != base.TokenSourceCache {
 				t.Fatalf("cache result wanted cache token source, got %d", result.Metadata.TokenSource)
 			}
 		})
@@ -750,7 +750,7 @@ func TestAzureMLAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if r := query.Get(resourceQueryParameterName); strings.HasSuffix(r, "/.default") {
 				t.Fatal("suffix /.default was not removed.")
 			}
-			if result.Metadata.TokenSource != base.IdentityProvider {
+			if result.Metadata.TokenSource != base.TokenSourceIdentityProvider {
 				t.Fatalf("expected IdentityProvider tokensource, got %d", result.Metadata.TokenSource)
 			}
 			if result.AccessToken != token {
@@ -764,7 +764,7 @@ func TestAzureMLAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if result.Metadata.TokenSource != base.Cache {
+			if result.Metadata.TokenSource != base.TokenSourceCache {
 				t.Fatalf("wanted cache token source, got %d", result.Metadata.TokenSource)
 			}
 			secondFakeClient, err := New(testCase.miType, WithHTTPClient(mockClient))
@@ -775,7 +775,7 @@ func TestAzureMLAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if result.Metadata.TokenSource != base.Cache {
+			if result.Metadata.TokenSource != base.TokenSourceCache {
 				t.Fatalf("cache result wanted cache token source, got %d", result.Metadata.TokenSource)
 			}
 		})
@@ -860,7 +860,7 @@ func TestAzureArc(t *testing.T) {
 	if query.Get(resourceQueryParameterName) != strings.TrimSuffix(resourceDefaultSuffix, "/.default") {
 		t.Fatal("suffix /.default was not removed.")
 	}
-	if result.Metadata.TokenSource != base.IdentityProvider {
+	if result.Metadata.TokenSource != base.TokenSourceIdentityProvider {
 		t.Fatalf("expected IndenityProvider tokensource, got %d", result.Metadata.TokenSource)
 	}
 	if result.AccessToken != token {
@@ -870,7 +870,7 @@ func TestAzureArc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Metadata.TokenSource != base.Cache {
+	if result.Metadata.TokenSource != base.TokenSourceCache {
 		t.Fatalf("wanted cache token source, got %d", result.Metadata.TokenSource)
 	}
 	secondFakeClient, err := New(SystemAssigned(), WithHTTPClient(mockClient))
@@ -881,7 +881,7 @@ func TestAzureArc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Metadata.TokenSource != base.Cache {
+	if result.Metadata.TokenSource != base.TokenSourceCache {
 		t.Fatalf("cache result wanted cache token source, got %d", result.Metadata.TokenSource)
 	}
 
@@ -1194,7 +1194,7 @@ func TestRefreshInMultipleRequests(t *testing.T) {
 				}
 				return
 			}
-			if ar.AccessToken == secondToken && ar.Metadata.TokenSource == base.IdentityProvider {
+			if ar.AccessToken == secondToken && ar.Metadata.TokenSource == base.TokenSourceIdentityProvider {
 				requestChecker = true
 			}
 		}()

--- a/apps/managedidentity/servicefabric_test.go
+++ b/apps/managedidentity/servicefabric_test.go
@@ -69,7 +69,7 @@ func TestServiceFabricAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if localHeader.Get("Secret") != "secret" {
 				t.Fatalf("expected secret to be secret, got %s", query.Get("Secret"))
 			}
-			if result.Metadata.TokenSource != base.IdentityProvider {
+			if result.Metadata.TokenSource != base.TokenSourceIdentityProvider {
 				t.Fatalf("expected IndenityProvider tokensource, got %d", result.Metadata.TokenSource)
 			}
 			if result.AccessToken != token {
@@ -79,7 +79,7 @@ func TestServiceFabricAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if result.Metadata.TokenSource != base.Cache {
+			if result.Metadata.TokenSource != base.TokenSourceCache {
 				t.Fatalf("wanted cache token source, got %d", result.Metadata.TokenSource)
 			}
 			secondFakeClient, err := New(testCase.miType, WithHTTPClient(mockClient))
@@ -90,7 +90,7 @@ func TestServiceFabricAcquireTokenReturnsTokenSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if result.Metadata.TokenSource != base.Cache {
+			if result.Metadata.TokenSource != base.TokenSourceCache {
 				t.Fatalf("cache result wanted cache token source, got %d", result.Metadata.TokenSource)
 			}
 		})

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -51,6 +51,12 @@ type AuthenticationScheme = authority.AuthenticationScheme
 
 type Account = shared.Account
 
+type TokenSource = base.TokenSource
+
+const TokenSourceUnknown = base.TokenSourceUnknown
+const TokenSourceIdentityProvider = base.TokenSourceIdentityProvider
+const TokenSourceCache = base.TokenSourceCache
+
 var errNoAccount = errors.New("no account was specified with public.WithSilentAccount(), or the specified account is invalid")
 
 // clientOptions configures the Client's behavior.


### PR DESCRIPTION
**PR Title:** Expose `TokenSource` and Related Values Across Packages in `AuthResult`

**PR Description:**

This PR exposes the `TokenSource` type and its associated values (`TokenSourceUnknown`, `TokenSourceCache`, `TokenSourceIdentityProvider`) from the `base` package to the `confidential`, `managedidentity`, and `public` packages.

### Changes:
- `TokenSource`, `TokenSourceUnknown`, `TokenSourceCache`, and `TokenSourceIdentityProvider` are now accessible from the `confidential`, `managedidentity`, and `public` packages.