### PR TITLE
Validate region string format in AADInstanceDiscovery

### DIFF
--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -43,6 +44,9 @@ const (
 	loginSTSWindows      = "sts.windows.net"
 	loginMicrosoftOnline = defaultHost
 )
+
+// validRegion matches Azure region names: lowercase alphanumeric and hyphens only.
+var validRegion = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
 // jsonCaller is an interface that allows us to mock the JSONCall method.
 type jsonCaller interface {
@@ -592,6 +596,9 @@ func (c Client) AADInstanceDiscovery(ctx context.Context, authorityInfo Info) (I
 		region = detectRegion(ctx)
 	}
 	if region != "" {
+		if !validRegion.MatchString(region) {
+			return resp, fmt.Errorf("invalid region %q: region must contain only lowercase alphanumeric characters and hyphens", region)
+		}
 		environment := authorityInfo.Host
 		switch environment {
 		case loginMicrosoft, loginWindows, loginSTSWindows, defaultHost:

--- a/apps/internal/oauth/ops/authority/authority_test.go
+++ b/apps/internal/oauth/ops/authority/authority_test.go
@@ -302,6 +302,55 @@ func TestAADInstanceDiscoveryWithRegion(t *testing.T) {
 	}
 }
 
+func TestAADInstanceDiscoveryInvalidRegion(t *testing.T) {
+	client := Client{&fakeJSONCaller{}}
+	for _, test := range []struct {
+		desc, region string
+	}{
+		{"contains dot", "east.us"},
+		{"contains slash", "east/us"},
+		{"contains uppercase", "EastUS"},
+		{"contains space", "east us"},
+		{"starts with digit", "1eastus"},
+		{"starts with hyphen", "-eastus"},
+		{"contains underscore", "east_us"},
+		{"contains special char", "east$us"},
+		{"path traversal attempt", "../evil"},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			authInfo := Info{Host: "login.microsoft.com", Tenant: "tenant", Region: test.region}
+			_, err := client.AADInstanceDiscovery(context.Background(), authInfo)
+			if err == nil {
+				t.Fatalf("AADInstanceDiscovery(%q): expected error, got nil", test.region)
+			}
+			if !strings.Contains(err.Error(), "invalid region") {
+				t.Errorf("AADInstanceDiscovery(%q): expected 'invalid region' error, got: %v", test.region, err)
+			}
+		})
+	}
+}
+
+func TestAADInstanceDiscoveryValidRegion(t *testing.T) {
+	client := Client{&fakeJSONCaller{}}
+	for _, region := range []string{
+		"eastus",
+		"westus2",
+		"east-us-2",
+		"centralus",
+		"a",
+		"a1",
+		"a-1",
+	} {
+		t.Run(region, func(t *testing.T) {
+			authInfo := Info{Host: "login.microsoft.com", Tenant: "tenant", Region: region}
+			_, err := client.AADInstanceDiscovery(context.Background(), authInfo)
+			if err != nil {
+				t.Errorf("AADInstanceDiscovery(%q): unexpected error: %v", region, err)
+			}
+		})
+	}
+}
+
 func TestCreateAuthorityInfoFromAuthorityUri(t *testing.T) {
 	const authorityURI = "https://login.microsoftonline.com/common/"
 


### PR DESCRIPTION
Fixes #624

## Problem
`AADInstanceDiscovery` uses the region string directly in URL construction (`https://{region}.{host}/...`) without validating its format. Malformed region values containing dots, slashes, or other special characters could produce incorrect URLs.

## Solution
Added a regex validation (`^[a-z][a-z0-9-]*$`) that checks the region string before it is used in URL construction. This matches the Azure region naming convention (e.g., `eastus`, `westus2`, `east-us-2`). If the region is invalid, a clear error is returned.

## Changes
- Added `regexp` import
- Added `validRegion` compiled regex at package level
- Added validation check in `AADInstanceDiscovery` before URL interpolation