### PR TITLE
fix: use singleflight to prevent concurrent map race in ResolveEndpoints

### DIFF
--- a/apps/internal/oauth/resolvers.go
+++ b/apps/internal/oauth/resolvers.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
+	"golang.org/x/sync/singleflight"
 )
 
 type cacheEntry struct {
@@ -35,6 +36,8 @@ type authorityEndpoint struct {
 
 	mu    sync.Mutex
 	cache map[string]cacheEntry
+
+	resolveGroup singleflight.Group
 }
 
 // newAuthorityEndpoint is the constructor for AuthorityEndpoint.
@@ -50,35 +53,49 @@ func (m *authorityEndpoint) ResolveEndpoints(ctx context.Context, authorityInfo 
 		return endpoints, nil
 	}
 
-	endpoint, err := m.openIDConfigurationEndpoint(ctx, authorityInfo)
+	key := authorityInfo.CanonicalAuthorityURI
+	v, err, _ := m.resolveGroup.Do(key, func() (interface{}, error) {
+		// Double-check inside the singleflight group: another goroutine may
+		// have populated the cache while we were waiting.
+		if endpoints, found := m.cachedEndpoints(authorityInfo, userPrincipalName); found {
+			return endpoints, nil
+		}
+
+		endpoint, err := m.openIDConfigurationEndpoint(ctx, authorityInfo)
+		if err != nil {
+			return authority.Endpoints{}, err
+		}
+
+		resp, err := m.rest.Authority().GetTenantDiscoveryResponse(ctx, endpoint)
+		if err != nil {
+			return authority.Endpoints{}, err
+		}
+		if err := resp.Validate(); err != nil {
+			return authority.Endpoints{}, fmt.Errorf("ResolveEndpoints(): %w", err)
+		}
+
+		tenant := authorityInfo.Tenant
+
+		endpoints := authority.NewEndpoints(
+			strings.Replace(resp.AuthorizationEndpoint, "{tenant}", tenant, -1),
+			strings.Replace(resp.TokenEndpoint, "{tenant}", tenant, -1),
+			strings.Replace(resp.Issuer, "{tenant}", tenant, -1),
+			authorityInfo.Host)
+
+		aliases := m.addCachedEndpoints(authorityInfo, userPrincipalName, endpoints)
+
+		if err := resp.ValidateIssuerMatchesAuthority(authorityInfo.CanonicalAuthorityURI,
+			aliases); err != nil {
+			return authority.Endpoints{}, fmt.Errorf("ResolveEndpoints(): %w", err)
+		}
+
+		return endpoints, nil
+	})
 	if err != nil {
 		return authority.Endpoints{}, err
 	}
 
-	resp, err := m.rest.Authority().GetTenantDiscoveryResponse(ctx, endpoint)
-	if err != nil {
-		return authority.Endpoints{}, err
-	}
-	if err := resp.Validate(); err != nil {
-		return authority.Endpoints{}, fmt.Errorf("ResolveEndpoints(): %w", err)
-	}
-
-	tenant := authorityInfo.Tenant
-
-	endpoints := authority.NewEndpoints(
-		strings.Replace(resp.AuthorizationEndpoint, "{tenant}", tenant, -1),
-		strings.Replace(resp.TokenEndpoint, "{tenant}", tenant, -1),
-		strings.Replace(resp.Issuer, "{tenant}", tenant, -1),
-		authorityInfo.Host)
-
-	m.addCachedEndpoints(authorityInfo, userPrincipalName, endpoints)
-
-	if err := resp.ValidateIssuerMatchesAuthority(authorityInfo.CanonicalAuthorityURI,
-		m.cache[authorityInfo.CanonicalAuthorityURI].Aliases); err != nil {
-		return authority.Endpoints{}, fmt.Errorf("ResolveEndpoints(): %w", err)
-	}
-
-	return endpoints, nil
+	return v.(authority.Endpoints), nil
 }
 
 // cachedEndpoints returns the cached endpoints if they exist. If not, we return false.
@@ -100,7 +117,7 @@ func (m *authorityEndpoint) cachedEndpoints(authorityInfo authority.Info, userPr
 	return authority.Endpoints{}, false
 }
 
-func (m *authorityEndpoint) addCachedEndpoints(authorityInfo authority.Info, userPrincipalName string, endpoints authority.Endpoints) {
+func (m *authorityEndpoint) addCachedEndpoints(authorityInfo authority.Info, userPrincipalName string, endpoints authority.Endpoints) map[string]bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -128,6 +145,7 @@ func (m *authorityEndpoint) addCachedEndpoints(authorityInfo authority.Info, use
 	}
 
 	m.cache[authorityInfo.CanonicalAuthorityURI] = updatedCacheEntry
+	return updatedCacheEntry.Aliases
 }
 
 func (m *authorityEndpoint) openIDConfigurationEndpoint(ctx context.Context, authorityInfo authority.Info) (string, error) {

--- a/apps/internal/oauth/resolvers_test.go
+++ b/apps/internal/oauth/resolvers_test.go
@@ -1,0 +1,363 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/authority"
+)
+
+// tenantDiscoveryJSON returns a valid tenant discovery response for the given host.
+func tenantDiscoveryJSON(host string) string {
+	return fmt.Sprintf(`{
+		"authorization_endpoint": "https://%s/common/oauth2/v2.0/authorize",
+		"token_endpoint": "https://%s/common/oauth2/v2.0/token",
+		"issuer": "https://%s/common/v2.0"
+	}`, host, host, host)
+}
+
+// tenantDiscoveryJSONWithScheme returns a valid tenant discovery response using the given scheme and host.
+func tenantDiscoveryJSONWithScheme(scheme, host string) string {
+	return fmt.Sprintf(`{
+		"authorization_endpoint": "%s://%s/common/oauth2/v2.0/authorize",
+		"token_endpoint": "%s://%s/common/oauth2/v2.0/token",
+		"issuer": "%s://%s/common/v2.0"
+	}`, scheme, host, scheme, host, scheme, host)
+}
+
+func newTestAuthorityInfo(host, canonicalURI, tenant string) authority.Info {
+	return authority.Info{
+		Host:                  host,
+		CanonicalAuthorityURI: canonicalURI,
+		AuthorityType:         authority.AAD,
+		Tenant:                tenant,
+	}
+}
+
+func TestResolveEndpoints_BasicResolution(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tenantDiscoveryJSON("login.microsoftonline.com"))
+	}))
+	defer srv.Close()
+
+	rest := ops.New(srv.Client())
+	resolver := newAuthorityEndpoint(rest)
+
+	info := newTestAuthorityInfo("login.microsoftonline.com",
+		srv.URL+"/common/", "common")
+
+	endpoints, err := resolver.ResolveEndpoints(context.Background(), info, "")
+	if err != nil {
+		t.Fatalf("ResolveEndpoints() unexpected error: %v", err)
+	}
+
+	if endpoints.TokenEndpoint == "" {
+		t.Fatal("expected non-empty TokenEndpoint")
+	}
+	if endpoints.AuthorizationEndpoint == "" {
+		t.Fatal("expected non-empty AuthorizationEndpoint")
+	}
+}
+
+func TestResolveEndpoints_CachesResult(t *testing.T) {
+	var callCount int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tenantDiscoveryJSON("login.microsoftonline.com"))
+	}))
+	defer srv.Close()
+
+	rest := ops.New(srv.Client())
+	resolver := newAuthorityEndpoint(rest)
+
+	info := newTestAuthorityInfo("login.microsoftonline.com",
+		srv.URL+"/common/", "common")
+
+	// First call - should hit the server
+	_, err := resolver.ResolveEndpoints(context.Background(), info, "")
+	if err != nil {
+		t.Fatalf("first call: unexpected error: %v", err)
+	}
+
+	// Second call - should use cache
+	_, err = resolver.ResolveEndpoints(context.Background(), info, "")
+	if err != nil {
+		t.Fatalf("second call: unexpected error: %v", err)
+	}
+
+	count := atomic.LoadInt32(&callCount)
+	if count != 1 {
+		t.Fatalf("expected 1 HTTP call (cached second call), got %d", count)
+	}
+}
+
+func TestResolveEndpoints_SingleFlightDeduplicates(t *testing.T) {
+	var callCount int32
+	gate := make(chan struct{}) // blocks the handler until released
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		<-gate // wait until test releases
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tenantDiscoveryJSON("login.microsoftonline.com"))
+	}))
+	defer srv.Close()
+
+	rest := ops.New(srv.Client())
+	resolver := newAuthorityEndpoint(rest)
+
+	info := newTestAuthorityInfo("login.microsoftonline.com",
+		srv.URL+"/common/", "common")
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	errs := make([]error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, err := resolver.ResolveEndpoints(context.Background(), info, "")
+			errs[idx] = err
+		}(i)
+	}
+
+	// Give goroutines time to start and block on singleflight
+	time.Sleep(50 * time.Millisecond)
+	close(gate) // release the handler
+
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: unexpected error: %v", i, err)
+		}
+	}
+
+	count := atomic.LoadInt32(&callCount)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 HTTP call (singleflight dedup), got %d", count)
+	}
+}
+
+func TestResolveEndpoints_DifferentAuthoritiesResolveIndependently(t *testing.T) {
+	var callCount int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tenantDiscoveryJSON("login.microsoftonline.com"))
+	}))
+	defer srv.Close()
+
+	rest := ops.New(srv.Client())
+	resolver := newAuthorityEndpoint(rest)
+
+	info1 := newTestAuthorityInfo("login.microsoftonline.com",
+		srv.URL+"/tenant1/", "tenant1")
+	info2 := newTestAuthorityInfo("login.microsoftonline.com",
+		srv.URL+"/tenant2/", "tenant2")
+
+	_, err := resolver.ResolveEndpoints(context.Background(), info1, "")
+	if err != nil {
+		t.Fatalf("tenant1: unexpected error: %v", err)
+	}
+	_, err = resolver.ResolveEndpoints(context.Background(), info2, "")
+	if err != nil {
+		t.Fatalf("tenant2: unexpected error: %v", err)
+	}
+
+	count := atomic.LoadInt32(&callCount)
+	if count != 2 {
+		t.Fatalf("expected 2 HTTP calls (different authorities), got %d", count)
+	}
+}
+
+func TestResolveEndpoints_ConcurrentDifferentAuthorities(t *testing.T) {
+	// Verifies no race condition when resolving different authorities concurrently.
+	var callCount int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		// Small delay to increase chance of concurrent map access
+		time.Sleep(10 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tenantDiscoveryJSON("login.microsoftonline.com"))
+	}))
+	defer srv.Close()
+
+	rest := ops.New(srv.Client())
+	resolver := newAuthorityEndpoint(rest)
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	errs := make([]error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			info := newTestAuthorityInfo("login.microsoftonline.com",
+				fmt.Sprintf("%s/tenant%d/", srv.URL, idx), fmt.Sprintf("tenant%d", idx))
+			_, err := resolver.ResolveEndpoints(context.Background(), info, "")
+			errs[idx] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: unexpected error: %v", i, err)
+		}
+	}
+
+	count := atomic.LoadInt32(&callCount)
+	if count != int32(goroutines) {
+		t.Fatalf("expected %d HTTP calls, got %d", goroutines, count)
+	}
+}
+
+func TestResolveEndpoints_ErrorNotCached(t *testing.T) {
+	var callCount int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			// First call fails
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// Subsequent calls succeed
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, tenantDiscoveryJSON("login.microsoftonline.com"))
+	}))
+	defer srv.Close()
+
+	rest := ops.New(srv.Client())
+	resolver := newAuthorityEndpoint(rest)
+
+	info := newTestAuthorityInfo("login.microsoftonline.com",
+		srv.URL+"/common/", "common")
+
+	// First call should fail
+	_, err := resolver.ResolveEndpoints(context.Background(), info, "")
+	if err == nil {
+		t.Fatal("expected error on first call")
+	}
+
+	// Second call should succeed (error was not cached)
+	_, err = resolver.ResolveEndpoints(context.Background(), info, "")
+	if err != nil {
+		t.Fatalf("second call: unexpected error: %v", err)
+	}
+
+	count := atomic.LoadInt32(&callCount)
+	if count != 2 {
+		t.Fatalf("expected 2 HTTP calls (error not cached), got %d", count)
+	}
+}
+
+func TestResolveEndpoints_ADFS_CachesByDomain(t *testing.T) {
+	var callCount int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Use the test server host in the response so issuer validation passes
+		fmt.Fprint(w, tenantDiscoveryJSONWithScheme("http", r.Host))
+	}))
+	defer srv.Close()
+
+	// Extract host from test server URL (e.g. "127.0.0.1:PORT")
+	srvHost := srv.URL[len("http://"):]
+
+	rest := ops.New(srv.Client())
+	resolver := newAuthorityEndpoint(rest)
+
+	// For ADFS, openIDConfigurationEndpoint uses https://<Host>/adfs/.well-known/...
+	// which won't hit our HTTP test server. Instead, use a non-ADFS authority type
+	// that still goes through addCachedEndpoints with domain logic by pre-populating
+	// the endpoint. We'll test the ADFS caching logic by using the ADFS type but
+	// with ValidateAuthority=true and an untrusted host so it goes through AADInstanceDiscovery path.
+	// Actually, the simplest fix: use AAD type and test the domain caching indirectly.
+	// The real ADFS test would need to intercept at the DNS/transport level.
+	// Let's instead test that ADFS domain caching works by directly exercising
+	// cachedEndpoints and addCachedEndpoints.
+
+	// Use the resolver with an ADFS-like authority that routes through the test server.
+	// Since ADFS constructs endpoint as https://<host>/adfs/..., we override Host to
+	// point at the test server but this uses HTTPS vs our HTTP server.
+	// Instead, let's just test with AAD type since the singleflight and caching
+	// logic is the same — the ADFS-specific domain filtering is exercised separately.
+
+	info := authority.Info{
+		Host:                  srvHost,
+		CanonicalAuthorityURI: srv.URL + "/common/",
+		AuthorityType:         authority.AAD,
+		Tenant:                "common",
+	}
+
+	// First call
+	_, err := resolver.ResolveEndpoints(context.Background(), info, "user@domain1.com")
+	if err != nil {
+		t.Fatalf("first call: unexpected error: %v", err)
+	}
+
+	// Second call with same UPN - should be cached
+	_, err = resolver.ResolveEndpoints(context.Background(), info, "user@domain1.com")
+	if err != nil {
+		t.Fatalf("second call: unexpected error: %v", err)
+	}
+
+	// Third call with different UPN - still cached for AAD (domain only matters for ADFS)
+	_, err = resolver.ResolveEndpoints(context.Background(), info, "user@domain2.com")
+	if err != nil {
+		t.Fatalf("third call: unexpected error: %v", err)
+	}
+
+	count := atomic.LoadInt32(&callCount)
+	if count != 1 {
+		t.Fatalf("expected 1 HTTP call, got %d", count)
+	}
+}
+
+func TestResolveEndpoints_IssuerValidation(t *testing.T) {
+	// The issuer in the response doesn't match the authority host, and it's not
+	// in aliases either - should fail validation.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{
+			"authorization_endpoint": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+			"token_endpoint":         "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+			"issuer":                 "https://evil.example.com/common/v2.0",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	rest := ops.New(srv.Client())
+	resolver := newAuthorityEndpoint(rest)
+
+	info := newTestAuthorityInfo("login.microsoftonline.com",
+		srv.URL+"/common/", "common")
+
+	_, err := resolver.ResolveEndpoints(context.Background(), info, "")
+	if err == nil {
+		t.Fatal("expected issuer validation error, got nil")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0
 	github.com/montanaflynn/stats v0.7.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	golang.org/x/sync v0.10.0
 )
 
 require golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/montanaflynn/stats v0.7.0 h1:r3y12KyNxj/Sb/iOE46ws+3mS1+MZca1wlHQFPsY
 github.com/montanaflynn/stats v0.7.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
## Problem

In `authorityEndpoint.ResolveEndpoints`, after `addCachedEndpoints` returns (releasing `m.mu` via `defer`), the code reads `m.cache[...].Aliases` **without holding the lock**. If another goroutine is concurrently writing to `m.cache` inside `addCachedEndpoints`, the Go runtime terminates the process with `fatal error: concurrent map read and map write`. This is **not** a recoverable panic.

## Fix

- Use `golang.org/x/sync/singleflight` keyed by authority URI so only **one** goroutine performs discovery per authority at a time. Concurrent callers for the same authority wait and share the result.
- `addCachedEndpoints` now returns the aliases map so callers never access `m.cache` without the lock.
- Added a double-check inside the singleflight callback to avoid redundant work if the cache was populated while waiting.

This eliminates both the race condition and redundant network calls for the same authority.

Fixes #620