### PR TITLE
Update version for 1.8.0 release

### DIFF
--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -8,4 +8,4 @@ package version
 const SKU = "MSAL.Go"
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "1.7.2"
+const Version = "1.8.0"


### PR DESCRIPTION
## What's Changed
* Recover from panics in `json.Unmarshal` to prevent token-cache crashes (fixes #579) by @4gust in https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/614
* fix(base.go): empty partition key causing external cache miss by @MatteoCalabro-TomTom in https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/615
* Add User Federated Identity Credential (`user_fic`) grant type support by @Avery-Dunn in https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/619