### PR TITLE
Fix app-only token proactive refresh writing to wrong cache partition key

### DIFF
--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -334,6 +334,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 	authParams.AuthorizationType = silent.AuthorizationType
 	authParams.Claims = silent.Claims
 	authParams.UserAssertion = silent.UserAssertion
+	authParams.IsAppCache = silent.IsAppCache
 	if silent.AuthnScheme != nil {
 		authParams.AuthnScheme = silent.AuthnScheme
 	}

--- a/apps/internal/base/base.go
+++ b/apps/internal/base/base.go
@@ -334,7 +334,7 @@ func (b Client) AcquireTokenSilent(ctx context.Context, silent AcquireTokenSilen
 	authParams.AuthorizationType = silent.AuthorizationType
 	authParams.Claims = silent.Claims
 	authParams.UserAssertion = silent.UserAssertion
-	authParams.IsAppCache = silent.IsAppCache
+	authParams.IsAppTokenCache = silent.IsAppCache
 	if silent.AuthnScheme != nil {
 		authParams.AuthnScheme = silent.AuthnScheme
 	}

--- a/apps/internal/base/base_test.go
+++ b/apps/internal/base/base_test.go
@@ -413,6 +413,86 @@ func TestAccountCachePartitionKey(t *testing.T) {
 	}
 }
 
+// TestAppTokenProactiveRefreshCachePartitionKey verifies that a proactive refresh
+// (RefreshOn elapsed) of an app-only (client credentials) token writes the refreshed
+// token back to the external cache under the app-token-cache partition key, i.e. the
+// same partition key the read path uses, rather than the empty partition key "".
+//
+// This guards against the regression described in
+// https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/630, where
+// AuthResultFromToken computed the write-back key via token.CacheKey(authParams).
+// Because AcquireTokenSilent overrides AuthorizationType to ATRefreshToken and an
+// app-only token has no home account, that returned "" instead of the app-token-cache
+// key, so subsequent silent reads missed the refreshed token and re-hit the IdP.
+func TestAppTokenProactiveRefreshCachePartitionKey(t *testing.T) {
+	ctx := context.Background()
+	pkCache := &partitionKeyCache{}
+	client := fakeClient(t, WithCacheAccessor(pkCache))
+
+	// The proactively-refreshed token is app-only (no ID token), so its HomeAccountID()
+	// is empty — exactly the condition that exposed the bug.
+	client.Token.AccessTokens.(*fake.AccessTokens).AccessToken = accesstokens.TokenResponse{
+		AccessToken:   "refreshed-app-token",
+		ExpiresOn:     time.Now().Add(time.Hour),
+		GrantedScopes: accesstokens.Scopes{Slice: testScopes},
+		TokenType:     "Bearer",
+	}
+
+	// Seed the cache with a still-valid app token whose RefreshOn has already elapsed,
+	// so the next silent acquire serves it from cache and triggers a proactive refresh.
+	_, err := client.manager.Write(
+		authority.AuthParams{
+			AuthorityInfo: authority.Info{
+				AuthorityType: authority.AAD,
+				Host:          fakeAuthority,
+				Tenant:        fakeTenantID,
+			},
+			ClientID:          fakeClientID,
+			Scopes:            testScopes,
+			AuthorizationType: authority.ATClientCredentials,
+			AuthnScheme:       &authority.BearerAuthenticationScheme{},
+		},
+		accesstokens.TokenResponse{
+			AccessToken:   "cached-app-token",
+			ExpiresOn:     time.Now().Add(time.Hour),
+			RefreshOn:     internalTime.DurationTime{T: time.Now().Add(-time.Hour)},
+			GrantedScopes: accesstokens.Scopes{Slice: testScopes},
+			TokenType:     "Bearer",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.AcquireTokenSilent(ctx, AcquireTokenSilentParameters{
+		Scopes:      testScopes,
+		Account:     shared.Account{},
+		RequestType: accesstokens.ATConfidential,
+		Credential:  &accesstokens.Credential{Secret: "secret"},
+		IsAppCache:  true,
+	}); err != nil {
+		t.Fatalf("AcquireTokenSilent returned an unexpected error: %v", err)
+	}
+
+	wantKey := fmt.Sprintf("%s_%s_AppTokenCache", fakeClientID, fakeTenantID)
+
+	if len(pkCache.exportKeys) == 0 {
+		t.Fatal("expected the proactive refresh to export the refreshed token to the external cache")
+	}
+	for i, got := range pkCache.exportKeys {
+		if got != wantKey {
+			t.Errorf("export partition key[%d] = %q, want %q (an empty key indicates the issue #630 regression)", i, got, wantKey)
+		}
+	}
+	// Every partition key touched during the flow (the initial read plus the
+	// refresh write-back) must be the app-token-cache key.
+	for i, got := range pkCache.replaceKeys {
+		if got != wantKey {
+			t.Errorf("replace partition key[%d] = %q, want %q", i, got, wantKey)
+		}
+	}
+}
+
 func TestCreateAuthenticationResult(t *testing.T) {
 	future := time.Now().Add(400 * time.Second)
 

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -292,7 +292,11 @@ func (tr *TokenResponse) CacheKey(authParams authority.AuthParams) string {
 	if authParams.AuthorizationType == authority.ATOnBehalfOf {
 		return authParams.AssertionHash()
 	}
-	if authParams.AuthorizationType == authority.ATClientCredentials {
+	// An app-only (client credentials) request keys on the app-token-cache partition.
+	// AcquireTokenSilent overrides AuthorizationType to ATRefreshToken before the
+	// proactive-refresh write-back, so check IsAppCache here to keep the write key
+	// aligned with the read key (authParams.CacheKey). See issue #630.
+	if authParams.AuthorizationType == authority.ATClientCredentials || authParams.IsAppCache {
 		return authParams.AppKey()
 	}
 	if authParams.IsConfidentialClient || authParams.AuthorizationType == authority.ATRefreshToken {

--- a/apps/internal/oauth/ops/accesstokens/tokens.go
+++ b/apps/internal/oauth/ops/accesstokens/tokens.go
@@ -294,9 +294,9 @@ func (tr *TokenResponse) CacheKey(authParams authority.AuthParams) string {
 	}
 	// An app-only (client credentials) request keys on the app-token-cache partition.
 	// AcquireTokenSilent overrides AuthorizationType to ATRefreshToken before the
-	// proactive-refresh write-back, so check IsAppCache here to keep the write key
+	// proactive-refresh write-back, so check IsAppTokenCache here to keep the write key
 	// aligned with the read key (authParams.CacheKey). See issue #630.
-	if authParams.AuthorizationType == authority.ATClientCredentials || authParams.IsAppCache {
+	if authParams.AuthorizationType == authority.ATClientCredentials || authParams.IsAppTokenCache {
 		return authParams.AppKey()
 	}
 	if authParams.IsConfidentialClient || authParams.AuthorizationType == authority.ATRefreshToken {

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -283,6 +283,11 @@ type AuthParams struct {
 	ExtraBodyParameters map[string]string
 	// CacheKeyComponents are additional components to include in the cache key.
 	CacheKeyComponents map[string]string
+	// IsAppCache indicates the request targets the app-only (client credentials) token
+	// cache partition. It is propagated onto silent requests so the proactive-refresh
+	// write-back computes the same partition key as the read path, even though
+	// AcquireTokenSilent overrides AuthorizationType to ATRefreshToken. See issue #630.
+	IsAppCache bool
 	// UserFederatedIdentityCredential is the federated credential token for user_fic flow.
 	UserFederatedIdentityCredential string
 	// UserObjectID is the target user's object ID for user_fic flow (mutually exclusive with Username).

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -283,11 +283,11 @@ type AuthParams struct {
 	ExtraBodyParameters map[string]string
 	// CacheKeyComponents are additional components to include in the cache key.
 	CacheKeyComponents map[string]string
-	// IsAppCache indicates the request targets the app-only (client credentials) token
-	// cache partition. It is propagated onto silent requests so the proactive-refresh
+	// IsAppTokenCache indicates the request targets the app-only (client credentials)
+	// token cache partition. It is propagated onto silent requests so the proactive-refresh
 	// write-back computes the same partition key as the read path, even though
 	// AcquireTokenSilent overrides AuthorizationType to ATRefreshToken. See issue #630.
-	IsAppCache bool
+	IsAppTokenCache bool
 	// UserFederatedIdentityCredential is the federated credential token for user_fic flow.
 	UserFederatedIdentityCredential string
 	// UserObjectID is the target user's object ID for user_fic flow (mutually exclusive with Username).


### PR DESCRIPTION
Fixes #630

## Summary

When a confidential client is configured with an external cache (`confidential.WithCache(...)`) and acquires an app-only token (`AcquireTokenByCredential`, client-credentials grant), a **proactive refresh** (triggered once `RefreshOn` has elapsed) wrote the refreshed token to the external cache under the partition key `""` instead of the app-token-cache key used by reads. The next silent read therefore missed the refreshed token, so MSAL re-acquired from the IdP on every call after `RefreshOn` elapsed, defeating the external cache for app tokens.

This is a correctness/performance issue, not a security issue. In-memory-only usage (no `WithCache`) is unaffected.

## Root cause

The read and write paths computed the app-cache partition key differently during a proactive refresh:

- **Read** -- `AcquireTokenSilent` computes `authParams.CacheKey(silent.IsAppCache)` => `..._AppTokenCache`.
- **Write** -- the proactive refresh calls `AuthResultFromToken`, which computes `token.CacheKey(authParams)`.

`AcquireTokenSilent` overrides `authParams.AuthorizationType` to `ATRefreshToken` for the non-OBO path. Inside `TokenResponse.CacheKey`, the `ATClientCredentials` branch is then skipped and execution falls to the `IsConfidentialClient || AuthorizationType == ATRefreshToken` branch, which returns `tr.HomeAccountID()`. For an app-only token there is no home account, so this is `""`.

## Fix

Make the refresh write-back use the same partition key as the read path for app tokens:

- Add an explicit `IsAppCache` flag to `authority.AuthParams`.
- Set it in `base.Client.AcquireTokenSilent` from `silent.IsAppCache` (it survives the `AuthorizationType = ATRefreshToken` override).
- Have `TokenResponse.CacheKey` return `authParams.AppKey()` when `IsAppCache` is set -- mirroring the read path's `authParams.CacheKey(isAppCache)`.

## Test

Added `TestAppTokenProactiveRefreshCachePartitionKey` (in `apps/internal/base/base_test.go`), which seeds a still-valid app token whose `RefreshOn` has elapsed, drives a proactive refresh through an external cache accessor, and asserts the export/replace partition keys equal `..._AppTokenCache` (not `""`). The test fails without the fix (`export key = ""`) and passes with it.

## Validation

- `go build ./...` -- clean.
- `go test ./apps/internal/... ./apps/confidential/...` -- pass.
- The only failing suites (`apps/tests/integration`, `apps/tests/performance`) fail identically on clean `main` (missing `cert.pem` / pre-existing panic) and are unrelated to this change.

## Notes

Pre-existing; discovered while porting dotnet#5999 (`WithClaimsFromClient`) in #629. Split out so it can be fixed independently.