### PR TITLE
feat: add WithPrompt option for AuthCodeURL

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -359,7 +359,7 @@ func New(authority, clientID string, cred Credential, options ...Option) (Client
 
 // authCodeURLOptions contains options for AuthCodeURL
 type authCodeURLOptions struct {
-	claims, loginHint, tenantID, domainHint string
+	claims, loginHint, tenantID, domainHint, prompt string
 }
 
 // AuthCodeURLOption is implemented by options for AuthCodeURL
@@ -369,7 +369,7 @@ type AuthCodeURLOption interface {
 
 // AuthCodeURL creates a URL used to acquire an authorization code. Users need to call CreateAuthorizationCodeURLParameters and pass it in.
 //
-// Options: [WithClaims], [WithDomainHint], [WithLoginHint], [WithTenantID]
+// Options: [WithClaims], [WithDomainHint], [WithLoginHint], [WithTenantID], [WithPrompt]
 func (cca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...AuthCodeURLOption) (string, error) {
 	o := authCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -382,6 +382,7 @@ func (cca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string,
 	ap.Claims = o.claims
 	ap.LoginHint = o.loginHint
 	ap.DomainHint = o.domainHint
+	ap.Prompt = o.prompt
 	return cca.base.AuthCodeURL(ctx, clientID, redirectURI, scopes, ap)
 }
 
@@ -422,6 +423,29 @@ func WithDomainHint(domain string) interface {
 				switch t := a.(type) {
 				case *authCodeURLOptions:
 					t.domainHint = domain
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
+
+// WithPrompt adds prompt query parameter in the auth url.
+func WithPrompt(prompt string) interface {
+	AuthCodeURLOption
+	options.CallOption
+} {
+	return struct {
+		AuthCodeURLOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *authCodeURLOptions:
+					t.prompt = prompt
 				default:
 					return fmt.Errorf("unexpected options type %T", a)
 				}

--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -1774,6 +1774,59 @@ func TestWithDomainHint(t *testing.T) {
 	}
 }
 
+func TestWithPrompt(t *testing.T) {
+	prompt := "login"
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := New(fakeAuthority, fakeClientID, cred, WithHTTPClient(&errorClient{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.base.Token.AccessTokens = &fake.AccessTokens{}
+	client.base.Token.Authority = &fake.Authority{}
+	client.base.Token.Resolver = &fake.ResolveEndpoints{}
+	for _, expectPrompt := range []bool{true, false} {
+		t.Run(fmt.Sprint(expectPrompt), func(t *testing.T) {
+			validate := func(v url.Values) error {
+				if !v.Has("prompt") {
+					if !expectPrompt {
+						return nil
+					}
+					return errors.New("expected a prompt")
+				} else if !expectPrompt {
+					return fmt.Errorf("expected no prompt, got %v", v["prompt"][0])
+				}
+
+				if actual := v["prompt"]; len(actual) != 1 || actual[0] != prompt {
+					err = fmt.Errorf(`unexpected prompt "%v"`, actual[0])
+				}
+				return err
+			}
+			var urlOpts []AuthCodeURLOption
+			if expectPrompt {
+				urlOpts = append(urlOpts, WithPrompt(prompt))
+			}
+			u, err := client.AuthCodeURL(context.Background(), "id", "https://localhost", tokenScope, urlOpts...)
+			print("actual URL: " + u)
+			if err == nil {
+				var parsed *url.URL
+				parsed, err = url.Parse(u)
+				if err == nil {
+					err = validate(parsed.Query())
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestWithAuthenticationScheme(t *testing.T) {
 	ctx := context.Background()
 	authScheme := mock.NewTestAuthnScheme()

--- a/apps/public/public.go
+++ b/apps/public/public.go
@@ -149,7 +149,7 @@ func New(clientID string, options ...Option) (Client, error) {
 
 // authCodeURLOptions contains options for AuthCodeURL
 type authCodeURLOptions struct {
-	claims, loginHint, tenantID, domainHint string
+	claims, loginHint, tenantID, domainHint, prompt string
 }
 
 // AuthCodeURLOption is implemented by options for AuthCodeURL
@@ -159,7 +159,7 @@ type AuthCodeURLOption interface {
 
 // AuthCodeURL creates a URL used to acquire an authorization code.
 //
-// Options: [WithClaims], [WithDomainHint], [WithLoginHint], [WithTenantID]
+// Options: [WithClaims], [WithDomainHint], [WithLoginHint], [WithTenantID], [WithPrompt]
 func (pca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string, scopes []string, opts ...AuthCodeURLOption) (string, error) {
 	o := authCodeURLOptions{}
 	if err := options.ApplyOptions(&o, opts); err != nil {
@@ -172,6 +172,7 @@ func (pca Client) AuthCodeURL(ctx context.Context, clientID, redirectURI string,
 	ap.Claims = o.claims
 	ap.LoginHint = o.loginHint
 	ap.DomainHint = o.domainHint
+	ap.Prompt = o.prompt
 	return pca.base.AuthCodeURL(ctx, clientID, redirectURI, scopes, ap)
 }
 
@@ -526,9 +527,9 @@ func (pca Client) RemoveAccount(ctx context.Context, account Account) error {
 
 // interactiveAuthOptions contains the optional parameters used to acquire an access token for interactive auth code flow.
 type interactiveAuthOptions struct {
-	claims, domainHint, loginHint, redirectURI, tenantID string
-	openURL                                              func(url string) error
-	authnScheme                                          AuthenticationScheme
+	claims, domainHint, loginHint, redirectURI, tenantID, prompt string
+	openURL                                                      func(url string) error
+	authnScheme                                                  AuthenticationScheme
 }
 
 // AcquireInteractiveOption is implemented by options for AcquireTokenInteractive
@@ -581,6 +582,33 @@ func WithDomainHint(domain string) interface {
 					t.domainHint = domain
 				case *interactiveAuthOptions:
 					t.domainHint = domain
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
+
+// WithPrompt adds the IdP prompt query parameter in the auth url.
+func WithPrompt(prompt string) interface {
+	AcquireInteractiveOption
+	AuthCodeURLOption
+	options.CallOption
+} {
+	return struct {
+		AcquireInteractiveOption
+		AuthCodeURLOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *authCodeURLOptions:
+					t.prompt = prompt
+				case *interactiveAuthOptions:
+					t.prompt = prompt
 				default:
 					return fmt.Errorf("unexpected options type %T", a)
 				}

--- a/apps/public/public_test.go
+++ b/apps/public/public_test.go
@@ -935,6 +935,52 @@ func TestWithDomainHint(t *testing.T) {
 	}
 }
 
+func TestWithPrompt(t *testing.T) {
+	prompt := "login"
+	client, err := New("client-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.base.Token.AccessTokens = &fake.AccessTokens{}
+	client.base.Token.Authority = &fake.Authority{}
+	client.base.Token.Resolver = &fake.ResolveEndpoints{}
+	for _, expectPrompt := range []bool{true, false} {
+		t.Run(fmt.Sprint(expectPrompt), func(t *testing.T) {
+			validate := func(v url.Values) error {
+				if !v.Has("prompt") {
+					if !expectPrompt {
+						return nil
+					}
+					return errors.New("expected a prompt")
+				} else if !expectPrompt {
+					return fmt.Errorf("expected no prompt, got %v", v["prompt"][0])
+				}
+
+				if actual := v["prompt"]; len(actual) != 1 || actual[0] != prompt {
+					err = fmt.Errorf(`unexpected prompt "%v"`, actual[0])
+				}
+				return err
+			}
+			var urlOpts []AuthCodeURLOption
+			if expectPrompt {
+				urlOpts = append(urlOpts, WithPrompt(prompt))
+			}
+			u, err := client.AuthCodeURL(context.Background(), "id", "https://localhost", tokenScope, urlOpts...)
+			print("actual URL: " + u)
+			if err == nil {
+				var parsed *url.URL
+				parsed, err = url.Parse(u)
+				if err == nil {
+					err = validate(parsed.Query())
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestWithAuthenticationScheme(t *testing.T) {
 	clientInfo := base64.RawStdEncoding.EncodeToString([]byte(`{"uid":"uid","utid":"utid"}`))
 	lmo, tenant := "login.microsoftonline.com", "tenant"


### PR DESCRIPTION
This PR adds WithPrompt option, so that URL can be crafted to use prompt parameter.