### PR TITLE
Add User Federated Identity Credential (`user_fic`) grant type support

### DIFF
--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -465,6 +465,7 @@ func WithClaims(claims string) interface {
 	AcquireByUsernamePasswordOption
 	AcquireSilentOption
 	AuthCodeURLOption
+	AcquireByUserFICOption
 	options.CallOption
 } {
 	return struct {
@@ -474,6 +475,7 @@ func WithClaims(claims string) interface {
 		AcquireByUsernamePasswordOption
 		AcquireSilentOption
 		AuthCodeURLOption
+		AcquireByUserFICOption
 		options.CallOption
 	}{
 		CallOption: options.NewCallOption(
@@ -490,6 +492,8 @@ func WithClaims(claims string) interface {
 				case *acquireTokenSilentOptions:
 					t.claims = claims
 				case *authCodeURLOptions:
+					t.claims = claims
+				case *acquireTokenByUserFICOptions:
 					t.claims = claims
 				default:
 					return fmt.Errorf("unexpected options type %T", a)
@@ -536,6 +540,7 @@ func WithTenantID(tenantID string) interface {
 	AcquireByUsernamePasswordOption
 	AcquireSilentOption
 	AuthCodeURLOption
+	AcquireByUserFICOption
 	options.CallOption
 } {
 	return struct {
@@ -545,6 +550,7 @@ func WithTenantID(tenantID string) interface {
 		AcquireByUsernamePasswordOption
 		AcquireSilentOption
 		AuthCodeURLOption
+		AcquireByUserFICOption
 		options.CallOption
 	}{
 		CallOption: options.NewCallOption(
@@ -561,6 +567,8 @@ func WithTenantID(tenantID string) interface {
 				case *acquireTokenSilentOptions:
 					t.tenantID = tenantID
 				case *authCodeURLOptions:
+					t.tenantID = tenantID
+				case *acquireTokenByUserFICOptions:
 					t.tenantID = tenantID
 				default:
 					return fmt.Errorf("unexpected options type %T", a)
@@ -901,4 +909,107 @@ func WithAttribute(attrValue string) interface {
 			},
 		),
 	}
+}
+
+// AcquireByUserFICOption is implemented by options for AcquireTokenByUserFederatedIdentityCredential.
+type AcquireByUserFICOption interface {
+	acquireByUserFICOption()
+}
+
+// acquireTokenByUserFICOptions contains optional configuration for AcquireTokenByUserFederatedIdentityCredential.
+type acquireTokenByUserFICOptions struct {
+	claims, tenantID string
+	username         string
+	userObjectID     string
+}
+
+func (acquireTokenByUserFICOptions) acquireByUserFICOption() {}
+
+// WithUserObjectID specifies the target user by their object ID (OID) for the user_fic flow.
+// This is mutually exclusive with WithUsername.
+func WithUserObjectID(oid string) interface {
+	AcquireByUserFICOption
+	options.CallOption
+} {
+	return struct {
+		AcquireByUserFICOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *acquireTokenByUserFICOptions:
+					t.userObjectID = oid
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
+
+// WithUserFICUsername specifies the target user by their UPN (username) for the user_fic flow.
+// This is mutually exclusive with WithUserObjectID.
+func WithUserFICUsername(username string) interface {
+	AcquireByUserFICOption
+	options.CallOption
+} {
+	return struct {
+		AcquireByUserFICOption
+		options.CallOption
+	}{
+		CallOption: options.NewCallOption(
+			func(a any) error {
+				switch t := a.(type) {
+				case *acquireTokenByUserFICOptions:
+					t.username = username
+				default:
+					return fmt.Errorf("unexpected options type %T", a)
+				}
+				return nil
+			},
+		),
+	}
+}
+
+// AcquireTokenByUserFederatedIdentityCredential acquires a user-scoped token using the user_fic grant type.
+// This exchanges a federated identity credential (assertion) for a user token, enabling an agent
+// to act on behalf of a user.
+//
+// Parameters:
+//   - ctx: Context for the request.
+//   - scopes: Scopes requested for the token.
+//   - assertion: The federated identity credential token (e.g., T2 from agent identity Leg 2).
+//   - opts: Options including user identification (exactly one of WithUserObjectID or WithUserFICUsername
+//     is required), [WithClaims], [WithTenantID].
+//
+// Options: [WithUserObjectID], [WithUserFICUsername], [WithClaims], [WithTenantID]
+func (cca Client) AcquireTokenByUserFederatedIdentityCredential(ctx context.Context, scopes []string, assertion string, opts ...AcquireByUserFICOption) (AuthResult, error) {
+	o := acquireTokenByUserFICOptions{}
+	if err := options.ApplyOptions(&o, opts); err != nil {
+		return AuthResult{}, err
+	}
+
+	// Validate inputs
+	if assertion == "" {
+		return AuthResult{}, errors.New("assertion must not be empty")
+	}
+	if o.username == "" && o.userObjectID == "" {
+		return AuthResult{}, errors.New("exactly one of WithUserObjectID or WithUserFICUsername must be specified")
+	}
+	if o.username != "" && o.userObjectID != "" {
+		return AuthResult{}, errors.New("WithUserObjectID and WithUserFICUsername are mutually exclusive")
+	}
+
+	params := base.AcquireTokenByUserFICParameters{
+		Scopes:                          scopes,
+		Claims:                          o.claims,
+		Credential:                      cca.cred,
+		TenantID:                        o.tenantID,
+		UserFederatedIdentityCredential: assertion,
+		Username:                        o.username,
+		UserObjectID:                    o.userObjectID,
+	}
+	return cca.base.AcquireTokenByUserFIC(ctx, params)
 }

--- a/apps/confidential/confidential.go
+++ b/apps/confidential/confidential.go
@@ -923,10 +923,11 @@ type acquireTokenByUserFICOptions struct {
 	userObjectID     string
 }
 
+// acquireByUserFICOption is a marker method that restricts option types to the user_fic API.
 func (acquireTokenByUserFICOptions) acquireByUserFICOption() {}
 
 // WithUserObjectID specifies the target user by their object ID (OID) for the user_fic flow.
-// This is mutually exclusive with WithUsername.
+// This is mutually exclusive with WithUserFICUsername.
 func WithUserObjectID(oid string) interface {
 	AcquireByUserFICOption
 	options.CallOption
@@ -975,12 +976,13 @@ func WithUserFICUsername(username string) interface {
 
 // AcquireTokenByUserFederatedIdentityCredential acquires a user-scoped token using the user_fic grant type.
 // This exchanges a federated identity credential (assertion) for a user token, enabling an agent
-// to act on behalf of a user.
+// to act on behalf of a user. The result includes an Account that can be used with
+// [Client.AcquireTokenSilent] for subsequent cached access.
 //
 // Parameters:
 //   - ctx: Context for the request.
 //   - scopes: Scopes requested for the token.
-//   - assertion: The federated identity credential token (e.g., T2 from agent identity Leg 2).
+//   - assertion: The federated identity credential (instance token) to exchange.
 //   - opts: Options including user identification (exactly one of WithUserObjectID or WithUserFICUsername
 //     is required), [WithClaims], [WithTenantID].
 //
@@ -991,7 +993,6 @@ func (cca Client) AcquireTokenByUserFederatedIdentityCredential(ctx context.Cont
 		return AuthResult{}, err
 	}
 
-	// Validate inputs
 	if assertion == "" {
 		return AuthResult{}, errors.New("assertion must not be empty")
 	}

--- a/apps/confidential/user_fic_test.go
+++ b/apps/confidential/user_fic_test.go
@@ -1,0 +1,582 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package confidential
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/mock"
+)
+
+// fakeClientInfo returns a base64url-encoded client_info JSON with the given uid and utid.
+func fakeClientInfo(uid, utid string) string {
+	raw := fmt.Sprintf(`{"uid":"%s","utid":"%s"}`, uid, utid)
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+// --- FMI Tests: Assertion Context ---
+
+func TestFMIPath_AssertionCallbackReceivesFMIPath(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	authority := fmt.Sprintf(authorityFmt, lmo, tenant)
+	fmiPath := "agent-app-id-123"
+	accessToken := "fmi-token"
+
+	var receivedFMIPath string
+	cred := NewCredFromAssertionCallback(func(ctx context.Context, opts AssertionRequestOptions) (string, error) {
+		receivedFMIPath = opts.FMIPath
+		return "fake-assertion", nil
+	})
+
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody(accessToken, mock.GetIDToken(tenant, authority), "", "", 3600, 0)))
+
+	client, err := New(authority, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByCredential(context.Background(), tokenScope, WithFMIPath(fmiPath))
+	if err != nil {
+		t.Fatalf("AcquireTokenByCredential failed: %v", err)
+	}
+
+	if receivedFMIPath != fmiPath {
+		t.Fatalf("assertion callback received FMIPath %q, want %q", receivedFMIPath, fmiPath)
+	}
+}
+
+func TestFMIPath_AssertionCallbackReceivesEmptyFMIPathWhenNotSet(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	authority := fmt.Sprintf(authorityFmt, lmo, tenant)
+	accessToken := "regular-token"
+
+	var receivedFMIPath string
+	cred := NewCredFromAssertionCallback(func(ctx context.Context, opts AssertionRequestOptions) (string, error) {
+		receivedFMIPath = opts.FMIPath
+		return "fake-assertion", nil
+	})
+
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody(accessToken, mock.GetIDToken(tenant, authority), "", "", 3600, 0)))
+
+	client, err := New(authority, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByCredential(context.Background(), tokenScope)
+	if err != nil {
+		t.Fatalf("AcquireTokenByCredential failed: %v", err)
+	}
+
+	if receivedFMIPath != "" {
+		t.Fatalf("assertion callback received FMIPath %q without WithFMIPath, want empty", receivedFMIPath)
+	}
+}
+
+// --- FMI Tests: Extended cache key ---
+
+func TestFMIPath_DifferentFMIPathsProduceDifferentCacheEntries(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	authority := fmt.Sprintf(authorityFmt, lmo, tenant)
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := mock.NewClient()
+	client, err := New(authority, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// First FMI path
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody("token-agent-A", mock.GetIDToken(tenant, authority), "", "", 3600, 0)))
+	ar1, err := client.AcquireTokenByCredential(ctx, tokenScope, WithFMIPath("agentA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second FMI path — should NOT be served from cache
+	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody("token-agent-B", mock.GetIDToken(tenant, authority), "", "", 3600, 0)))
+	ar2, err := client.AcquireTokenByCredential(ctx, tokenScope, WithFMIPath("agentB"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ar1.AccessToken == ar2.AccessToken {
+		t.Fatal("different fmi_path values should produce different cache entries")
+	}
+
+	// Same FMI path again — should be served from cache
+	ar3, err := client.AcquireTokenByCredential(ctx, tokenScope, WithFMIPath("agentA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ar3.AccessToken != "token-agent-A" {
+		t.Fatalf("expected cached token for agentA, got %q", ar3.AccessToken)
+	}
+	if ar3.Metadata.TokenSource != TokenSourceCache {
+		t.Fatal("expected token from cache on repeated fmi_path request")
+	}
+}
+
+func TestFMIPath_FMITokenDoesNotCollideWithRegularToken(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	authority := fmt.Sprintf(authorityFmt, lmo, tenant)
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := mock.NewClient()
+	client, err := New(authority, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// Regular token (no FMI)
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody("regular-token", mock.GetIDToken(tenant, authority), "", "", 3600, 0)))
+	ar1, err := client.AcquireTokenByCredential(ctx, tokenScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// FMI token (same scopes, same client) — must NOT collide with regular
+	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody("fmi-token", mock.GetIDToken(tenant, authority), "", "", 3600, 0)))
+	ar2, err := client.AcquireTokenByCredential(ctx, tokenScope, WithFMIPath("someAgent"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ar1.AccessToken == ar2.AccessToken {
+		t.Fatal("FMI token should not collide with regular token at same scope")
+	}
+
+	// Regular should still be from cache
+	ar3, err := client.AcquireTokenByCredential(ctx, tokenScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ar3.AccessToken != "regular-token" {
+		t.Fatal("regular token was overwritten by FMI token")
+	}
+}
+
+// --- FIC Tests: Protocol Correctness ---
+
+func TestUserFIC_SendsCorrectGrantType(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	auth := fmt.Sprintf(authorityFmt, lmo, tenant)
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var requestBody string
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(
+		mock.WithBody(mock.GetAccessTokenBody("user-token", mock.GetIDToken(tenant, auth), "rt", fakeClientInfo("user-oid", tenant), 3600, 0)),
+		mock.WithCallback(func(r *http.Request) {
+			body, _ := readAndRestoreBody(r)
+			requestBody = string(body)
+		}),
+	)
+
+	client, err := New(auth, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByUserFederatedIdentityCredential(
+		context.Background(),
+		[]string{"https://graph.microsoft.com/.default"},
+		"federated-credential-t2",
+		WithUserObjectID("user-oid-value"),
+	)
+	if err != nil {
+		t.Fatalf("AcquireTokenByUserFederatedIdentityCredential failed: %v", err)
+	}
+
+	assertBodyContains(t, requestBody, "grant_type", "user_fic")
+	assertBodyContains(t, requestBody, "user_federated_identity_credential", "federated-credential-t2")
+	assertBodyContains(t, requestBody, "user_id", "user-oid-value")
+	assertBodyContains(t, requestBody, "client_info", "1")
+}
+
+func TestUserFIC_ScopeIncludesOidcScopes(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	auth := fmt.Sprintf(authorityFmt, lmo, tenant)
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var requestBody string
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(
+		mock.WithBody(mock.GetAccessTokenBody("user-token", mock.GetIDToken(tenant, auth), "rt", fakeClientInfo("uid1", tenant), 3600, 0)),
+		mock.WithCallback(func(r *http.Request) {
+			body, _ := readAndRestoreBody(r)
+			requestBody = string(body)
+		}),
+	)
+
+	client, err := New(auth, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByUserFederatedIdentityCredential(
+		context.Background(),
+		[]string{"https://graph.microsoft.com/.default"},
+		"t2-assertion",
+		WithUserFICUsername("user@contoso.com"),
+	)
+	if err != nil {
+		t.Fatalf("AcquireTokenByUserFederatedIdentityCredential failed: %v", err)
+	}
+
+	// Scope should include openid, offline_access, profile
+	assertBodyContains(t, requestBody, "scope", "openid")
+	assertBodyContains(t, requestBody, "scope", "offline_access")
+	assertBodyContains(t, requestBody, "scope", "profile")
+	assertBodyContains(t, requestBody, "scope", "https://graph.microsoft.com/.default")
+}
+
+// --- FIC Tests: User Identification ---
+
+func TestUserFIC_WithUsername_SendsUsernameNotUserID(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	auth := fmt.Sprintf(authorityFmt, lmo, tenant)
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var requestBody string
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(
+		mock.WithBody(mock.GetAccessTokenBody("user-token", mock.GetIDToken(tenant, auth), "rt", fakeClientInfo("uid1", tenant), 3600, 0)),
+		mock.WithCallback(func(r *http.Request) {
+			body, _ := readAndRestoreBody(r)
+			requestBody = string(body)
+		}),
+	)
+
+	client, err := New(auth, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByUserFederatedIdentityCredential(
+		context.Background(),
+		tokenScope,
+		"assertion-value",
+		WithUserFICUsername("user@contoso.com"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertBodyContains(t, requestBody, "username", "user@contoso.com")
+	assertBodyNotContains(t, requestBody, "user_id")
+}
+
+func TestUserFIC_WithObjectID_SendsUserIDNotUsername(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	auth := fmt.Sprintf(authorityFmt, lmo, tenant)
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var requestBody string
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(
+		mock.WithBody(mock.GetAccessTokenBody("user-token", mock.GetIDToken(tenant, auth), "rt", fakeClientInfo("uid1", tenant), 3600, 0)),
+		mock.WithCallback(func(r *http.Request) {
+			body, _ := readAndRestoreBody(r)
+			requestBody = string(body)
+		}),
+	)
+
+	client, err := New(auth, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByUserFederatedIdentityCredential(
+		context.Background(),
+		tokenScope,
+		"assertion-value",
+		WithUserObjectID("00000000-0000-0000-0000-000000000001"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertBodyContains(t, requestBody, "user_id", "00000000-0000-0000-0000-000000000001")
+	assertBodyNotContains(t, requestBody, "username")
+}
+
+// --- FIC Tests: Cache Behavior ---
+
+func TestUserFIC_TokenStoredInUserCache(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	auth := fmt.Sprintf(authorityFmt, lmo, tenant)
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody("user-token-1", mock.GetIDToken(tenant, auth), "rt", fakeClientInfo("user-oid-1", tenant), 3600, 0)))
+
+	client, err := New(auth, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ar, err := client.AcquireTokenByUserFederatedIdentityCredential(
+		context.Background(),
+		tokenScope,
+		"assertion-t2",
+		WithUserObjectID("user-oid-1"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ar.AccessToken != "user-token-1" {
+		t.Fatalf("expected user-token-1, got %q", ar.AccessToken)
+	}
+	// Account should be populated (user cache)
+	if ar.Account.HomeAccountID == "" {
+		t.Fatal("expected account to be populated (user cache storage)")
+	}
+}
+
+func TestUserFIC_CacheHit_UseAcquireTokenSilentForCaching(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	auth := fmt.Sprintf(authorityFmt, lmo, tenant)
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(mock.WithBody(mock.GetAccessTokenBody("user-token", mock.GetIDToken(tenant, auth), "rt", fakeClientInfo("user-oid", tenant), 3600, 0)))
+
+	client, err := New(auth, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// First call — hits the network, stores in user cache
+	ar1, err := client.AcquireTokenByUserFederatedIdentityCredential(ctx, tokenScope, "t2", WithUserObjectID("user-oid"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ar1.Account.HomeAccountID == "" {
+		t.Fatal("expected account with HomeAccountID after first call")
+	}
+
+	// Developer uses AcquireTokenSilent for subsequent calls
+	ar2, err := client.AcquireTokenSilent(ctx, tokenScope, WithSilentAccount(ar1.Account))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ar2.AccessToken != ar1.AccessToken {
+		t.Fatalf("expected cached token %q, got %q", ar1.AccessToken, ar2.AccessToken)
+	}
+}
+
+func TestUserFIC_MultipleCallsHitNetwork(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	auth := fmt.Sprintf(authorityFmt, lmo, tenant)
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpCalls := 0
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(
+		mock.WithBody(mock.GetAccessTokenBody("user-token-1", mock.GetIDToken(tenant, auth), "rt", fakeClientInfo("uid", tenant), 3600, 0)),
+		mock.WithCallback(func(r *http.Request) { httpCalls++ }),
+	)
+
+	client, err := New(auth, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// First call
+	_, err = client.AcquireTokenByUserFederatedIdentityCredential(ctx, tokenScope, "t2", WithUserObjectID("uid"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if httpCalls != 1 {
+		t.Fatalf("expected 1 HTTP call, got %d", httpCalls)
+	}
+
+	// Second call — always hits network (developer should use AcquireTokenSilent for caching)
+	mockClient.AppendResponse(
+		mock.WithBody(mock.GetAccessTokenBody("user-token-2", mock.GetIDToken(tenant, auth), "rt", fakeClientInfo("uid", tenant), 3600, 0)),
+		mock.WithCallback(func(r *http.Request) { httpCalls++ }),
+	)
+
+	ar2, err := client.AcquireTokenByUserFederatedIdentityCredential(ctx, tokenScope, "t2", WithUserObjectID("uid"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if httpCalls != 2 {
+		t.Fatalf("expected 2 HTTP calls total, got %d", httpCalls)
+	}
+	if ar2.AccessToken != "user-token-2" {
+		t.Fatalf("expected new token from second call, got %q", ar2.AccessToken)
+	}
+}
+
+// --- FIC Tests: Input Validation ---
+
+func TestUserFIC_EmptyAssertion_ReturnsError(t *testing.T) {
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := mock.NewClient()
+	client, err := New(fakeAuthority, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByUserFederatedIdentityCredential(
+		context.Background(), tokenScope, "", WithUserObjectID("oid"),
+	)
+	if err == nil {
+		t.Fatal("expected error for empty assertion")
+	}
+}
+
+func TestUserFIC_NoUserIdentifier_ReturnsError(t *testing.T) {
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := mock.NewClient()
+	client, err := New(fakeAuthority, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByUserFederatedIdentityCredential(
+		context.Background(), tokenScope, "assertion",
+	)
+	if err == nil {
+		t.Fatal("expected error when neither WithUserObjectID nor WithUserFICUsername is specified")
+	}
+}
+
+func TestUserFIC_BothUserIdentifiers_ReturnsError(t *testing.T) {
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := mock.NewClient()
+	client, err := New(fakeAuthority, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByUserFederatedIdentityCredential(
+		context.Background(), tokenScope, "assertion",
+		WithUserObjectID("oid"), WithUserFICUsername("user@contoso.com"),
+	)
+	if err == nil {
+		t.Fatal("expected error when both WithUserObjectID and WithUserFICUsername are specified")
+	}
+}
+
+// --- Helper functions ---
+
+func readAndRestoreBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return body, nil
+}
+
+func assertBodyContains(t *testing.T, body, key, expectedValue string) {
+	t.Helper()
+	parsed, err := url.ParseQuery(body)
+	if err != nil {
+		t.Fatalf("failed to parse request body: %v", err)
+	}
+	values := parsed[key]
+	if len(values) == 0 {
+		t.Fatalf("expected %q in request body, but not found. Body: %s", key, body)
+	}
+	for _, v := range values {
+		if strings.Contains(v, expectedValue) {
+			return
+		}
+	}
+	t.Fatalf("expected %q to contain %q, got %v", key, expectedValue, values)
+}
+
+func assertBodyNotContains(t *testing.T, body, key string) {
+	t.Helper()
+	parsed, err := url.ParseQuery(body)
+	if err != nil {
+		t.Fatalf("failed to parse request body: %v", err)
+	}
+	if v := parsed.Get(key); v != "" {
+		t.Fatalf("expected %q NOT to be in request body, but found value %q", key, v)
+	}
+}

--- a/apps/confidential/user_fic_test.go
+++ b/apps/confidential/user_fic_test.go
@@ -538,6 +538,45 @@ func TestUserFIC_BothUserIdentifiers_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestUserFIC_AssertionCredential_SendsClientAssertionParams(t *testing.T) {
+	lmo := "login.microsoftonline.com"
+	tenant := "test-tenant"
+	auth := fmt.Sprintf(authorityFmt, lmo, tenant)
+
+	cred := NewCredFromAssertionCallback(
+		func(ctx context.Context, opts AssertionRequestOptions) (string, error) {
+			return "fake-client-assertion-jwt", nil
+		},
+	)
+
+	var requestBody string
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(mock.WithBody(mock.GetTenantDiscoveryBody(lmo, tenant)))
+	mockClient.AppendResponse(
+		mock.WithBody(mock.GetAccessTokenBody("user-token", mock.GetIDToken(tenant, auth), "rt", fakeClientInfo("uid", tenant), 3600, 0)),
+		mock.WithCallback(func(r *http.Request) {
+			body, _ := readAndRestoreBody(r)
+			requestBody = string(body)
+		}),
+	)
+
+	client, err := New(auth, fakeClientID, cred, WithHTTPClient(mockClient), WithInstanceDiscovery(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AcquireTokenByUserFederatedIdentityCredential(
+		context.Background(), tokenScope, "t2-assertion", WithUserObjectID("uid"),
+	)
+	if err != nil {
+		t.Fatalf("AcquireTokenByUserFederatedIdentityCredential failed: %v", err)
+	}
+
+	assertBodyContains(t, requestBody, "client_assertion", "fake-client-assertion-jwt")
+	assertBodyContains(t, requestBody, "client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	assertBodyContains(t, requestBody, "grant_type", "user_fic")
+}
+
 // --- Helper functions ---
 
 func readAndRestoreBody(r *http.Request) ([]byte, error) {
@@ -562,14 +601,16 @@ func assertBodyContains(t *testing.T, body, key, expectedValue string) {
 	if len(values) == 0 {
 		t.Fatalf("expected %q in request body, but not found. Body: %s", key, body)
 	}
-	// For scope (space-delimited multi-value), check membership; for all others, check exact match
+	// For scope (space-delimited multi-value), check exact token membership; for all others, check exact match
 	if key == "scope" {
 		for _, v := range values {
-			if strings.Contains(v, expectedValue) {
-				return
+			for _, scope := range strings.Fields(v) {
+				if scope == expectedValue {
+					return
+				}
 			}
 		}
-		t.Fatalf("expected scope to contain %q, got %v", expectedValue, values)
+		t.Fatalf("expected scope to contain token %q, got %v", expectedValue, values)
 	} else {
 		if values[0] != expectedValue {
 			t.Fatalf("expected %q = %q, got %q", key, expectedValue, values[0])

--- a/apps/confidential/user_fic_test.go
+++ b/apps/confidential/user_fic_test.go
@@ -562,12 +562,19 @@ func assertBodyContains(t *testing.T, body, key, expectedValue string) {
 	if len(values) == 0 {
 		t.Fatalf("expected %q in request body, but not found. Body: %s", key, body)
 	}
-	for _, v := range values {
-		if strings.Contains(v, expectedValue) {
-			return
+	// For scope (space-delimited multi-value), check membership; for all others, check exact match
+	if key == "scope" {
+		for _, v := range values {
+			if strings.Contains(v, expectedValue) {
+				return
+			}
+		}
+		t.Fatalf("expected scope to contain %q, got %v", expectedValue, values)
+	} else {
+		if values[0] != expectedValue {
+			t.Fatalf("expected %q = %q, got %q", key, expectedValue, values[0])
 		}
 	}
-	t.Fatalf("expected %q to contain %q, got %v", key, expectedValue, values)
 }
 
 func assertBodyNotContains(t *testing.T, body, key string) {
@@ -576,7 +583,7 @@ func assertBodyNotContains(t *testing.T, body, key string) {
 	if err != nil {
 		t.Fatalf("failed to parse request body: %v", err)
 	}
-	if v := parsed.Get(key); v != "" {
-		t.Fatalf("expected %q NOT to be in request body, but found value %q", key, v)
+	if _, present := parsed[key]; present {
+		t.Fatalf("expected %q NOT to be in request body, but found value %q", key, parsed.Get(key))
 	}
 }

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -83,6 +83,17 @@ type AcquireTokenOnBehalfOfParameters struct {
 	UserAssertion string
 }
 
+// AcquireTokenByUserFICParameters contains the parameters to acquire a user token via the user_fic flow.
+type AcquireTokenByUserFICParameters struct {
+	Scopes                          []string
+	Claims                          string
+	Credential                      *accesstokens.Credential
+	TenantID                        string
+	UserFederatedIdentityCredential string
+	Username                        string
+	UserObjectID                    string
+}
+
 // AuthResult contains the results of one token acquisition operation in PublicClientApplication
 // or ConfidentialClientApplication. For details see https://aka.ms/msal-net-authenticationresult
 type AuthResult struct {
@@ -469,6 +480,26 @@ func (b Client) AcquireTokenOnBehalfOf(ctx context.Context, onBehalfOfParams Acq
 		ar, err = b.AuthResultFromToken(ctx, authParams, token)
 	}
 	return ar, err
+}
+
+// AcquireTokenByUserFIC acquires a user-scoped token using the user_fic grant type.
+func (b Client) AcquireTokenByUserFIC(ctx context.Context, params AcquireTokenByUserFICParameters) (AuthResult, error) {
+	authParams, err := b.AuthParams.WithTenant(params.TenantID)
+	if err != nil {
+		return AuthResult{}, err
+	}
+	authParams.AuthorizationType = authority.ATUserFIC
+	authParams.Claims = params.Claims
+	authParams.Scopes = params.Scopes
+	authParams.UserFederatedIdentityCredential = params.UserFederatedIdentityCredential
+	authParams.Username = params.Username
+	authParams.UserObjectID = params.UserObjectID
+
+	token, err := b.Token.UserFederatedIdentityCredential(ctx, authParams, params.Credential)
+	if err != nil {
+		return AuthResult{}, err
+	}
+	return b.AuthResultFromToken(ctx, authParams, token)
 }
 
 func (b Client) AuthResultFromToken(ctx context.Context, authParams authority.AuthParams, token accesstokens.TokenResponse) (AuthResult, error) {

--- a/apps/internal/exported/exported.go
+++ b/apps/internal/exported/exported.go
@@ -11,6 +11,10 @@ type AssertionRequestOptions struct {
 
 	// TokenEndpoint is the intended token endpoint. Used as the assertion's "aud" claim.
 	TokenEndpoint string
+
+	// FMIPath is the federated managed identity path for the current request, if any.
+	// This allows assertion providers to include the FMI path in signed assertions when needed.
+	FMIPath string
 }
 
 // TokenProviderParameters is the authentication parameters passed to token providers

--- a/apps/internal/exported/exported.go
+++ b/apps/internal/exported/exported.go
@@ -13,7 +13,7 @@ type AssertionRequestOptions struct {
 	TokenEndpoint string
 
 	// FMIPath is the federated managed identity path for the current request, if any.
-	// This allows assertion providers to include the FMI path in signed assertions when needed.
+	// Assertion providers can use this to scope the credential they return.
 	FMIPath string
 }
 

--- a/apps/internal/oauth/fake/fake.go
+++ b/apps/internal/oauth/fake/fake.go
@@ -124,6 +124,12 @@ func (f *AccessTokens) FromSamlGrant(ctx context.Context, authParameters authori
 	}
 	return f.AccessToken, nil
 }
+func (f *AccessTokens) FromUserFederatedIdentityCredential(ctx context.Context, authParameters authority.AuthParams, cred *accesstokens.Credential) (accesstokens.TokenResponse, error) {
+	if f.Err {
+		return accesstokens.TokenResponse{}, fmt.Errorf("error")
+	}
+	return f.AccessToken, nil
+}
 
 // Authority is a fake implementation of the oauth.fetchAuthority interface.
 type Authority struct {

--- a/apps/internal/oauth/oauth.go
+++ b/apps/internal/oauth/oauth.go
@@ -39,6 +39,7 @@ type AccessTokens interface {
 	FromUserAssertionClientCertificate(ctx context.Context, authParameters authority.AuthParams, userAssertion string, assertion string) (accesstokens.TokenResponse, error)
 	FromDeviceCodeResult(ctx context.Context, authParameters authority.AuthParams, deviceCodeResult accesstokens.DeviceCodeResult) (accesstokens.TokenResponse, error)
 	FromSamlGrant(ctx context.Context, authParameters authority.AuthParams, samlGrant wstrust.SamlTokenInfo) (accesstokens.TokenResponse, error)
+	FromUserFederatedIdentityCredential(ctx context.Context, authParameters authority.AuthParams, cred *accesstokens.Credential) (accesstokens.TokenResponse, error)
 }
 
 // FetchAuthority will be implemented by authority.Authority.
@@ -168,6 +169,17 @@ func (t *Client) OnBehalfOf(ctx context.Context, authParams authority.AuthParams
 		return accesstokens.TokenResponse{}, err
 	}
 	return tr, nil
+}
+
+// UserFederatedIdentityCredential acquires a user-scoped token using the user_fic grant type.
+func (t *Client) UserFederatedIdentityCredential(ctx context.Context, authParams authority.AuthParams, cred *accesstokens.Credential) (accesstokens.TokenResponse, error) {
+	if err := scopeError(authParams); err != nil {
+		return accesstokens.TokenResponse{}, err
+	}
+	if err := t.resolveEndpoint(ctx, &authParams, ""); err != nil {
+		return accesstokens.TokenResponse{}, err
+	}
+	return t.AccessTokens.FromUserFederatedIdentityCredential(ctx, authParams, cred)
 }
 
 func (t *Client) Refresh(ctx context.Context, reqType accesstokens.AppType, authParams authority.AuthParams, cc *accesstokens.Credential, refreshToken accesstokens.RefreshToken) (accesstokens.TokenResponse, error) {

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -353,17 +353,15 @@ func (c Client) FromUserFederatedIdentityCredential(ctx context.Context, authPar
 	qv.Set("user_federated_identity_credential", authParameters.UserFederatedIdentityCredential)
 	qv.Set(clientInfo, clientInfoVal)
 
-	// Set user identifier: either user_id (OID) or username (UPN), mutually exclusive
+	// Set user identifier: either user_id (OID) or username (UPN)
 	if authParameters.UserObjectID != "" {
 		qv.Set("user_id", authParameters.UserObjectID)
 	} else if authParameters.Username != "" {
 		qv.Set("username", authParameters.Username)
 	}
 
-	// Scope augmentation: add openid, offline_access, profile (same as auth code flow)
 	addScopeQueryParam(qv, authParameters)
 
-	// Add client credential (assertion or secret)
 	credParams, err := prepURLVals(ctx, cred, authParameters)
 	if err != nil {
 		return TokenResponse{}, err

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -110,6 +110,7 @@ func (c *Credential) JWT(ctx context.Context, authParams authority.AuthParams) (
 		options := exported.AssertionRequestOptions{
 			ClientID:      authParams.ClientID,
 			TokenEndpoint: authParams.Endpoints.TokenEndpoint,
+			FMIPath:       authParams.ExtraBodyParameters["fmi_path"],
 		}
 		return c.AssertionCallback(ctx, options)
 	}
@@ -337,6 +338,42 @@ func (c Client) FromUserAssertionClientCertificate(ctx context.Context, authPara
 
 	// Add extra body parameters if provided
 	addExtraBodyParameters(ctx, qv, authParameters)
+	return c.doTokenResp(ctx, authParameters, qv)
+}
+
+// FromUserFederatedIdentityCredential acquires a user-scoped token using the user_fic grant type.
+// This exchanges a federated identity credential for a user token.
+func (c Client) FromUserFederatedIdentityCredential(ctx context.Context, authParameters authority.AuthParams, cred *Credential) (TokenResponse, error) {
+	qv := url.Values{}
+	if err := addClaims(qv, authParameters); err != nil {
+		return TokenResponse{}, err
+	}
+	qv.Set(grantType, grant.UserFIC)
+	qv.Set(clientID, authParameters.ClientID)
+	qv.Set("user_federated_identity_credential", authParameters.UserFederatedIdentityCredential)
+	qv.Set(clientInfo, clientInfoVal)
+
+	// Set user identifier: either user_id (OID) or username (UPN), mutually exclusive
+	if authParameters.UserObjectID != "" {
+		qv.Set("user_id", authParameters.UserObjectID)
+	} else if authParameters.Username != "" {
+		qv.Set("username", authParameters.Username)
+	}
+
+	// Scope augmentation: add openid, offline_access, profile (same as auth code flow)
+	addScopeQueryParam(qv, authParameters)
+
+	// Add client credential (assertion or secret)
+	credParams, err := prepURLVals(ctx, cred, authParameters)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	for k, vs := range credParams {
+		for _, v := range vs {
+			qv.Set(k, v)
+		}
+	}
+
 	return c.doTokenResp(ctx, authParameters, qv)
 }
 

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -344,6 +344,9 @@ func (c Client) FromUserAssertionClientCertificate(ctx context.Context, authPara
 // FromUserFederatedIdentityCredential acquires a user-scoped token using the user_fic grant type.
 // This exchanges a federated identity credential for a user token.
 func (c Client) FromUserFederatedIdentityCredential(ctx context.Context, authParameters authority.AuthParams, cred *Credential) (TokenResponse, error) {
+	if cred.Secret == "" && cred.Cert == nil && cred.AssertionCallback == nil {
+		return TokenResponse{}, fmt.Errorf("user_fic requires a client secret or assertion credential; token provider credentials are not supported")
+	}
 	qv := url.Values{}
 	if err := addClaims(qv, authParameters); err != nil {
 		return TokenResponse{}, err

--- a/apps/internal/oauth/ops/accesstokens/accesstokens.go
+++ b/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -364,6 +364,7 @@ func (c Client) FromUserFederatedIdentityCredential(ctx context.Context, authPar
 	}
 
 	addScopeQueryParam(qv, authParameters)
+	addExtraBodyParameters(ctx, qv, authParameters)
 
 	credParams, err := prepURLVals(ctx, cred, authParameters)
 	if err != nil {

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -188,6 +188,7 @@ const (
 	ATRefreshToken
 	AccountByID
 	ATOnBehalfOf
+	ATUserFIC
 )
 
 // These are all authority types
@@ -283,6 +284,10 @@ type AuthParams struct {
 	ExtraBodyParameters map[string]string
 	// CacheKeyComponents are additional components to include in the cache key.
 	CacheKeyComponents map[string]string
+	// UserFederatedIdentityCredential is the federated credential token (T2) for user_fic flow.
+	UserFederatedIdentityCredential string
+	// UserObjectID is the target user's object ID for user_fic flow (mutually exclusive with Username).
+	UserObjectID string
 }
 
 // NewAuthParams creates an authorization parameters object.
@@ -663,7 +668,7 @@ func (a *AuthParams) CacheKey(isAppCache bool) string {
 	if a.AuthorizationType == ATClientCredentials || isAppCache {
 		return a.AppKey()
 	}
-	if a.AuthorizationType == ATRefreshToken || a.AuthorizationType == AccountByID {
+	if a.AuthorizationType == ATRefreshToken || a.AuthorizationType == AccountByID || a.AuthorizationType == ATUserFIC {
 		return a.HomeAccountID
 	}
 	return ""

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -284,7 +284,7 @@ type AuthParams struct {
 	ExtraBodyParameters map[string]string
 	// CacheKeyComponents are additional components to include in the cache key.
 	CacheKeyComponents map[string]string
-	// UserFederatedIdentityCredential is the federated credential token (T2) for user_fic flow.
+	// UserFederatedIdentityCredential is the federated credential token for user_fic flow.
 	UserFederatedIdentityCredential string
 	// UserObjectID is the target user's object ID for user_fic flow (mutually exclusive with Username).
 	UserObjectID string

--- a/apps/internal/oauth/ops/authority/authorizetype_string.go
+++ b/apps/internal/oauth/ops/authority/authorizetype_string.go
@@ -16,15 +16,19 @@ func _() {
 	_ = x[ATClientCredentials-5]
 	_ = x[ATDeviceCode-6]
 	_ = x[ATRefreshToken-7]
+	_ = x[AccountByID-8]
+	_ = x[ATOnBehalfOf-9]
+	_ = x[ATUserFIC-10]
 }
 
-const _AuthorizeType_name = "ATUnknownATUsernamePasswordATWindowsIntegratedATAuthCodeATInteractiveATClientCredentialsATDeviceCodeATRefreshToken"
+const _AuthorizeType_name = "ATUnknownATUsernamePasswordATWindowsIntegratedATAuthCodeATInteractiveATClientCredentialsATDeviceCodeATRefreshTokenAccountByIDATOnBehalfOfATUserFIC"
 
-var _AuthorizeType_index = [...]uint8{0, 9, 27, 46, 56, 69, 88, 100, 114}
+var _AuthorizeType_index = [...]uint8{0, 9, 27, 46, 56, 69, 88, 100, 114, 125, 137, 146}
 
 func (i AuthorizeType) String() string {
-	if i < 0 || i >= AuthorizeType(len(_AuthorizeType_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_AuthorizeType_index)-1 {
 		return "AuthorizeType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _AuthorizeType_name[_AuthorizeType_index[i]:_AuthorizeType_index[i+1]]
+	return _AuthorizeType_name[_AuthorizeType_index[idx]:_AuthorizeType_index[idx+1]]
 }

--- a/apps/internal/oauth/ops/internal/grant/grant.go
+++ b/apps/internal/oauth/ops/internal/grant/grant.go
@@ -14,4 +14,5 @@ const (
 	RefreshToken     = "refresh_token"
 	ClientCredential = "client_credentials"
 	ClientAssertion  = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+	UserFIC          = "user_fic"
 )


### PR DESCRIPTION
This PR adds the `user_fic` (User Federated Identity Credential) grant type and related APIs to MSAL Go's confidential client, matching what was done in MSAL .NET and Java.

In addition, this PR also adds a new piece for FMI required by an (eventual) support for agent identity scenarios: passing `FMIPath` to assertion callbacks via `AssertionRequestOptions`, so assertion callbacks can acquire the correct credential.

---

#### What's included

**FMI completion — assertion callback context:**

- `AssertionRequestOptions.FMIPath` — new exported field populated when `WithFMIPath` is set on the request
- `accesstokens.JWT()` callback now passes `FMIPath` from `AuthParams` into the `AssertionRequestOptions` struct

**FIC — new public APIs:**

- `confidential.AcquireTokenByUserFederatedIdentityCredential(ctx, scopes, assertion, opts...)` — acquires a user-scoped token using the `user_fic` grant type
- `confidential.WithUserObjectID(oid)` — identifies the target user by Object ID
- `confidential.WithUserFICUsername(username)` — identifies the target user by UPN
- `confidential.AcquireByUserFICOption` — marker interface for FIC-specific options
- Existing `WithClaims` and `WithTenantID` options extended to support FIC calls

**FIC — token request behavior:**

- Sends `grant_type=user_fic` in the POST body
- Sends `user_federated_identity_credential=<assertion>` (the instance token from Leg 2)
- Sends either `user_id=<OID>` or `username=<UPN>` (mutually exclusive, validated at call time)
- Augments scopes with `openid`, `profile`, `offline_access` (user-flow behavior)
- Sends `client_info=1` to receive account information in the response
- Includes client credential (secret or assertion) for confidential client authentication

**FIC — cache behavior:**

- FIC always hits the network (no built-in silent lookup)
- Tokens are stored in the standard user token cache with full account information
- Developers use `AcquireTokenSilent` with the returned `Account` for subsequent cached access
- This matches MSAL .NET's pattern and keeps the implementation simple

**Internal changes:**

- `grant.UserFIC = "user_fic"` — new grant type constant
- `authority.ATUserFIC` — new `AuthorizeType` enum value
- `authority.AuthParams.UserFederatedIdentityCredential` / `UserObjectID` — new fields
- `authority.AuthParams.CacheKey()` — returns `HomeAccountID` for `ATUserFIC` type
- `accesstokens.FromUserFederatedIdentityCredential()` — builds the OAuth2 POST body
- `oauth.Client.UserFederatedIdentityCredential()` — wire-through with endpoint resolution
- `base.Client.AcquireTokenByUserFIC()` — base client method (always network, stores in user cache)
- `oauth/fake` — updated to implement new `AccessTokens` interface method

**Tests (14 total in `user_fic_test.go`):**

FMI assertion context tests (4):
- `TestFMIPath_AssertionCallbackReceivesFMIPath` — callback receives FMI path when set
- `TestFMIPath_AssertionCallbackReceivesEmptyFMIPathWhenNotSet` — callback gets empty string without FMI
- `TestFMIPath_DifferentFMIPathsProduceDifferentCacheEntries` — cache isolation between FMI paths
- `TestFMIPath_FMITokenDoesNotCollideWithRegularToken` — FMI vs non-FMI cache isolation

FIC protocol tests (4):
- `TestUserFIC_SendsCorrectGrantType` — verifies `grant_type=user_fic`, credential param, user_id, client_info
- `TestUserFIC_ScopeIncludesOidcScopes` — verifies openid/offline_access/profile augmentation
- `TestUserFIC_WithUsername_SendsUsernameNotUserID` — username param sent, user_id absent
- `TestUserFIC_WithObjectID_SendsUserIDNotUsername` — user_id param sent, username absent

FIC cache behavior tests (3):
- `TestUserFIC_TokenStoredInUserCache` — token stored with populated Account (HomeAccountID)
- `TestUserFIC_CacheHit_UseAcquireTokenSilentForCaching` — AcquireTokenSilent returns cached FIC token
- `TestUserFIC_MultipleCallsHitNetwork` — repeated FIC calls always hit network (no built-in cache)

FIC validation tests (3):
- `TestUserFIC_EmptyAssertion_ReturnsError` — empty assertion rejected
- `TestUserFIC_NoUserIdentifier_ReturnsError` — missing user identification rejected
- `TestUserFIC_BothUserIdentifiers_ReturnsError` — both OID and UPN rejected (mutually exclusive)