### PR TITLE
 Recover from panics in `json.Unmarshal` to prevent token-cache crashes (fixes #579)

### DIFF
--- a/apps/internal/json/json.go
+++ b/apps/internal/json/json.go
@@ -58,7 +58,26 @@ func Marshal(i interface{}) ([]byte, error) {
 // Unmarshal unmarshals a []byte representing JSON into i, which must be a *struct. In addition, if the struct has
 // a field called AdditionalFields of type map[string]interface{}, JSON data representing fields not in the struct
 // will be written as key/value pairs to AdditionalFields.
-func Unmarshal(b []byte, i interface{}) error {
+//
+// Any panic that escapes the underlying reflect-based decoder (for example
+// "reflect: New of type that may not be allocated in heap") is recovered and
+// returned as an error so that callers are not crashed by malformed or
+// otherwise unexpected input.
+//
+// IMPORTANT: when Unmarshal returns a non-nil error, the destination i may
+// have been partially populated (the decoder writes fields sequentially and a
+// panic mid-decode does not roll back earlier writes). Callers that need
+// all-or-nothing semantics — particularly those handling untrusted input —
+// must decode into a temporary value and only copy/assign it on success.
+// MSAL's own token-cache callers already follow this pattern (see
+// apps/internal/base/storage.Manager.Unmarshal).
+func Unmarshal(b []byte, i interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("json: panic during Unmarshal: %v", r)
+		}
+	}()
+
 	if len(b) == 0 {
 		return nil
 	}

--- a/apps/internal/json/json_test.go
+++ b/apps/internal/json/json_test.go
@@ -6,6 +6,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -200,5 +201,113 @@ func TestDelimIs(t *testing.T) {
 		if got != test.want {
 			t.Errorf("TestDelimIs(%s): got %v, want %v", test.desc, got, test.want)
 		}
+	}
+}
+
+// panicUnmarshaler is a type whose UnmarshalJSON always panics. It is used to
+// simulate a panic escaping the reflect-based decoder so we can verify that
+// Unmarshal recovers and returns an error instead of crashing the caller.
+type panicUnmarshaler struct{}
+
+func (p *panicUnmarshaler) UnmarshalJSON(_ []byte) error {
+	panic("reflect: New of type that may not be allocated in heap (possibly undefined cgo C type)")
+}
+
+type withPanicField struct {
+	Inner            map[string]panicUnmarshaler
+	AdditionalFields map[string]interface{}
+}
+
+// TestUnmarshalPanicRecovery verifies that a panic originating deep in the
+// reflect-based decoder (see issue #579) is converted into an error by
+// Unmarshal rather than propagating to the caller. The panic unwinds through
+// the same frames as the #579 stack trace
+// (unmarshalStruct -> decoder.storeValue -> unmarshalMap -> mapWalk.run ->
+// mapWalk.storeStruct -> unmarshalStruct), so this proves the recover()
+// boundary catches panics on the reported code path.
+func TestUnmarshalPanicRecovery(t *testing.T) {
+	target := &withPanicField{}
+	err := Unmarshal([]byte(`{"Inner":{"k":{}}}`), target)
+	if err == nil {
+		t.Fatal("TestUnmarshalPanicRecovery: expected an error from recovered panic, got nil")
+	}
+	if !strings.Contains(err.Error(), "panic during Unmarshal") {
+		t.Errorf("TestUnmarshalPanicRecovery: expected error to mention recovered panic, got %q", err.Error())
+	}
+}
+
+// runtimePanicUnmarshaler triggers a real runtime.Error (nil pointer
+// dereference) from inside its UnmarshalJSON. The original #579 panic
+// ("reflect: New of type that may not be allocated in heap") is also a
+// runtime.Error emitted by reflect.New, but a notinheap type cannot be
+// constructed from user code. Triggering a nil-deref runtime.Error here is
+// the closest faithful reproduction available and proves that Unmarshal's
+// recover() catches runtime-level panics (not just panics with string args).
+type runtimePanicUnmarshaler struct{}
+
+func (r *runtimePanicUnmarshaler) UnmarshalJSON(_ []byte) error {
+	var p *int
+	_ = *p // nil pointer dereference -> runtime.Error panic
+	return nil
+}
+
+type runtimePanicMapHolder struct {
+	Inner            map[string]runtimePanicUnmarshaler
+	AdditionalFields map[string]interface{}
+}
+
+type runtimePanicSliceHolder struct {
+	Inner            []runtimePanicUnmarshaler
+	AdditionalFields map[string]interface{}
+}
+
+type runtimePanicStructHolder struct {
+	Inner            runtimePanicUnmarshaler
+	AdditionalFields map[string]interface{}
+}
+
+// TestUnmarshalRuntimePanicRecovery is a regression test that locks in
+// recover() coverage for every reflect-bearing code path inside the json
+// package. If a future change moves the recover, restructures the unwind, or
+// otherwise lets a runtime panic escape Unmarshal on any of these paths, this
+// test will fail.
+//
+// Paths covered:
+//   - map[string]<struct>  -> mapslice.mapWalk.storeStruct (exact #579 frames)
+//   - []<struct>           -> mapslice.sliceWalk.storeStruct
+//   - <struct> field       -> struct.go decoder.storeValue (struct branch)
+func TestUnmarshalRuntimePanicRecovery(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		target interface{}
+	}{
+		{
+			name:   "map of struct (issue #579 stack)",
+			input:  `{"Inner":{"k":{}}}`,
+			target: &runtimePanicMapHolder{},
+		},
+		{
+			name:   "slice of struct",
+			input:  `{"Inner":[{}]}`,
+			target: &runtimePanicSliceHolder{},
+		},
+		{
+			name:   "nested struct field",
+			input:  `{"Inner":{}}`,
+			target: &runtimePanicStructHolder{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := Unmarshal([]byte(test.input), test.target)
+			if err == nil {
+				t.Fatalf("expected an error from recovered runtime panic on path %q, got nil", test.name)
+			}
+			if !strings.Contains(err.Error(), "panic during Unmarshal") {
+				t.Errorf("expected error to mention recovered panic on path %q, got %q", test.name, err.Error())
+			}
+		})
 	}
 }


### PR DESCRIPTION
 ## Summary
 
 Fixes #579.
 
 `apps/internal/json.Unmarshal` could panic with `reflect: New of type that may
 not be allocated in heap (possibly undefined cgo C type)` (and similar
 runtime-level panics) when processing certain inputs. The panic originates
 deep in the custom reflect-based decoder
 (`mapWalk.storeStruct → newValue → reflect.New`) and escapes unhandled,
 crashing the caller — including any application using the in-memory token
 cache, since `storage.Manager.Unmarshal` is the entry point on the cache
 deserialization path.
 
 ## Fix
 
 `apps/internal/json/json.go`
 
 - Add a deferred `recover()` to `Unmarshal` (using a named return) that
   converts any escaping panic into an error of the form
   `json: panic during Unmarshal: <value>`. This restores the documented
   contract: callers get an error, not a process-level crash.
 - Update the doc comment to describe the new recover behavior and warn that
   on error the destination `i` may be partially populated, since the decoder
   writes fields sequentially. MSAL's own `storage.Manager.Unmarshal` already
   follows the safe decode-into-temporary-then-swap pattern, so the in-memory
   cache cannot end up half-populated from a panicking input.
 
 ## Tests
 
 `apps/internal/json/json_test.go`
 
 Added regression coverage that locks in `recover()` behavior on every
 reflect-bearing code path in the json package, so a future change cannot
 silently let a panic escape `Unmarshal` again.
 
 | Test | Code path exercised | Panic source |
 |---|---|---|
 | `TestUnmarshalPanicRecovery` | `mapWalk.storeStruct` (custom Unmarshaler) | `panic(string)` |
 | `TestUnmarshalRuntimePanicRecovery/map_of_struct` | `mapWalk.storeStruct` — **exact #579 stack frames** | `runtime.Error` (nil-pointer dereference) |
 | `TestUnmarshalRuntimePanicRecovery/slice_of_struct` | `sliceWalk.storeStruct` | `runtime.Error` |
 | `TestUnmarshalRuntimePanicRecovery/nested_struct_field` | `decoder.storeValue` (struct branch) | `runtime.Error` |
 
 A true `notinheap` `reflect.New` panic cannot be constructed from user code
 (the flag is only set on internal runtime types), so the regression tests
 trigger a `runtime.Error` (nil-pointer dereference) from a custom
 `UnmarshalJSON` — the same panic *category* as the original failure. With
 the `recover()` removed, the map-of-struct test fails with a stack trace
 identical to the one reported in #579, confirming the test exercises the
 real failure path.
 
 ## Verification
 
 - `go build ./apps/...` — clean
 - `go test ./apps/internal/...` — all packages pass
 - New tests pass with the fix; fail with the expected `runtime.Error` stack
   trace when the `recover()` is removed.
