### PR TITLE
added a fix for oidc cross cloud fix

### DIFF
--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -50,30 +50,13 @@ type jsonCaller interface {
 }
 
 // For backward compatibility, accept both old and new China endpoints for a transition period.
-// This list is derived from the AAD instance discovery metadata and represents all known trusted hosts
-// across different Azure clouds (Public, China, Germany, US Government, etc.)
-var aadTrustedHostList = map[string]bool{
-	"login.windows.net":                true, // Microsoft Azure Worldwide - Used in validation scenarios where host is not this list
-	"login.partner.microsoftonline.cn": true, // Microsoft Azure China (new)
-	"login.chinacloudapi.cn":           true, // Microsoft Azure China (legacy, backward compatibility)
-	"login.microsoftonline.de":         true, // Microsoft Azure Blackforest
-	"login-us.microsoftonline.com":     true, // Microsoft Azure US Government - Legacy
-	"login.microsoftonline.us":         true, // Microsoft Azure US Government
-	"login.microsoftonline.com":        true, // Microsoft Azure Worldwide
-	"login.microsoft.com":              true,
-	"sts.windows.net":                  true,
-	"login.usgovcloudapi.net":          true,
-	"login.sovcloud-identity.fr":       true, // Bleu (France sovereign cloud)
-	"login.sovcloud-identity.de":       true, // Delos (Germany sovereign cloud)
-	"login.sovcloud-identity.sg":       true, // GovSG (Singapore sovereign cloud)
-}
+// TrustedHost is a thin wrapper over GetKnownMetadata so the trusted-host set
+// cannot drift from the canonical knownClouds list in known_metadata.go.
 
 // TrustedHost checks if an AAD host is trusted/valid.
 func TrustedHost(host string) bool {
-	if _, ok := aadTrustedHostList[host]; ok {
-		return true
-	}
-	return false
+	_, ok := GetKnownMetadata(host)
+	return ok
 }
 
 // OAuthResponseBase is the base JSON return message for an OAuth call.
@@ -111,8 +94,15 @@ func (r *TenantDiscoveryResponse) Validate() error {
 	return nil
 }
 
-// ValidateIssuerMatchesAuthority validates that the issuer in the TenantDiscoveryResponse matches the authority.
-// This is used to identity security or configuration issues in authorities and the OIDC endpoint
+// ValidateIssuerMatchesAuthority validates that the issuer in the TenantDiscoveryResponse
+// matches the authority. Acceptance rules:
+//
+//	Rule 1: exact scheme + host match.
+//	Rule 2: known-Microsoft https issuer
+//	        2a) custom-domain authority + known-MS issuer (#5927 federation).
+//	        2b) known-MS authority + same-cloud issuer (cross-cloud rejected).
+//	Rule 3: instance-discovery alias match.
+//	Rule 4: CIAM tenant pattern — https://{tenant}.ciamlogin.com[/{tenant}[/v2.0]].
 func (r *TenantDiscoveryResponse) ValidateIssuerMatchesAuthority(authorityURI string, aliases map[string]bool) error {
 	if authorityURI == "" {
 		return errors.New("TenantDiscoveryResponse: empty authorityURI provided for validation")
@@ -130,30 +120,112 @@ func (r *TenantDiscoveryResponse) ValidateIssuerMatchesAuthority(authorityURI st
 		return fmt.Errorf("TenantDiscoveryResponse: failed to parse authority URL: %w", err)
 	}
 
-	// Fast path: exact scheme + host match
-	if issuerURL.Scheme == authorityURL.Scheme && issuerURL.Host == authorityURL.Host {
+	issuerHost := strings.ToLower(issuerURL.Host)
+	authorityHost := strings.ToLower(authorityURL.Host)
+
+	// Rule 1: exact scheme + host match.
+	if strings.EqualFold(issuerURL.Scheme, authorityURL.Scheme) && issuerHost == authorityHost {
 		return nil
 	}
 
-	// Alias-based acceptance
-	if aliases != nil && aliases[issuerURL.Host] {
-		return nil
+	// Rule 2: known-Microsoft issuer over HTTPS.
+	if strings.EqualFold(issuerURL.Scheme, "https") {
+		if issuerCloud := ResolveKnownCloud(issuerHost); issuerCloud != "" {
+			authorityCloud := ResolveKnownCloud(authorityHost)
+			// Rule 2a: authority is a custom domain (not a known Microsoft host) —
+			// accept any known-MS issuer (legitimate federation, see
+			// AzureAD/microsoft-authentication-library-for-dotnet#5927).
+			if authorityCloud == "" {
+				return nil
+			}
+			// Rule 2b: both sides resolve to a known cloud — must be the SAME cloud.
+			if authorityCloud == issuerCloud {
+				return nil
+			}
+			// Cross-cloud: fall through to other rules, then reject.
+		}
 	}
 
-	issuerHost := issuerURL.Host
-	authorityHost := authorityURL.Host
-
-	// Accept if issuer host is trusted
-	if TrustedHost(issuerHost) {
-		return nil
+	// Rule 3: instance-discovery alias acceptance (case-insensitive).
+	if len(aliases) > 0 {
+		if aliases[issuerHost] {
+			return nil
+		}
+		for alias := range aliases {
+			if strings.EqualFold(alias, issuerHost) {
+				return nil
+			}
+		}
 	}
 
-	// Accept if authority is a regional variant ending with ".<issuerHost>"
-	if strings.HasSuffix(authorityHost, "."+issuerHost) {
+	// Rule 4: CIAM tenant pattern.
+	if matchesCIAMIssuer(authorityURL, issuerURL) {
 		return nil
 	}
 
 	return fmt.Errorf("TenantDiscoveryResponse: issuer '%s' does not match authority '%s' or any trusted/alias rule", r.Issuer, authorityURI)
+}
+
+// matchesCIAMIssuer reports whether issuer matches the CIAM tenant pattern
+// derived from authority. Accepted issuer shapes:
+//
+//	https://{tenant}.ciamlogin.com
+//	https://{tenant}.ciamlogin.com/{tenant}
+//	https://{tenant}.ciamlogin.com/{tenant}/v2.0
+//
+// {tenant} is the authority's first path segment, or the first hostname label
+// if the authority has no path.
+func matchesCIAMIssuer(authorityURL, issuerURL *url.URL) bool {
+	if !strings.EqualFold(issuerURL.Scheme, "https") {
+		return false
+	}
+	issuerHost := strings.ToLower(issuerURL.Host)
+	if !strings.HasSuffix(issuerHost, ".ciamlogin.com") {
+		return false
+	}
+	tenantFromIssuerHost := strings.TrimSuffix(issuerHost, ".ciamlogin.com")
+	if tenantFromIssuerHost == "" || strings.Contains(tenantFromIssuerHost, ".") {
+		return false
+	}
+
+	// Derive the tenant from the authority: prefer the first non-empty path
+	// segment, fall back to the first hostname label.
+	tenantFromAuthority := ""
+	for _, seg := range strings.Split(authorityURL.EscapedPath(), "/") {
+		if seg != "" {
+			tenantFromAuthority = seg
+			break
+		}
+	}
+	if tenantFromAuthority == "" {
+		host := strings.ToLower(authorityURL.Host)
+		if i := strings.Index(host, "."); i > 0 {
+			tenantFromAuthority = host[:i]
+		} else {
+			tenantFromAuthority = host
+		}
+	}
+	if !strings.EqualFold(tenantFromAuthority, tenantFromIssuerHost) {
+		return false
+	}
+
+	// Validate the issuer path is one of: empty, "/", "/{tenant}", "/{tenant}/",
+	// "/{tenant}/v2.0", "/{tenant}/v2.0/".
+	path := strings.Trim(issuerURL.EscapedPath(), "/")
+	if path == "" {
+		return true
+	}
+	parts := strings.Split(path, "/")
+	if !strings.EqualFold(parts[0], tenantFromIssuerHost) {
+		return false
+	}
+	if len(parts) == 1 {
+		return true
+	}
+	if len(parts) == 2 && strings.EqualFold(parts[1], "v2.0") {
+		return true
+	}
+	return false
 }
 
 type InstanceDiscoveryMetadata struct {

--- a/apps/internal/oauth/ops/authority/authority_test.go
+++ b/apps/internal/oauth/ops/authority/authority_test.go
@@ -644,11 +644,14 @@ func TestTenantDiscoveryValidateIssuer(t *testing.T) {
 			aliases:     nil,
 			expectError: false,
 		}, {
-			desc:        "regional authority subdomain with matching trusted issuer",
+			// Regional-shaped subdomain of an UNKNOWN base host: rejected.
+			// The same-cloud check is gated on the dictionary lookup, not on a
+			// generic "ends with the issuer host" suffix heuristic.
+			desc:        "regional-shaped authority of unknown base host",
 			issuer:      "https://login.dummy-uri.com/tenant-id",
 			authority:   "https://region.login.dummy-uri.com/tenant-id",
 			aliases:     nil,
-			expectError: false,
+			expectError: true,
 		},
 	}
 

--- a/apps/internal/oauth/ops/authority/cross_cloud_test.go
+++ b/apps/internal/oauth/ops/authority/cross_cloud_test.go
@@ -1,0 +1,414 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package authority
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResolveKnownCloud verifies that known Microsoft cloud hosts (and their
+// regional sub-hosts) resolve to a non-empty cloud identifier and that
+// unknown hosts resolve to "".
+func TestResolveKnownCloud(t *testing.T) {
+	tests := []struct {
+		host     string
+		wantNon  bool   // true if a non-empty cloud id is expected
+		wantSame string // if non-empty, this host must resolve to the same cloud
+	}{
+		// Public cloud aliases — all four collapse to the same cloud id.
+		{"login.microsoftonline.com", true, "login.windows.net"},
+		{"login.windows.net", true, "login.microsoft.com"},
+		{"login.microsoft.com", true, "sts.windows.net"},
+		{"sts.windows.net", true, "login.microsoftonline.com"},
+		// Regional public hosts.
+		{"westus2.login.microsoft.com", true, "login.microsoftonline.com"},
+		{"eastus2euap.login.microsoft.com", true, "login.windows.net"},
+		{"southafricanorth.login.microsoft.com", true, "login.microsoftonline.com"},
+		// China.
+		{"login.partner.microsoftonline.cn", true, "login.chinacloudapi.cn"},
+		{"login.chinacloudapi.cn", true, "login.partner.microsoftonline.cn"},
+		{"chinaeast2.login.chinacloudapi.cn", true, "login.partner.microsoftonline.cn"},
+		// US Gov.
+		{"login.microsoftonline.us", true, "login.usgovcloudapi.net"},
+		{"login.usgovcloudapi.net", true, "login.microsoftonline.us"},
+		{"usgovvirginia.login.microsoftonline.us", true, "login.microsoftonline.us"},
+		// Sovereign clouds.
+		{"login.sovcloud-identity.fr", true, ""},
+		{"francecentral.login.sovcloud-identity.fr", true, "login.sovcloud-identity.fr"},
+		{"login.sovcloud-identity.de", true, ""},
+		{"germanywestcentral.login.sovcloud-identity.de", true, "login.sovcloud-identity.de"},
+		// Case-insensitive host matching.
+		{"LOGIN.MICROSOFTONLINE.COM", true, "login.microsoftonline.com"},
+		// Unknown hosts.
+		{"", false, ""},
+		{"custom.example.com", false, ""},
+		{"login.example.com", false, ""},
+		// Regional-shape failures over a known base — must NOT resolve.
+		{"attacker.evil.login.microsoft.com", false, ""},              // multi-label prefix
+		{"weird_prefix.login.microsoft.com", false, ""},               // underscore
+		{"-leading.login.microsoft.com", false, ""},                   // leading hyphen
+		{"trailing-.login.microsoft.com", false, ""},                  // trailing hyphen
+		{strings.Repeat("a", 64) + ".login.microsoft.com", false, ""}, // 64-char prefix
+		// Regional-shape over an unknown base — also must not resolve.
+		{"westus2.login.example.com", false, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.host, func(t *testing.T) {
+			got := ResolveKnownCloud(tc.host)
+			if tc.wantNon {
+				if got == "" {
+					t.Fatalf("ResolveKnownCloud(%q) = %q, want non-empty", tc.host, got)
+				}
+				if tc.wantSame != "" {
+					if other := ResolveKnownCloud(tc.wantSame); other == "" || other != got {
+						t.Fatalf("ResolveKnownCloud(%q) = %q, ResolveKnownCloud(%q) = %q; want equal non-empty", tc.host, got, tc.wantSame, other)
+					}
+				}
+			} else if got != "" {
+				t.Fatalf("ResolveKnownCloud(%q) = %q, want empty", tc.host, got)
+			}
+		})
+	}
+}
+
+// TestAreInSameCloud is the direct unit test for the same-cloud helper.
+func TestAreInSameCloud(t *testing.T) {
+	pass := []struct{ a, b string }{
+		// Public cloud aliases.
+		{"login.microsoftonline.com", "login.windows.net"},
+		{"login.microsoftonline.com", "westus2.login.microsoft.com"},
+		{"login.microsoft.com", "sts.windows.net"},
+		// US Gov.
+		{"login.microsoftonline.us", "login.usgovcloudapi.net"},
+		{"login.microsoftonline.us", "usgovvirginia.login.microsoftonline.us"},
+		// China.
+		{"login.partner.microsoftonline.cn", "chinaeast2.login.chinacloudapi.cn"},
+		{"login.partner.microsoftonline.cn", "login.chinacloudapi.cn"},
+		// Bleu (sovereign FR).
+		{"login.sovcloud-identity.fr", "francecentral.login.sovcloud-identity.fr"},
+		// Case-insensitive.
+		{"LOGIN.MICROSOFTONLINE.COM", "login.windows.net"},
+	}
+	for _, tc := range pass {
+		if !AreInSameCloud(tc.a, tc.b) {
+			t.Errorf("AreInSameCloud(%q, %q) = false, want true", tc.a, tc.b)
+		}
+		if !AreInSameCloud(tc.b, tc.a) {
+			t.Errorf("AreInSameCloud(%q, %q) = false, want true (commutativity)", tc.b, tc.a)
+		}
+	}
+
+	reject := []struct{ a, b string }{
+		// Different known clouds.
+		{"login.microsoftonline.com", "login.partner.microsoftonline.cn"},
+		{"login.microsoftonline.com", "login.microsoftonline.us"},
+		{"login.microsoftonline.us", "login.chinacloudapi.cn"},
+		{"login.microsoftonline.com", "login.microsoftonline.de"},
+		{"login.sovcloud-identity.fr", "login.sovcloud-identity.de"},
+		// Unknown vs known.
+		{"login.microsoftonline.com", "custom.example.com"},
+		{"custom.example.com", "another.example.org"},
+		// Empty/null inputs.
+		{"custom.example.com", ""},
+		{"", "login.microsoftonline.com"},
+		{"", ""},
+		// Regional-shape failures over a known base.
+		{"attacker.evil.login.microsoft.com", "login.microsoftonline.com"},
+		{"weird_prefix.login.microsoft.com", "login.microsoftonline.com"},
+		{"-leading.login.microsoft.com", "login.microsoftonline.com"},
+		{"trailing-.login.microsoft.com", "login.microsoftonline.com"},
+		{strings.Repeat("a", 64) + ".login.microsoft.com", "login.microsoftonline.com"},
+	}
+	for _, tc := range reject {
+		if AreInSameCloud(tc.a, tc.b) {
+			t.Errorf("AreInSameCloud(%q, %q) = true, want false", tc.a, tc.b)
+		}
+	}
+}
+
+// TestValidateIssuer_CrossCloudRejected exercises the cross-cloud combinations
+// that were silently accepted before the fix and must now throw.
+func TestValidateIssuer_CrossCloudRejected(t *testing.T) {
+	tests := []struct {
+		desc      string
+		authority string
+		issuer    string
+	}{
+		{"public authority + China issuer",
+			"https://login.microsoftonline.com/tenant",
+			"https://login.partner.microsoftonline.cn/tenant"},
+		{"public authority + US Gov issuer",
+			"https://login.microsoftonline.com/tenant",
+			"https://login.microsoftonline.us/tenant"},
+		{"US Gov authority + Public issuer",
+			"https://login.microsoftonline.us/tenant",
+			"https://login.microsoftonline.com/tenant"},
+		{"China authority + Public issuer",
+			"https://login.partner.microsoftonline.cn/tenant",
+			"https://login.microsoftonline.com/tenant"},
+		{"public authority + regional China issuer",
+			"https://login.microsoftonline.com/tenant",
+			"https://chinaeast2.login.chinacloudapi.cn/tenant"},
+		{"US Gov authority + regional Public issuer",
+			"https://login.microsoftonline.us/tenant",
+			"https://westus2.login.microsoft.com/tenant"},
+		{"Bleu authority + Delos issuer",
+			"https://login.sovcloud-identity.fr/tenant",
+			"https://login.sovcloud-identity.de/tenant"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			r := &TenantDiscoveryResponse{
+				AuthorizationEndpoint: tc.authority + "/oauth2/v2.0/authorize",
+				TokenEndpoint:         tc.authority + "/oauth2/v2.0/token",
+				Issuer:                tc.issuer,
+			}
+			if err := r.ValidateIssuerMatchesAuthority(tc.authority, nil); err == nil {
+				t.Fatalf("expected cross-cloud rejection but got nil for authority=%q issuer=%q", tc.authority, tc.issuer)
+			}
+		})
+	}
+}
+
+// TestValidateIssuer_SameCloudAccepted verifies the every-cloud × every-alias
+// matrix from category B of the spec.
+func TestValidateIssuer_SameCloudAccepted(t *testing.T) {
+	tests := []struct {
+		desc      string
+		authority string
+		issuer    string
+	}{
+		// Public cloud cross-alias acceptance.
+		{"public ↔ login.windows.net",
+			"https://login.microsoftonline.com/tenant",
+			"https://login.windows.net/tenant"},
+		{"public ↔ sts.windows.net",
+			"https://login.microsoftonline.com/tenant",
+			"https://sts.windows.net/tenant"},
+		{"public ↔ login.microsoft.com",
+			"https://login.microsoftonline.com/tenant",
+			"https://login.microsoft.com/tenant"},
+		{"US Gov ↔ login.usgovcloudapi.net",
+			"https://login.microsoftonline.us/tenant",
+			"https://login.usgovcloudapi.net/tenant"},
+		{"China ↔ login.chinacloudapi.cn",
+			"https://login.partner.microsoftonline.cn/tenant",
+			"https://login.chinacloudapi.cn/tenant"},
+		// Regional same-cloud.
+		{"public ↔ regional public",
+			"https://login.microsoftonline.com/tenant",
+			"https://westus2.login.microsoft.com/tenant"},
+		{"China ↔ regional China",
+			"https://login.partner.microsoftonline.cn/tenant",
+			"https://chinaeast2.login.chinacloudapi.cn/tenant"},
+		{"Delos ↔ regional Delos",
+			"https://login.sovcloud-identity.de/tenant",
+			"https://germanywestcentral.login.sovcloud-identity.de/tenant"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			r := &TenantDiscoveryResponse{
+				AuthorizationEndpoint: tc.authority + "/oauth2/v2.0/authorize",
+				TokenEndpoint:         tc.authority + "/oauth2/v2.0/token",
+				Issuer:                tc.issuer,
+			}
+			if err := r.ValidateIssuerMatchesAuthority(tc.authority, nil); err != nil {
+				t.Fatalf("expected acceptance but got err=%v for authority=%q issuer=%q", err, tc.authority, tc.issuer)
+			}
+		})
+	}
+}
+
+// TestValidateIssuer_CustomDomainFederation covers Rule 2a: a custom-domain
+// authority is allowed to federate with any known Microsoft cloud issuer.
+// This is the regression path for issue
+// AzureAD/microsoft-authentication-library-for-dotnet#5927.
+func TestValidateIssuer_CustomDomainFederation(t *testing.T) {
+	tests := []struct {
+		desc      string
+		authority string
+		issuer    string
+	}{
+		{"parentpay-style federation with public",
+			"https://clientlogin.test.parentpay.com/tid/v2.0",
+			"https://login.microsoftonline.com/tid/v2.0"},
+		{"custom domain federation with US Gov",
+			"https://customlogin.example.com/tenant",
+			"https://login.microsoftonline.us/tenant"},
+		{"custom domain federation with China",
+			"https://idp.contoso.com/tenant",
+			"https://login.partner.microsoftonline.cn/tenant"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			r := &TenantDiscoveryResponse{
+				AuthorizationEndpoint: tc.authority + "/oauth2/v2.0/authorize",
+				TokenEndpoint:         tc.authority + "/oauth2/v2.0/token",
+				Issuer:                tc.issuer,
+			}
+			if err := r.ValidateIssuerMatchesAuthority(tc.authority, nil); err != nil {
+				t.Fatalf("expected #5927-style acceptance but got err=%v", err)
+			}
+		})
+	}
+}
+
+// TestValidateIssuer_CIAM exercises Rule 4 (CIAM tenant pattern).
+func TestValidateIssuer_CIAM(t *testing.T) {
+	pass := []struct {
+		desc      string
+		authority string
+		issuer    string
+	}{
+		{"CIAM via custom domain authority",
+			"https://customdomain.com/contoso",
+			"https://contoso.ciamlogin.com/contoso/v2.0"},
+		{"CIAM with bare host issuer",
+			"https://contoso.ciamlogin.com",
+			"https://contoso.ciamlogin.com"},
+		{"CIAM with tenant-only path",
+			"https://customdomain.com/contoso",
+			"https://contoso.ciamlogin.com/contoso"},
+		{"CIAM with bare host (no path)",
+			"https://customdomain.com/contoso",
+			"https://contoso.ciamlogin.com"},
+	}
+	for _, tc := range pass {
+		t.Run(tc.desc, func(t *testing.T) {
+			r := &TenantDiscoveryResponse{
+				AuthorizationEndpoint: tc.authority + "/oauth2/v2.0/authorize",
+				TokenEndpoint:         tc.authority + "/oauth2/v2.0/token",
+				Issuer:                tc.issuer,
+			}
+			if err := r.ValidateIssuerMatchesAuthority(tc.authority, nil); err != nil {
+				t.Fatalf("expected CIAM acceptance, got err=%v", err)
+			}
+		})
+	}
+
+	throw := []struct {
+		desc      string
+		authority string
+		issuer    string
+	}{
+		{"CIAM tenant mismatch",
+			"https://customdomain.com/tenantA",
+			"https://tenantB.ciamlogin.com/tenantB/v2.0"},
+		{"CIAM with wrong issuer path tenant",
+			"https://customdomain.com/contoso",
+			"https://contoso.ciamlogin.com/wrongtenant/v2.0"},
+	}
+	for _, tc := range throw {
+		t.Run(tc.desc, func(t *testing.T) {
+			r := &TenantDiscoveryResponse{
+				AuthorizationEndpoint: tc.authority + "/oauth2/v2.0/authorize",
+				TokenEndpoint:         tc.authority + "/oauth2/v2.0/token",
+				Issuer:                tc.issuer,
+			}
+			if err := r.ValidateIssuerMatchesAuthority(tc.authority, nil); err == nil {
+				t.Fatalf("expected rejection for CIAM tenant mismatch but got nil")
+			}
+		})
+	}
+}
+
+// TestValidateIssuer_OtherRejections covers category G of the spec: other
+// rejections that must throw both before AND after the fix.
+func TestValidateIssuer_OtherRejections(t *testing.T) {
+	tests := []struct {
+		desc      string
+		authority string
+		issuer    string
+	}{
+		{"http issuer scheme under known-MS authority",
+			"https://login.microsoftonline.com/tenant",
+			"http://login.microsoftonline.com/tenant"},
+		{"custom authority + unknown-host issuer",
+			"https://customlogin.example.com/tenant",
+			"https://otherhost.example.com/tenant"},
+		{"custom authority + spoofed-but-not-known host",
+			"https://customlogin.example.com/tenant",
+			"https://fake-login.microsoftonline.com/tenant"},
+		{"regional-shaped prefix on unknown base",
+			"https://login.microsoftonline.com/tenant",
+			"https://westus2.login.example.com/tenant"},
+		{"empty issuer",
+			"https://login.microsoftonline.com/tenant",
+			""},
+		{"multi-label prefix on known base",
+			"https://login.microsoftonline.com/tenant",
+			"https://attacker.evil.login.microsoft.com/tenant"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			r := &TenantDiscoveryResponse{
+				AuthorizationEndpoint: tc.authority + "/oauth2/v2.0/authorize",
+				TokenEndpoint:         tc.authority + "/oauth2/v2.0/token",
+				Issuer:                tc.issuer,
+			}
+			if err := r.ValidateIssuerMatchesAuthority(tc.authority, nil); err == nil {
+				t.Fatalf("expected rejection but got nil for %s", tc.desc)
+			}
+		})
+	}
+}
+
+// TestValidateIssuer_BehaviorMatrix is the single-source-of-truth table
+// described in category J. It documents BEFORE vs AFTER for every meaningful
+// (authority shape, issuer shape) combination, so a future regression is
+// visible at a glance.
+func TestValidateIssuer_BehaviorMatrix(t *testing.T) {
+	type row struct {
+		desc   string
+		auth   string
+		iss    string
+		before bool // accepted by the old code
+		after  bool // accepted by the new code
+	}
+	matrix := []row{
+		// --- Pass before AND after (no behavior change) -----------------------
+		{"Rule 1 exact host", "https://login.microsoftonline.com/t", "https://login.microsoftonline.com/t/v2.0", true, true},
+		{"Rule 2 same-cloud (public alias)", "https://login.microsoftonline.com/t", "https://login.windows.net/t", true, true},
+		{"Rule 2 same-cloud (regional public)", "https://login.microsoftonline.com/t", "https://westus2.login.microsoft.com/t", true, true},
+		{"Rule 2 same-cloud (US Gov alias)", "https://login.microsoftonline.us/t", "https://login.usgovcloudapi.net/t", true, true},
+		{"#5927 federation parentpay style", "https://clientlogin.test.parentpay.com/tid/v2.0", "https://login.microsoftonline.com/tid/v2.0", true, true},
+
+		// --- Passed before, NOW THROWS (the fix) ------------------------------
+		{"cross-cloud public ↔ China", "https://login.microsoftonline.com/t", "https://login.partner.microsoftonline.cn/t", true, false},
+		{"cross-cloud public ↔ US Gov", "https://login.microsoftonline.com/t", "https://login.microsoftonline.us/t", true, false},
+		{"cross-cloud US Gov ↔ Public", "https://login.microsoftonline.us/t", "https://login.microsoftonline.com/t", true, false},
+		{"cross-cloud China ↔ Public", "https://login.partner.microsoftonline.cn/t", "https://login.microsoftonline.com/t", true, false},
+		{"cross-cloud public ↔ regional China", "https://login.microsoftonline.com/t", "https://chinaeast2.login.chinacloudapi.cn/t", true, false},
+		{"cross-cloud US Gov ↔ regional Public", "https://login.microsoftonline.us/t", "https://westus2.login.microsoft.com/t", true, false},
+		{"cross-cloud Bleu ↔ Delos", "https://login.sovcloud-identity.fr/t", "https://login.sovcloud-identity.de/t", true, false},
+
+		// --- Throws before AND after (no change) ------------------------------
+		{"http scheme under known-MS authority", "https://login.microsoftonline.com/t", "http://login.microsoftonline.com/t", false, false},
+		{"unknown issuer + custom authority", "https://customlogin.example.com/t", "https://otherhost.example.com/t", false, false},
+		{"multi-label regional-looking", "https://login.microsoftonline.com/t", "https://attacker.evil.login.microsoft.com/t", false, false},
+
+		// --- Threw before, NOW PASSES (only #5927-style federation) -----------
+		// (Already covered above by the parentpay row, kept here for completeness
+		// with an additional cross-cloud federation case.)
+		// Old code accepted this via the TrustedHost(issuerHost) fallback, so
+		// 'before' is true. The new code accepts it via Rule 2a explicitly.
+		{"#5927 federation US Gov", "https://customlogin.example.com/t", "https://login.microsoftonline.us/t", true, true},
+	}
+
+	for _, r := range matrix {
+		t.Run(r.desc, func(t *testing.T) {
+			resp := &TenantDiscoveryResponse{
+				AuthorizationEndpoint: r.auth + "/oauth2/v2.0/authorize",
+				TokenEndpoint:         r.auth + "/oauth2/v2.0/token",
+				Issuer:                r.iss,
+			}
+			err := resp.ValidateIssuerMatchesAuthority(r.auth, nil)
+			accepted := err == nil
+			if accepted != r.after {
+				t.Fatalf("matrix row %q: accepted=%v, want %v (after); err=%v", r.desc, accepted, r.after, err)
+			}
+		})
+	}
+}

--- a/apps/internal/oauth/ops/authority/known_metadata.go
+++ b/apps/internal/oauth/ops/authority/known_metadata.go
@@ -3,68 +3,129 @@
 
 package authority
 
+import (
+	"regexp"
+	"strings"
+)
+
+// regionPrefixRegex matches a single DNS label (RFC 1035 §2.3.1 / RFC 1123 §2.1).
+// Used to shape-check the {region} prefix in a regional host like
+// "westus2.login.microsoft.com" before looking up the base. Not an allow-list.
+var regionPrefixRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+// ResolveKnownCloud returns a stable identifier for the Microsoft sovereign cloud
+// the host belongs to (case-insensitive), or "" if unknown. Hosts in the same
+// cloud return the same identifier so callers can compare with ==. Accepts
+// regional sub-hosts of the shape `{region}.{base}`.
+func ResolveKnownCloud(host string) string {
+	if host == "" {
+		return ""
+	}
+	host = strings.ToLower(host)
+	if md, ok := GetKnownMetadata(host); ok {
+		return md.PreferredCache
+	}
+	// Regional sub-host: {region}.{base}
+	if i := strings.Index(host, "."); i > 0 {
+		prefix := host[:i]
+		base := host[i+1:]
+		if regionPrefixRegex.MatchString(prefix) {
+			if md, ok := GetKnownMetadata(base); ok {
+				return md.PreferredCache
+			}
+		}
+	}
+	return ""
+}
+
+// AreInSameCloud reports whether two hosts belong to the same known Microsoft
+// sovereign cloud. Returns false if either host is unknown (default-deny).
+func AreInSameCloud(a, b string) bool {
+	cloudA := ResolveKnownCloud(a)
+	if cloudA == "" {
+		return false
+	}
+	cloudB := ResolveKnownCloud(b)
+	if cloudB == "" {
+		return false
+	}
+	return cloudA == cloudB
+}
+
+// knownClouds is the authoritative list of Microsoft sovereign clouds. The
+// per-host lookup map and TrustedHost are derived from it at init, so editing
+// this list is the only place to add a cloud or alias.
+var knownClouds = []InstanceDiscoveryMetadata{
+	{
+		// Public Cloud
+		PreferredNetwork: "login.microsoftonline.com",
+		PreferredCache:   "login.windows.net",
+		Aliases:          []string{"login.microsoftonline.com", "login.windows.net", "login.microsoft.com", "sts.windows.net"},
+	},
+	{
+		// China Cloud (login.chinacloudapi.cn kept for backward compatibility)
+		PreferredNetwork: "login.partner.microsoftonline.cn",
+		PreferredCache:   "login.partner.microsoftonline.cn",
+		Aliases:          []string{"login.partner.microsoftonline.cn", "login.chinacloudapi.cn"},
+	},
+	{
+		// Germany Cloud (legacy)
+		PreferredNetwork: "login.microsoftonline.de",
+		PreferredCache:   "login.microsoftonline.de",
+		Aliases:          []string{"login.microsoftonline.de"},
+	},
+	{
+		// US Government Cloud
+		PreferredNetwork: "login.microsoftonline.us",
+		PreferredCache:   "login.microsoftonline.us",
+		Aliases:          []string{"login.microsoftonline.us", "login.usgovcloudapi.net"},
+	},
+	{
+		// US Regional
+		PreferredNetwork: "login-us.microsoftonline.com",
+		PreferredCache:   "login-us.microsoftonline.com",
+		Aliases:          []string{"login-us.microsoftonline.com"},
+	},
+	{
+		// Bleu (France sovereign cloud)
+		PreferredNetwork: "login.sovcloud-identity.fr",
+		PreferredCache:   "login.sovcloud-identity.fr",
+		Aliases:          []string{"login.sovcloud-identity.fr"},
+	},
+	{
+		// Delos (Germany sovereign cloud)
+		PreferredNetwork: "login.sovcloud-identity.de",
+		PreferredCache:   "login.sovcloud-identity.de",
+		Aliases:          []string{"login.sovcloud-identity.de"},
+	},
+	{
+		// GovSG (Singapore sovereign cloud)
+		PreferredNetwork: "login.sovcloud-identity.sg",
+		PreferredCache:   "login.sovcloud-identity.sg",
+		Aliases:          []string{"login.sovcloud-identity.sg"},
+	},
+}
+
+// knownHostMetadata is the alias → metadata lookup, derived from knownClouds
+// at init so the two views cannot drift.
+var knownHostMetadata = func() map[string]InstanceDiscoveryMetadata {
+	m := make(map[string]InstanceDiscoveryMetadata)
+	for _, cloud := range knownClouds {
+		for _, alias := range cloud.Aliases {
+			m[alias] = cloud
+		}
+	}
+	return m
+}()
+
 // GetKnownMetadata returns the known instance discovery metadata for the given
 // host, if any. Each call returns a fresh struct with its own Aliases slice,
 // so callers may freely modify the result without affecting future calls.
 func GetKnownMetadata(host string) (InstanceDiscoveryMetadata, bool) {
-	switch host {
-	// Public Cloud
-	case "login.microsoftonline.com", "login.windows.net", "login.microsoft.com", "sts.windows.net":
-		return InstanceDiscoveryMetadata{
-			PreferredNetwork: "login.microsoftonline.com",
-			PreferredCache:   "login.windows.net",
-			Aliases:          []string{"login.microsoftonline.com", "login.windows.net", "login.microsoft.com", "sts.windows.net"},
-		}, true
-	// China Cloud
-	case "login.partner.microsoftonline.cn", "login.chinacloudapi.cn":
-		return InstanceDiscoveryMetadata{
-			PreferredNetwork: "login.partner.microsoftonline.cn",
-			PreferredCache:   "login.partner.microsoftonline.cn",
-			Aliases:          []string{"login.partner.microsoftonline.cn", "login.chinacloudapi.cn"},
-		}, true
-	// Germany Cloud (legacy)
-	case "login.microsoftonline.de":
-		return InstanceDiscoveryMetadata{
-			PreferredNetwork: "login.microsoftonline.de",
-			PreferredCache:   "login.microsoftonline.de",
-			Aliases:          []string{"login.microsoftonline.de"},
-		}, true
-	// US Government Cloud
-	case "login.microsoftonline.us", "login.usgovcloudapi.net":
-		return InstanceDiscoveryMetadata{
-			PreferredNetwork: "login.microsoftonline.us",
-			PreferredCache:   "login.microsoftonline.us",
-			Aliases:          []string{"login.microsoftonline.us", "login.usgovcloudapi.net"},
-		}, true
-	// US Regional
-	case "login-us.microsoftonline.com":
-		return InstanceDiscoveryMetadata{
-			PreferredNetwork: "login-us.microsoftonline.com",
-			PreferredCache:   "login-us.microsoftonline.com",
-			Aliases:          []string{"login-us.microsoftonline.com"},
-		}, true
-	// Bleu (France sovereign cloud)
-	case "login.sovcloud-identity.fr":
-		return InstanceDiscoveryMetadata{
-			PreferredNetwork: "login.sovcloud-identity.fr",
-			PreferredCache:   "login.sovcloud-identity.fr",
-			Aliases:          []string{"login.sovcloud-identity.fr"},
-		}, true
-	// Delos (Germany sovereign cloud)
-	case "login.sovcloud-identity.de":
-		return InstanceDiscoveryMetadata{
-			PreferredNetwork: "login.sovcloud-identity.de",
-			PreferredCache:   "login.sovcloud-identity.de",
-			Aliases:          []string{"login.sovcloud-identity.de"},
-		}, true
-	// GovSG (Singapore sovereign cloud)
-	case "login.sovcloud-identity.sg":
-		return InstanceDiscoveryMetadata{
-			PreferredNetwork: "login.sovcloud-identity.sg",
-			PreferredCache:   "login.sovcloud-identity.sg",
-			Aliases:          []string{"login.sovcloud-identity.sg"},
-		}, true
-	default:
+	md, ok := knownHostMetadata[host]
+	if !ok {
 		return InstanceDiscoveryMetadata{}, false
 	}
+	md.Aliases = append([]string(nil), md.Aliases...)
+	return md, true
 }

--- a/apps/internal/oauth/ops/authority/known_metadata_test.go
+++ b/apps/internal/oauth/ops/authority/known_metadata_test.go
@@ -96,24 +96,41 @@ func TestPublicCloudAliasesShareEntry(t *testing.T) {
 	}
 }
 
-// TestTrustedHostsHaveKnownMetadata verifies that every host in the
-// aadTrustedHostList has a corresponding entry in GetKnownMetadata. This
-// catches maintenance mistakes where a new cloud is added to one list but
-// not the other, which would cause fallback to produce a degraded self-entry
-// instead of the correct alias set.
-func TestTrustedHostsHaveKnownMetadata(t *testing.T) {
-	for host := range aadTrustedHostList {
-		t.Run(host, func(t *testing.T) {
-			md, ok := GetKnownMetadata(host)
+// TestKnownCloudsAreInternallyConsistent verifies that every alias declared
+// in the canonical knownClouds list is reachable through GetKnownMetadata
+// and through TrustedHost, that PreferredNetwork is non-empty, and that
+// PreferredCache is unique per cloud (ResolveKnownCloud uses it as the
+// cloud-identity sentinel, so collisions would silently merge clouds).
+func TestKnownCloudsAreInternallyConsistent(t *testing.T) {
+	preferredCacheSeen := make(map[string]string)
+	for _, cloud := range knownClouds {
+		if cloud.PreferredNetwork == "" {
+			t.Errorf("cloud %+v has empty PreferredNetwork", cloud)
+		}
+		if cloud.PreferredCache == "" {
+			t.Errorf("cloud %+v has empty PreferredCache", cloud)
+		}
+		if prev, dup := preferredCacheSeen[cloud.PreferredCache]; dup {
+			t.Errorf("PreferredCache %q used by two clouds: %q and %q (must be unique per cloud)",
+				cloud.PreferredCache, prev, cloud.PreferredNetwork)
+		}
+		preferredCacheSeen[cloud.PreferredCache] = cloud.PreferredNetwork
+		if len(cloud.Aliases) == 0 {
+			t.Errorf("cloud %q has no aliases", cloud.PreferredNetwork)
+		}
+		for _, alias := range cloud.Aliases {
+			md, ok := GetKnownMetadata(alias)
 			if !ok {
-				t.Fatalf("trusted host %q has no entry in GetKnownMetadata", host)
+				t.Errorf("alias %q not reachable through GetKnownMetadata", alias)
+				continue
 			}
-			if md.PreferredNetwork == "" {
-				t.Errorf("trusted host %q has empty PreferredNetwork", host)
+			if md.PreferredNetwork != cloud.PreferredNetwork {
+				t.Errorf("alias %q resolves to PreferredNetwork %q, want %q",
+					alias, md.PreferredNetwork, cloud.PreferredNetwork)
 			}
-			if len(md.Aliases) == 0 {
-				t.Errorf("trusted host %q has no aliases", host)
+			if !TrustedHost(alias) {
+				t.Errorf("alias %q is not a TrustedHost", alias)
 			}
-		})
+		}
 	}
 }

--- a/apps/internal/oauth/resolvers.go
+++ b/apps/internal/oauth/resolvers.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -21,12 +22,10 @@ import (
 type cacheEntry struct {
 	Endpoints             authority.Endpoints
 	ValidForDomainsInList map[string]bool
-	// Aliases stores host aliases from instance discovery for quick lookup
-	Aliases map[string]bool
 }
 
 func createcacheEntry(endpoints authority.Endpoints) cacheEntry {
-	return cacheEntry{endpoints, map[string]bool{}, map[string]bool{}}
+	return cacheEntry{endpoints, map[string]bool{}}
 }
 
 // AuthorityEndpoint retrieves endpoints from an authority for auth and token acquisition.
@@ -50,7 +49,7 @@ func (m *authorityEndpoint) ResolveEndpoints(ctx context.Context, authorityInfo 
 		return endpoints, nil
 	}
 
-	endpoint, err := m.openIDConfigurationEndpoint(ctx, authorityInfo)
+	endpoint, err := m.openIDConfigurationEndpoint(ctx, &authorityInfo)
 	if err != nil {
 		return authority.Endpoints{}, err
 	}
@@ -71,14 +70,67 @@ func (m *authorityEndpoint) ResolveEndpoints(ctx context.Context, authorityInfo 
 		strings.Replace(resp.Issuer, "{tenant}", tenant, -1),
 		authorityInfo.Host)
 
-	m.addCachedEndpoints(authorityInfo, userPrincipalName, endpoints)
+	// Build aliases from instance-discovery metadata. Computed locally so
+	// validation runs BEFORE addCachedEndpoints (a tampered doc must not poison
+	// the cache).
+	aliases := map[string]bool{}
+	for _, metadata := range authorityInfo.InstanceDiscoveryMetadata {
+		for _, alias := range metadata.Aliases {
+			aliases[alias] = true
+		}
+	}
 
-	if err := resp.ValidateIssuerMatchesAuthority(authorityInfo.CanonicalAuthorityURI,
-		m.cache[authorityInfo.CanonicalAuthorityURI].Aliases); err != nil {
+	if err := resp.ValidateIssuerMatchesAuthority(authorityInfo.CanonicalAuthorityURI, aliases); err != nil {
 		return authority.Endpoints{}, fmt.Errorf("ResolveEndpoints(): %w", err)
 	}
 
+	// Cross-cloud endpoint check: refuse a discovery doc whose token_endpoint
+	// or authorization_endpoint resolves to a different sovereign cloud than
+	// the configured authority.
+	if err := ensureKnownAuthorityEndpointSameCloud(authorityInfo, endpoints.TokenEndpoint, "token_endpoint"); err != nil {
+		return authority.Endpoints{}, fmt.Errorf("ResolveEndpoints(): %w", err)
+	}
+	if err := ensureKnownAuthorityEndpointSameCloud(authorityInfo, endpoints.AuthorizationEndpoint, "authorization_endpoint"); err != nil {
+		return authority.Endpoints{}, fmt.Errorf("ResolveEndpoints(): %w", err)
+	}
+
+	m.addCachedEndpoints(authorityInfo, userPrincipalName, endpoints)
+
 	return endpoints, nil
+}
+
+// ensureKnownAuthorityEndpointSameCloud rejects an OIDC endpoint that does not
+// resolve to the same Microsoft sovereign cloud as authorityInfo. Custom-domain
+// authorities are skipped (see AzureAD/microsoft-authentication-library-for-dotnet#5927).
+// Once the rule is in scope, malformed or non-absolute URLs fail closed.
+func ensureKnownAuthorityEndpointSameCloud(authorityInfo authority.Info, endpoint, endpointName string) error {
+	if endpoint == "" {
+		return nil
+	}
+	authorityCloud := authority.ResolveKnownCloud(authorityInfo.Host)
+	if authorityCloud == "" {
+		// Custom-domain authority — not constrained.
+		return nil
+	}
+	rejectf := func(reason string) error {
+		return fmt.Errorf(
+			"OIDC discovery for authority %q returned a %s %q that %s. "+
+				"MSAL refused to use that endpoint. Verify the OIDC discovery endpoint is not being intercepted and that the configured authority points at the correct sovereign cloud.",
+			authorityInfo.CanonicalAuthorityURI, endpointName, endpoint, reason,
+		)
+	}
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil || !endpointURL.IsAbs() {
+		return rejectf("is not a parseable absolute URL")
+	}
+	if !strings.EqualFold(endpointURL.Scheme, "https") {
+		return rejectf("is not an https URL")
+	}
+	endpointCloud := authority.ResolveKnownCloud(endpointURL.Hostname())
+	if endpointCloud == "" || endpointCloud != authorityCloud {
+		return rejectf("is not in the same Microsoft sovereign cloud as the authority")
+	}
+	return nil
 }
 
 // cachedEndpoints returns the cached endpoints if they exist. If not, we return false.
@@ -120,31 +172,28 @@ func (m *authorityEndpoint) addCachedEndpoints(authorityInfo authority.Info, use
 		}
 	}
 
-	// Extract aliases from instance discovery metadata and add to cache
-	for _, metadata := range authorityInfo.InstanceDiscoveryMetadata {
-		for _, alias := range metadata.Aliases {
-			updatedCacheEntry.Aliases[alias] = true
-		}
-	}
-
 	m.cache[authorityInfo.CanonicalAuthorityURI] = updatedCacheEntry
 }
 
-func (m *authorityEndpoint) openIDConfigurationEndpoint(ctx context.Context, authorityInfo authority.Info) (string, error) {
+// openIDConfigurationEndpoint resolves the OIDC discovery endpoint URL.
+// authorityInfo is taken by pointer so AAD instance-discovery metadata
+// (resp.Metadata) propagates back to the caller; a value receiver would
+// silently leave the caller's alias set empty.
+func (m *authorityEndpoint) openIDConfigurationEndpoint(ctx context.Context, authorityInfo *authority.Info) (string, error) {
 	if authorityInfo.AuthorityType == authority.ADFS {
 		return fmt.Sprintf("https://%s/adfs/.well-known/openid-configuration", authorityInfo.Host), nil
 	} else if authorityInfo.AuthorityType == authority.DSTS {
 		return fmt.Sprintf("https://%s/dstsv2/%s/v2.0/.well-known/openid-configuration", authorityInfo.Host, authority.DSTSTenant), nil
 
 	} else if authorityInfo.ValidateAuthority && !authority.TrustedHost(authorityInfo.Host) {
-		resp, err := m.rest.Authority().AADInstanceDiscovery(ctx, authorityInfo)
+		resp, err := m.rest.Authority().AADInstanceDiscovery(ctx, *authorityInfo)
 		if err != nil {
 			return "", err
 		}
 		authorityInfo.InstanceDiscoveryMetadata = resp.Metadata
 		return resp.TenantDiscoveryEndpoint, nil
 	} else if authorityInfo.Region != "" {
-		resp, err := m.rest.Authority().AADInstanceDiscovery(ctx, authorityInfo)
+		resp, err := m.rest.Authority().AADInstanceDiscovery(ctx, *authorityInfo)
 		if err != nil {
 			return "", err
 		}

--- a/apps/internal/oauth/resolvers_test.go
+++ b/apps/internal/oauth/resolvers_test.go
@@ -1,0 +1,300 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/mock"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
+)
+
+// crossCloudDiscoveryBody returns a discovery doc whose issuer matches the
+// authority host (so issuer validation passes) but whose token_endpoint and
+// authorization_endpoint can be overridden to point anywhere (to simulate a
+// tampered or hijacked discovery response).
+func crossCloudDiscoveryBody(authorityHost, tenant, tokenEndpoint, authorizationEndpoint string) []byte {
+	if tokenEndpoint == "" {
+		tokenEndpoint = fmt.Sprintf("https://%s/%s/oauth2/v2.0/token", authorityHost, tenant)
+	}
+	if authorizationEndpoint == "" {
+		authorizationEndpoint = fmt.Sprintf("https://%s/%s/oauth2/v2.0/authorize", authorityHost, tenant)
+	}
+	return []byte(fmt.Sprintf(
+		`{"token_endpoint":%q,"authorization_endpoint":%q,"issuer":%q}`,
+		tokenEndpoint,
+		authorizationEndpoint,
+		fmt.Sprintf("https://%s/%s/v2.0", authorityHost, tenant),
+	))
+}
+
+func newAuthorityInfoForTest(t *testing.T, host, tenant string) authority.Info {
+	t.Helper()
+	authorityURI := fmt.Sprintf("https://%s/%s/", host, tenant)
+	info, err := authority.NewInfoFromAuthorityURI(authorityURI, false /*validateAuthority*/, true /*disableInstanceDiscovery*/)
+	if err != nil {
+		t.Fatalf("NewInfoFromAuthorityURI: %v", err)
+	}
+	return info
+}
+
+// requestCountingClient wraps a mock client to record the number of POST
+// requests issued. The cross-cloud check must trip BEFORE any credential POST
+// to the spoofed endpoint.
+type requestCountingClient struct {
+	inner *mock.Client
+	posts int32
+}
+
+func (c *requestCountingClient) Do(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodPost {
+		atomic.AddInt32(&c.posts, 1)
+	}
+	return c.inner.Do(req)
+}
+func (c *requestCountingClient) CloseIdleConnections() { c.inner.CloseIdleConnections() }
+
+// TestResolveEndpoints_CrossCloudTokenEndpointRefused verifies that when the
+// configured authority is a known Microsoft host, a discovery doc whose
+// token_endpoint resolves to a different sovereign cloud is refused, and
+// that NO credential POST was issued to the spoofed endpoint.
+func TestResolveEndpoints_CrossCloudTokenEndpointRefused(t *testing.T) {
+	host := "login.microsoftonline.com" // Public cloud authority
+	tenant := "contoso"
+	spoofedTokenEndpoint := "https://login.partner.microsoftonline.cn/contoso/oauth2/v2.0/token"
+
+	mc := mock.NewClient()
+	mc.AppendResponse(mock.WithBody(crossCloudDiscoveryBody(host, tenant, spoofedTokenEndpoint, "")))
+	counter := &requestCountingClient{inner: mc}
+
+	client := New(counter)
+	info := newAuthorityInfoForTest(t, host, tenant)
+	_, err := client.ResolveEndpoints(context.Background(), info, "")
+	if err == nil {
+		t.Fatal("expected cross-cloud rejection, got nil error")
+	}
+	if !strings.Contains(err.Error(), "token_endpoint") {
+		t.Errorf("error should mention token_endpoint; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), spoofedTokenEndpoint) {
+		t.Errorf("error should contain spoofed endpoint %q; got: %v", spoofedTokenEndpoint, err)
+	}
+	if got := atomic.LoadInt32(&counter.posts); got != 0 {
+		t.Errorf("expected zero POSTs to the spoofed endpoint, got %d", got)
+	}
+}
+
+// TestResolveEndpoints_CustomEndpointUnderKnownAuthorityRefused verifies that
+// a discovery doc whose token_endpoint points at an attacker-controlled
+// custom domain is refused when the configured authority is a known Microsoft
+// host.
+func TestResolveEndpoints_CustomEndpointUnderKnownAuthorityRefused(t *testing.T) {
+	host := "login.microsoftonline.com"
+	tenant := "contoso"
+	spoofedTokenEndpoint := "https://attacker.example.com/oauth2/v2.0/token"
+
+	mc := mock.NewClient()
+	mc.AppendResponse(mock.WithBody(crossCloudDiscoveryBody(host, tenant, spoofedTokenEndpoint, "")))
+
+	client := New(mc)
+	info := newAuthorityInfoForTest(t, host, tenant)
+	_, err := client.ResolveEndpoints(context.Background(), info, "")
+	if err == nil {
+		t.Fatal("expected rejection for custom endpoint under known-MS authority, got nil")
+	}
+	if !strings.Contains(err.Error(), spoofedTokenEndpoint) {
+		t.Errorf("error should contain spoofed endpoint %q; got: %v", spoofedTokenEndpoint, err)
+	}
+}
+
+// TestResolveEndpoints_CrossCloudAuthorizationEndpointRefused verifies that
+// the same-cloud check also fires on the authorization_endpoint, not just
+// token_endpoint.
+func TestResolveEndpoints_CrossCloudAuthorizationEndpointRefused(t *testing.T) {
+	host := "login.microsoftonline.com"
+	tenant := "contoso"
+	spoofedAuthEndpoint := "https://login.partner.microsoftonline.cn/contoso/oauth2/v2.0/authorize"
+
+	mc := mock.NewClient()
+	mc.AppendResponse(mock.WithBody(crossCloudDiscoveryBody(host, tenant, "", spoofedAuthEndpoint)))
+
+	client := New(mc)
+	info := newAuthorityInfoForTest(t, host, tenant)
+	_, err := client.ResolveEndpoints(context.Background(), info, "")
+	if err == nil {
+		t.Fatal("expected rejection for cross-cloud authorization_endpoint, got nil")
+	}
+	if !strings.Contains(err.Error(), "authorization_endpoint") {
+		t.Errorf("error should mention authorization_endpoint; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), spoofedAuthEndpoint) {
+		t.Errorf("error should contain spoofed endpoint %q; got: %v", spoofedAuthEndpoint, err)
+	}
+}
+
+// TestResolveEndpoints_CustomIdpEndpointAllowed verifies that custom-domain
+// authorities (not in the known-host map) are NOT constrained by the
+// same-cloud check. A custom OIDC IdP can publish its own endpoints freely.
+func TestResolveEndpoints_CustomIdpEndpointAllowed(t *testing.T) {
+	host := "idp.crosscloudtest-1.example.com"
+	tenant := "tenant"
+
+	mc := mock.NewClient()
+	mc.AppendResponse(mock.WithBody(crossCloudDiscoveryBody(host, tenant, "", "")))
+
+	client := New(mc)
+	info := newAuthorityInfoForTest(t, host, tenant)
+	endpoints, err := client.ResolveEndpoints(context.Background(), info, "")
+	if err != nil {
+		t.Fatalf("expected success for custom OIDC authority, got %v", err)
+	}
+	if !strings.HasPrefix(endpoints.TokenEndpoint, "https://"+host) {
+		t.Errorf("unexpected token endpoint %q for custom authority %q", endpoints.TokenEndpoint, host)
+	}
+}
+
+// TestResolveEndpoints_TamperedDocNotCached verifies the ordering requirement:
+// a tampered discovery doc must NOT poison the cache. After a cross-cloud
+// rejection, a subsequent call with a clean doc for the same authority must
+// re-issue discovery (and succeed).
+func TestResolveEndpoints_TamperedDocNotCached(t *testing.T) {
+	host := "login.microsoftonline.com"
+	tenant := "tampercheck-tenant"
+	spoofed := "https://login.partner.microsoftonline.cn/" + tenant + "/oauth2/v2.0/token"
+
+	mc := mock.NewClient()
+	// First call: tampered.
+	mc.AppendResponse(mock.WithBody(crossCloudDiscoveryBody(host, tenant, spoofed, "")))
+	// Second call: clean — should be re-fetched because the first call must
+	// not have cached the tampered response.
+	mc.AppendResponse(mock.WithBody(crossCloudDiscoveryBody(host, tenant, "", "")))
+
+	client := New(mc)
+	info := newAuthorityInfoForTest(t, host, tenant)
+
+	if _, err := client.ResolveEndpoints(context.Background(), info, ""); err == nil {
+		t.Fatal("first call: expected cross-cloud rejection, got nil")
+	}
+	endpoints, err := client.ResolveEndpoints(context.Background(), info, "")
+	if err != nil {
+		t.Fatalf("second call (clean doc): expected success, got %v", err)
+	}
+	wantTokenPrefix := "https://" + host
+	if !strings.HasPrefix(endpoints.TokenEndpoint, wantTokenPrefix) {
+		t.Errorf("second call: unexpected token endpoint %q", endpoints.TokenEndpoint)
+	}
+}
+
+// TestResolveEndpoints_MalformedTokenEndpointRefused verifies fail-closed
+// behavior of the same-cloud check when the discovery doc returns a
+// token_endpoint that is not a parseable absolute URL. For a known-MS
+// authority, MSAL must refuse rather than silently fall through.
+func TestResolveEndpoints_MalformedTokenEndpointRefused(t *testing.T) {
+	host := "login.microsoftonline.com"
+	tenant := "malformed-tenant"
+	malformed := "not-a-url"
+
+	mc := mock.NewClient()
+	mc.AppendResponse(mock.WithBody(crossCloudDiscoveryBody(host, tenant, malformed, "")))
+
+	client := New(mc)
+	info := newAuthorityInfoForTest(t, host, tenant)
+	_, err := client.ResolveEndpoints(context.Background(), info, "")
+	if err == nil {
+		t.Fatal("expected rejection for malformed token_endpoint, got nil")
+	}
+	if !strings.Contains(err.Error(), "token_endpoint") {
+		t.Errorf("error should mention token_endpoint; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), malformed) {
+		t.Errorf("error should contain malformed value %q; got: %v", malformed, err)
+	}
+}
+
+// TestResolveEndpoints_MalformedAuthorizationEndpointRefused mirrors the
+// token_endpoint case for the second endpoint covered by the same-cloud check.
+func TestResolveEndpoints_MalformedAuthorizationEndpointRefused(t *testing.T) {
+	host := "login.microsoftonline.com"
+	tenant := "malformed-authz-tenant"
+	malformed := "not-a-url"
+
+	mc := mock.NewClient()
+	mc.AppendResponse(mock.WithBody(crossCloudDiscoveryBody(host, tenant, "", malformed)))
+
+	client := New(mc)
+	info := newAuthorityInfoForTest(t, host, tenant)
+	_, err := client.ResolveEndpoints(context.Background(), info, "")
+	if err == nil {
+		t.Fatal("expected rejection for malformed authorization_endpoint, got nil")
+	}
+	if !strings.Contains(err.Error(), "authorization_endpoint") {
+		t.Errorf("error should mention authorization_endpoint; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), malformed) {
+		t.Errorf("error should contain malformed value %q; got: %v", malformed, err)
+	}
+}
+
+// TestResolveEndpoints_HTTPSchemeEndpointRefused verifies that a discovery doc
+// returning a same-cloud host but downgraded to plain http is refused. The
+// same-cloud check must require https for known-MS authorities.
+func TestResolveEndpoints_HTTPSchemeEndpointRefused(t *testing.T) {
+	host := "login.microsoftonline.com"
+	tenant := "http-downgrade-tenant"
+	downgraded := "http://login.windows.net/" + tenant + "/oauth2/v2.0/token"
+
+	mc := mock.NewClient()
+	mc.AppendResponse(mock.WithBody(crossCloudDiscoveryBody(host, tenant, downgraded, "")))
+	counter := &requestCountingClient{inner: mc}
+
+	client := New(counter)
+	info := newAuthorityInfoForTest(t, host, tenant)
+	_, err := client.ResolveEndpoints(context.Background(), info, "")
+	if err == nil {
+		t.Fatal("expected rejection for http token_endpoint, got nil")
+	}
+	if !strings.Contains(err.Error(), "https") {
+		t.Errorf("error should mention https; got: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter.posts); got != 0 {
+		t.Errorf("expected zero POSTs to downgraded endpoint, got %d", got)
+	}
+}
+
+// TestResolveEndpoints_SameCloudAliasAllowed verifies that a discovery doc
+// publishing a token_endpoint on a DIFFERENT host alias of the SAME sovereign
+// cloud (e.g. login.windows.net for a login.microsoftonline.com authority) is
+// accepted by the same-cloud check.
+func TestResolveEndpoints_SameCloudAliasAllowed(t *testing.T) {
+	host := "login.microsoftonline.com"
+	tenant := "samecloudalias-tenant"
+	// Different host but same Public cloud.
+	aliasTokenEndpoint := "https://login.windows.net/" + tenant + "/oauth2/v2.0/token"
+
+	// Issuer must still pass ValidateIssuerMatchesAuthority — login.windows.net
+	// is a same-cloud alias and is accepted by Rule 2b.
+	body := []byte(fmt.Sprintf(
+		`{"token_endpoint":%q,"authorization_endpoint":%q,"issuer":%q}`,
+		aliasTokenEndpoint,
+		fmt.Sprintf("https://%s/%s/oauth2/v2.0/authorize", host, tenant),
+		fmt.Sprintf("https://login.windows.net/%s/v2.0", tenant),
+	))
+	mc := mock.NewClient()
+	mc.AppendResponse(mock.WithBody(body))
+
+	client := New(mc)
+	info := newAuthorityInfoForTest(t, host, tenant)
+	endpoints, err := client.ResolveEndpoints(context.Background(), info, "")
+	if err != nil {
+		t.Fatalf("expected acceptance for same-cloud alias, got %v", err)
+	}
+	if endpoints.TokenEndpoint != aliasTokenEndpoint {
+		t.Errorf("unexpected token endpoint %q", endpoints.TokenEndpoint)
+	}
+}


### PR DESCRIPTION
This pull request refactors and strengthens the logic for validating Microsoft Azure Active Directory (AAD) authority hosts and OIDC discovery endpoints. The changes centralize cloud/host metadata, improve security by enforcing stricter issuer and endpoint validation, and simplify maintenance by consolidating trusted host lists.

**Key improvements:**

- Trusted host and cloud logic is now derived from a single canonical list, preventing drift and ensuring consistency.
- Issuer validation rules are clarified and extended, especially for Microsoft sovereign clouds and CIAM tenants.
- OIDC endpoint validation is tightened to prevent cross-cloud misconfiguration or tampering.
- Test coverage and internal consistency checks are improved.

---

### Trusted Host and Cloud Metadata Refactoring

* Removed the hardcoded `aadTrustedHostList` map and replaced it with a canonical `knownClouds` list in `known_metadata.go`. All trusted host and cloud logic (including `TrustedHost`, `GetKnownMetadata`, and new cloud comparison helpers) now derive from this list, ensuring consistency and simplifying future updates. 
* Added `ResolveKnownCloud` and `AreInSameCloud` helpers to reliably identify and compare Microsoft sovereign clouds based on hostnames, including support for regional subdomains.

### Issuer and Endpoint Validation Hardening

* Refactored `ValidateIssuerMatchesAuthority` to clarify and enforce acceptance rules for issuer validation, including exact match, known Microsoft hosts, instance-discovery aliases, and CIAM tenant patterns. Added a dedicated `matchesCIAMIssuer` helper for CIAM validation. 
* Added new logic to ensure that OIDC `token_endpoint` and `authorization_endpoint` URLs returned by discovery are in the same sovereign cloud as the configured authority, except for custom domains.

### Codebase Simplification and Maintenance

* Consolidated the cache entry structure and removed the now-unnecessary alias map from the cache. Aliases are now built locally as needed for validation. 
* Refactored OIDC discovery endpoint resolution to pass authority info by pointer, ensuring instance discovery metadata is correctly propagated. 

### Test Improvements

* Updated and expanded tests to reflect new validation rules, including rejecting regional-shaped authorities of unknown base hosts and verifying internal consistency of the canonical cloud list and all aliases. 

### Documentation and Clarity

* Improved comments and documentation throughout the codebase, especially around validation logic and the structure of the canonical cloud list. 