### PR TITLE
Fix CodeQL warning 'Cross-site scripting vulnerability due to user-provided value

### DIFF
--- a/apps/internal/local/server.go
+++ b/apps/internal/local/server.go
@@ -143,9 +143,10 @@ func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
 	headerErr := q.Get("error")
 	if headerErr != "" {
 		desc := html.EscapeString(q.Get("error_description"))
+		escapedHeaderErr := html.EscapeString(headerErr)
 		// Note: It is a little weird we handle some errors by not going to the failPage. If they all should,
 		// change this to s.error() and make s.error() write the failPage instead of an error code.
-		_, _ = w.Write([]byte(fmt.Sprintf(failPage, headerErr, desc)))
+		_, _ = w.Write([]byte(fmt.Sprintf(failPage, escapedHeaderErr, desc)))
 		s.putResult(Result{Err: fmt.Errorf("%s", desc)})
 
 		return


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4b264138-ed8f-436d-8ebe-591c9de8fca8)

The issue in the original code was that only the 'error_description' parameter was properly HTML-escaped, while the 'error' parameter was left unescaped. This modification adds proper escaping to the 'headerErr' variable using the html.EscapeString function, converting it to safe HTML string representation to prevent potential cross-site scripting (XSS) attacks.

With both parameters now properly HTML-escaped before being inserted into the HTML page, the security warning should no longer appear.