### PR TITLE
Migrate region discovery to IMDS /compute JSON endpoint

### DIFF
--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -28,8 +28,8 @@ const (
 	aadInstanceDiscoveryEndpoint      = "https://%v/common/discovery/instance"
 	tenantDiscoveryEndpointWithRegion = "https://%s.%s/%s/v2.0/.well-known/openid-configuration"
 	regionName                        = "REGION_NAME"
-	defaultAPIVersion                 = "2021-10-01"
-	imdsEndpoint                      = "http://169.254.169.254/metadata/instance/compute/location?format=text&api-version=" + defaultAPIVersion
+	defaultAPIVersion                 = "2021-02-01"
+	imdsEndpoint                      = "http://169.254.169.254/metadata/instance/compute?api-version=" + defaultAPIVersion
 	autoDetectRegion                  = "TryAutoDetect"
 	AccessTokenTypeBearer             = "Bearer"
 )
@@ -661,7 +661,24 @@ func detectRegion(ctx context.Context) string {
 	if err != nil {
 		return ""
 	}
-	return string(response)
+	return parseRegionFromIMDSResponse(response)
+}
+
+// imdsComputeResponse models the subset of the IMDS compute metadata response
+// (http://169.254.169.254/metadata/instance/compute) used for region detection.
+type imdsComputeResponse struct {
+	Location string `json:"location"`
+}
+
+// parseRegionFromIMDSResponse extracts the Azure region from an IMDS compute
+// metadata JSON response body. It returns an empty string when the body cannot
+// be parsed or the location field is absent.
+func parseRegionFromIMDSResponse(body []byte) string {
+	var parsed imdsComputeResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	return parsed.Location
 }
 
 func (a *AuthParams) CacheKey(isAppCache bool) string {

--- a/apps/internal/oauth/ops/authority/authority_test.go
+++ b/apps/internal/oauth/ops/authority/authority_test.go
@@ -841,3 +841,37 @@ func (f *fakeCallErrCaller) JSONCall(ctx context.Context, endpoint string, heade
 		Err: fmt.Errorf("http call(%s)(GET) error: reply status code was %d:\n%s", endpoint, f.statusCode, f.body),
 	}
 }
+
+func TestParseRegionFromIMDSResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "valid location", body: `{"location":"westus2"}`, want: "westus2"},
+		{name: "location among other fields", body: `{"location":"eastus","name":"vm"}`, want: "eastus"},
+		{name: "missing location", body: `{}`, want: ""},
+		{name: "null location", body: `{"location":null}`, want: ""},
+		{name: "malformed json", body: `not json`, want: ""},
+		{name: "empty body", body: ``, want: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := parseRegionFromIMDSResponse([]byte(test.body)); got != test.want {
+				t.Fatalf("parseRegionFromIMDSResponse(%q) = %q, want %q", test.body, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIMDSEndpoint(t *testing.T) {
+	if !strings.Contains(imdsEndpoint, "/metadata/instance/compute?api-version=2021-02-01") {
+		t.Errorf("imdsEndpoint should target the compute JSON endpoint, got %q", imdsEndpoint)
+	}
+	if strings.Contains(imdsEndpoint, "/location") {
+		t.Errorf("imdsEndpoint should not use the /location route parameter, got %q", imdsEndpoint)
+	}
+	if strings.Contains(imdsEndpoint, "format=text") {
+		t.Errorf("imdsEndpoint should not request format=text, got %q", imdsEndpoint)
+	}
+}


### PR DESCRIPTION
Ports [microsoft-authentication-library-for-dotnet#6057](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6057) to MSAL Go.

## What
Migrates Azure VM region auto-detection from the legacy IMDS **text** endpoint to the newer **JSON** endpoint.

- **Before:** `GET http://169.254.169.254/metadata/instance/compute/location?format=text&api-version=2021-10-01` — response body *is* the region string.
- **After:** `GET http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01` — region is read from the `location` field of the JSON body.

## Details
- `apps/internal/oauth/ops/authority/authority.go`: updated `imdsEndpoint` (dropped `/location` route param and `format=text`, `api-version` -> `2021-02-01`) and added `imdsComputeResponse` + `parseRegionFromIMDSResponse` to parse the `location` field.
- A malformed body or missing `location` yields an empty region, preserving the existing no-region fallback. `REGION_NAME` env-var precedence and the timeout/retry behavior are unchanged.
- No public API, telemetry, or config changes. `encoding/json` was already imported.

## Tests
Added to `authority_test.go`:
- `TestParseRegionFromIMDSResponse` — valid location, location among other fields, missing, null, malformed JSON, empty body.
- `TestIMDSEndpoint` — asserts the endpoint targets `/metadata/instance/compute?api-version=2021-02-01` and no longer uses `/location` or `format=text`.

`go build ./...`, `go vet`, and `go test ./apps/internal/oauth/ops/authority/...` all pass.