### PR TITLE
Fix panic in AcquireTokenSilent for public clients due to nil Credential

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -367,8 +367,10 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 					// If the token is not same, we don't need to refresh it.
 					// Which means it refreshed.
 					if str, err := m.Read(ctx, authParams); err == nil && str.AccessToken.Secret == ar.AccessToken {
-						if tr, er := b.Token.Credential(ctx, authParams, silent.Credential); er == nil {
-							return b.AuthResultFromToken(ctx, authParams, tr)
+						if silent.RequestType == accesstokens.ATConfidential {
+							if tr, er := b.Token.Credential(ctx, authParams, silent.Credential); er == nil {
+								return b.AuthResultFromToken(ctx, authParams, tr)
+							}
 						}
 					}
 				}


### PR DESCRIPTION
**Fix panic in AcquireTokenSilent for public clients due to nil Credential**

### Description

This PR addresses a `nil` panic occurring during `AcquireTokenSilent` calls for **public clients** in the Microsoft Authentication Library for Go. #580 

### Root Cause

In `apps/internal/base/base.go`, the `Token.Credential(...)` function is called unconditionally within `AcquireTokenSilent`, even for **public clients**. This function expects a non-nil `*accesstokens.Credential` (specifically, `silent.Credential`), but for public clients, this value is `nil`.

The panic occurs in `apps/internal/oauth/oauth.go` at line 104:

```go
if cred.TokenProvider != nil {
```

Here, `cred` is `nil`, leading to a runtime panic.

### Fix

Added a conditional check to ensure that `Token.Credential(...)` is only called for confidential client flows (i.e., when `silent.RequestType == accesstokens.ATConfidential`), preventing the use of a `nil` credential for public clients.

