### PR TITLE
fix: support both login.partner.microsoftonline.cn and login.chinaclo…

### DIFF
--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -46,9 +46,11 @@ type jsonCaller interface {
 	JSONCall(ctx context.Context, endpoint string, headers http.Header, qv url.Values, body, resp interface{}) error
 }
 
+// For backward compatibility, accept both old and new China endpoints for a transition period.
 var aadTrustedHostList = map[string]bool{
 	"login.windows.net":                true, // Microsoft Azure Worldwide - Used in validation scenarios where host is not this list
-	"login.partner.microsoftonline.cn": true, // Microsoft Azure China
+	"login.partner.microsoftonline.cn": true, // Microsoft Azure China (new)
+	"login.chinacloudapi.cn":           true, // Microsoft Azure China (legacy, backward compatibility)
 	"login.microsoftonline.de":         true, // Microsoft Azure Blackforest
 	"login-us.microsoftonline.com":     true, // Microsoft Azure US Government - Legacy
 	"login.microsoftonline.us":         true, // Microsoft Azure US Government


### PR DESCRIPTION
here problem(#574 ) is when we upgrad the azure thing and the ms auth thing for go, it break in china cloud. it not login good anymore. new lib only like login.partner.microsoftonline.cn but lot of old stuffs still use login.chinacloudapi.cn. so it not work and the cloud thingy not start.

i make this pr to fix it. now we say okay to both old and new login link in the aadTrustedHostList.

* add login.partner.microsoftonline.cn (new one)
* keep login.chinacloudapi.cn (old one lots people still use)

so now both new and old can login. no more break. i also write small note in code so we remember to check this again later maybe.

this help people move slowly to new thing without everything go boom. it only fix china cloud. other clouds is okay.

this fix the bug where login.partner.microsoftonline.cn no work in china cloud. it also related to the azure provider and the ms login thing change.
