### PR TITLE
Adjust constants used in FMI tests

### DIFF
--- a/apps/tests/integration/fmi_integration_test.go
+++ b/apps/tests/integration/fmi_integration_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	// Common test configuration - matches MSAL .NET FmiIntegrationTests
+	// Common test configuration
 	testTenantID = "10c419d4-4a50-45b2-aa4e-919fb84df24f"
 	testClientID = "3bf56293-fbb5-42bd-a407-248ba7431a8c"
 	testScope    = "api://aa464f73-2868-4f67-b0e7-fc2f749e757f/.default"
@@ -46,7 +46,7 @@ func TestFMIBasicFunctionality(t *testing.T) {
 	ctx := context.Background()
 	scopes := []string{testScope}
 
-	// Get certificate credentials (LabAuth cert, matching MSAL .NET)
+	// Get certificate credentials
 	cert, privateKey, err := getCertDataFromFile(pemFile)
 	if err != nil {
 		t.Fatalf("TestFMIBasicFunctionality: getCertDataFromFile() failed: %s", errors.Verbose(err))
@@ -159,7 +159,7 @@ func TestFMIIntegration(t *testing.T) {
 
 // GetFmiCredentialFromRma acquires an FMI token from RMA service
 func GetFmiCredentialFromRma(ctx context.Context) (string, error) {
-	// Get certificate data using the existing helper method (LabAuth cert, matching MSAL .NET)
+	// Get certificate data using the existing helper method
 	cert, privateKey, err := getCertDataFromFile(pemFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to get certificate data: %w", err)

--- a/apps/tests/integration/fmi_integration_test.go
+++ b/apps/tests/integration/fmi_integration_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	// Common test configuration
-	testTenantID = "f645ad92-e38d-4d1a-b510-d1b09a74a8ca"
-	testClientID = "4df2cbbb-8612-49c1-87c8-f334d6d065ad"
-	testScope    = "3091264c-7afb-45d4-b527-39737ee86187/.default"
+	// Common test configuration - matches MSAL .NET FmiIntegrationTests
+	testTenantID = "10c419d4-4a50-45b2-aa4e-919fb84df24f"
+	testClientID = "3bf56293-fbb5-42bd-a407-248ba7431a8c"
+	testScope    = "api://aa464f73-2868-4f67-b0e7-fc2f749e757f/.default"
 	fmiClientID  = "urn:microsoft:identity:fmi"
 	fmiScope     = "api://AzureFMITokenExchange/.default"
 	fmiPath      = "SomeFmiPath/FmiCredentialPath"
@@ -46,8 +46,8 @@ func TestFMIBasicFunctionality(t *testing.T) {
 	ctx := context.Background()
 	scopes := []string{testScope}
 
-	// Get certificate credentials
-	cert, privateKey, err := getCertDataFromFile(ccaPemFile)
+	// Get certificate credentials (LabAuth cert, matching MSAL .NET)
+	cert, privateKey, err := getCertDataFromFile(pemFile)
 	if err != nil {
 		t.Fatalf("TestFMIBasicFunctionality: getCertDataFromFile() failed: %s", errors.Verbose(err))
 	}
@@ -159,8 +159,8 @@ func TestFMIIntegration(t *testing.T) {
 
 // GetFmiCredentialFromRma acquires an FMI token from RMA service
 func GetFmiCredentialFromRma(ctx context.Context) (string, error) {
-	// Get certificate data using the existing helper method
-	cert, privateKey, err := getCertDataFromFile(ccaPemFile)
+	// Get certificate data using the existing helper method (LabAuth cert, matching MSAL .NET)
+	cert, privateKey, err := getCertDataFromFile(pemFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to get certificate data: %w", err)
 	}


### PR DESCRIPTION
Adjusts the apps/tenants/certs/etc. used in the FMI tests to our latest resources. This scenario appears to have been missed when migrating other integration tests to a new tenant in: https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/593

The constants used in these tests will now match what is currently done in MSAL .NET: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/main/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/FmiIntegrationTests.cs