### PR TITLE
Persist managed identity fallback RefreshOn in cache

### DIFF
--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -462,15 +462,15 @@ func authResultFromToken(authParams authority.AuthParams, token accesstokens.Tok
 	if cacheManager == nil {
 		return AuthResult{}, errors.New("cache instance is nil")
 	}
-	account, err := cacheManager.Write(authParams, token)
-	if err != nil {
-		return AuthResult{}, err
-	}
 	// if refreshOn is not set, set it to half of the time until expiry if expiry is more than 2 hours away
 	if token.RefreshOn.T.IsZero() {
 		if lifetime := time.Until(token.ExpiresOn); lifetime > 2*time.Hour {
 			token.RefreshOn.T = time.Now().Add(lifetime / 2)
 		}
+	}
+	account, err := cacheManager.Write(authParams, token)
+	if err != nil {
+		return AuthResult{}, err
 	}
 	ar, err := base.NewAuthResult(token, account)
 	if err != nil {

--- a/apps/managedidentity/managedidentity_test.go
+++ b/apps/managedidentity/managedidentity_test.go
@@ -1224,3 +1224,65 @@ func TestRefreshInMultipleRequests(t *testing.T) {
 	}
 	close(ch)
 }
+
+func TestAcquireTokenPreservesFallbackRefreshOnInCache(t *testing.T) {
+	firstToken := "first token"
+	expiresIn := 86400
+	resource := "https://resource/.default"
+	miType := SystemAssigned()
+	setEnvVars(t, CloudShell)
+
+	before := cacheManager
+	defer func() { cacheManager = before }()
+	cacheManager = storage.New(nil)
+
+	responseBody, err := json.Marshal(SuccessfulResponse{
+		AccessToken: firstToken,
+		ExpiresIn:   int64(expiresIn),
+		ExpiresOn:   time.Now().Add(time.Duration(expiresIn) * time.Second).Unix(),
+		Resource:    resource,
+		TokenType:   "Bearer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := mock.NewClient()
+	mockClient.AppendResponse(
+		mock.WithHTTPStatusCode(http.StatusOK),
+		mock.WithBody(responseBody),
+	)
+
+	client, err := New(miType, WithHTTPClient(mockClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.AcquireToken(context.Background(), resource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Metadata.TokenSource != TokenSourceIdentityProvider {
+		t.Fatalf("expected IdentityProvider tokensource, got %d", result.Metadata.TokenSource)
+	}
+	if result.AccessToken != firstToken {
+		t.Fatalf("wanted %q, got %q", firstToken, result.AccessToken)
+	}
+	if result.Metadata.RefreshOn.IsZero() {
+		t.Fatal("expected fallback RefreshOn from identity provider response")
+	}
+
+	// The mock has no second response, so this acquisition must come from cache.
+	result, err = client.AcquireToken(context.Background(), resource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Metadata.TokenSource != TokenSourceCache {
+		t.Fatalf("wanted cache token source, got %d", result.Metadata.TokenSource)
+	}
+	if result.AccessToken != firstToken {
+		t.Fatalf("wanted cached token %q, got %q", firstToken, result.AccessToken)
+	}
+	if result.Metadata.RefreshOn.IsZero() {
+		t.Fatal("expected cached token to preserve fallback RefreshOn")
+	}
+}


### PR DESCRIPTION
Fixes #570.

Managed identity responses can omit `refresh_in`, in which case MSAL Go computes a fallback `RefreshOn` value. That fallback was computed after the token response was written to cache, so the first acquisition returned refresh metadata but later cache hits did not.

This moves the existing fallback calculation before the cache write and adds a regression test for the cached acquisition path.
