### PR TITLE
ci: split build_test pipeline into Build / Unit Tests / Integration Tests stages

### DIFF
--- a/ado/build_test.yaml
+++ b/ado/build_test.yaml
@@ -7,50 +7,129 @@ pr:
     include:
       - main
 
-pool:
-  vmImage: "ubuntu-latest"
+variables:
+  goVersion: "1.22.3"
 
-steps:
-  - task: GoTool@0
-    inputs:
-      version: "1.22.3"
-  - task: Go@0
-    inputs:
-      command: "get"
-      arguments: "-d -v -t -d ./..."
-      workingDirectory: "$(System.DefaultWorkingDirectory)"
-    displayName: "Install dependencies"
-  - task: Go@0
-    inputs:
-      command: "build"
-      arguments: "./apps/..."
-      workingDirectory: "$(System.DefaultWorkingDirectory)"
+stages:
+  # ──────────────────────────────────────────────
+  # Stage 1 — Build
+  # ──────────────────────────────────────────────
+  - stage: Build
     displayName: "Build"
-  - task: Go@0
-    inputs:
-      command: "test"
-      arguments: "-race -short ./apps/cache/... ./apps/confidential/... ./apps/public/... ./apps/internal/... ./apps/managedidentity/..."
-      workingDirectory: "$(System.DefaultWorkingDirectory)"
-    displayName: "Run Unit Tests"
-  - task: AzureKeyVault@2
-    displayName: "Connect to Key Vault"
-    inputs:
-      azureSubscription: "AuthSdkResourceManager"
-      KeyVaultName: "msidlabs"
-      SecretsFilter: "LabAuth,IDLABS-APP-Confidential-Client-Cert-OnPrem"
-  - task: Bash@3
-    displayName: Installing certificate
-    inputs:
-      targetType: "inline"
-      script: |
-        echo $(LabAuth) | base64 -d > $(Build.SourcesDirectory)/cert.pfx
-        OPENSSL_CONF=/dev/null openssl pkcs12 -in $(Build.SourcesDirectory)/cert.pfx -out $(Build.SourcesDirectory)/cert.pem -nodes -passin pass:'' -legacy
-        echo "$(IDLABS-APP-Confidential-Client-Cert-OnPrem)" | base64 -d > $(Build.SourcesDirectory)/ccaCert.pfx
-        OPENSSL_CONF=/dev/null openssl pkcs12 -in $(Build.SourcesDirectory)/ccaCert.pfx -out $(Build.SourcesDirectory)/ccaCert.pem -nodes -passin pass:'' -legacy
+    dependsOn: []
+    jobs:
+      - job: Build
+        displayName: "Build MSAL Go"
+        pool:
+          vmImage: "ubuntu-latest"
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Go@0
+            inputs:
+              command: "get"
+              arguments: "-d -v -t -d ./..."
+              workingDirectory: "$(System.DefaultWorkingDirectory)"
+            displayName: "Install dependencies"
+          - task: Go@0
+            inputs:
+              command: "build"
+              arguments: "./apps/..."
+              workingDirectory: "$(System.DefaultWorkingDirectory)"
+            displayName: "Build"
 
-  - task: Go@0
-    inputs:
-      command: "test"
-      arguments: "-race ./apps/tests/integration/..."
-      workingDirectory: "$(System.DefaultWorkingDirectory)"
-    displayName: "Run Integration Tests"
+  # ──────────────────────────────────────────────
+  # Stage 2 — Unit Tests
+  # ──────────────────────────────────────────────
+  - stage: UnitTests
+    displayName: "Unit Tests"
+    dependsOn: Build
+    jobs:
+      - job: UnitTests
+        displayName: "Run Unit Tests"
+        pool:
+          vmImage: "ubuntu-latest"
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Go@0
+            inputs:
+              command: "get"
+              arguments: "-d -v -t -d ./..."
+              workingDirectory: "$(System.DefaultWorkingDirectory)"
+            displayName: "Install dependencies"
+          - task: Bash@3
+            displayName: "Run Unit Tests"
+            inputs:
+              targetType: "inline"
+              workingDirectory: "$(System.DefaultWorkingDirectory)"
+              script: |
+                set -e
+                go install gotest.tools/gotestsum@latest
+                export PATH="$PATH:$(go env GOPATH)/bin"
+                gotestsum --junitfile "$(Build.SourcesDirectory)/unit-tests.xml" -- \
+                  -race -short ./apps/cache/... ./apps/confidential/... ./apps/public/... ./apps/internal/... ./apps/managedidentity/...
+          - task: PublishTestResults@2
+            displayName: "Publish unit test results"
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFormat: "JUnit"
+              testResultsFiles: "**/unit-tests.xml"
+              testRunTitle: "Unit Tests"
+
+  # ──────────────────────────────────────────────
+  # Stage 3 — Integration Tests
+  # ──────────────────────────────────────────────
+  - stage: IntegrationTests
+    displayName: "Integration Tests"
+    dependsOn: Build
+    jobs:
+      - job: IntegrationTests
+        displayName: "Run Integration Tests"
+        pool:
+          vmImage: "ubuntu-latest"
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: $(goVersion)
+          - task: Go@0
+            inputs:
+              command: "get"
+              arguments: "-d -v -t -d ./..."
+              workingDirectory: "$(System.DefaultWorkingDirectory)"
+            displayName: "Install dependencies"
+          - task: AzureKeyVault@2
+            displayName: "Connect to Key Vault"
+            inputs:
+              azureSubscription: "AuthSdkResourceManager"
+              KeyVaultName: "msidlabs"
+              SecretsFilter: "LabAuth,IDLABS-APP-Confidential-Client-Cert-OnPrem"
+          - task: Bash@3
+            displayName: "Installing certificate"
+            inputs:
+              targetType: "inline"
+              script: |
+                echo $(LabAuth) | base64 -d > $(Build.SourcesDirectory)/cert.pfx
+                OPENSSL_CONF=/dev/null openssl pkcs12 -in $(Build.SourcesDirectory)/cert.pfx -out $(Build.SourcesDirectory)/cert.pem -nodes -passin pass:'' -legacy
+                echo "$(IDLABS-APP-Confidential-Client-Cert-OnPrem)" | base64 -d > $(Build.SourcesDirectory)/ccaCert.pfx
+                OPENSSL_CONF=/dev/null openssl pkcs12 -in $(Build.SourcesDirectory)/ccaCert.pfx -out $(Build.SourcesDirectory)/ccaCert.pem -nodes -passin pass:'' -legacy
+          - task: Bash@3
+            displayName: "Run Integration Tests"
+            inputs:
+              targetType: "inline"
+              workingDirectory: "$(System.DefaultWorkingDirectory)"
+              script: |
+                set -e
+                go install gotest.tools/gotestsum@latest
+                export PATH="$PATH:$(go env GOPATH)/bin"
+                gotestsum --junitfile "$(Build.SourcesDirectory)/integration-tests.xml" -- \
+                  -race ./apps/tests/integration/...
+          - task: PublishTestResults@2
+            displayName: "Publish integration test results"
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFormat: "JUnit"
+              testResultsFiles: "**/integration-tests.xml"
+              testRunTitle: "Integration Tests"

--- a/ado/build_test.yaml
+++ b/ado/build_test.yaml
@@ -67,7 +67,7 @@ stages:
               workingDirectory: "$(System.DefaultWorkingDirectory)"
               script: |
                 set -e
-                go install gotest.tools/gotestsum@latest
+                go install gotest.tools/gotestsum@v1.12.2
                 export PATH="$PATH:$(go env GOPATH)/bin"
                 gotestsum --junitfile "$(Build.SourcesDirectory)/unit-tests.xml" -- \
                   -race -short ./apps/cache/... ./apps/confidential/... ./apps/public/... ./apps/internal/... ./apps/managedidentity/...
@@ -122,7 +122,7 @@ stages:
               workingDirectory: "$(System.DefaultWorkingDirectory)"
               script: |
                 set -e
-                go install gotest.tools/gotestsum@latest
+                go install gotest.tools/gotestsum@v1.12.2
                 export PATH="$PATH:$(go env GOPATH)/bin"
                 gotestsum --junitfile "$(Build.SourcesDirectory)/integration-tests.xml" -- \
                   -race ./apps/tests/integration/...


### PR DESCRIPTION
## Summary

Refactors the single-job `ado/build_test.yaml` into **three stages** — **Build**, **Unit Tests**, **Integration Tests** — mirroring the MSAL .NET pipeline layout so each section reports independently in Azure DevOps (instead of one long job).

## Before / After

**Before:** one `steps:` job (`GoTool → go get → go build → unit tests → Key Vault + cert → integration tests`).

**After:** `stages:`
- **Build** — `GoTool` + `go build ./apps/...`
- **Unit Tests** (`dependsOn: Build`) — `go test -race -short ./apps/cache/... ./apps/confidential/... ./apps/public/... ./apps/internal/... ./apps/managedidentity/...`
- **Integration Tests** (`dependsOn: Build`) — Key Vault + cert install + `go test -race ./apps/tests/integration/...`

## Notes

- **No change to what is built or tested** — same commands, same coverage, same Key Vault secrets and cert setup.
- Each stage runs on `ubuntu-latest` and re-installs the Go toolchain + deps (Go builds are cheap; keeps stages independent, matching how MSAL .NET's stages build from source).
- Adds **`gotestsum` + `PublishTestResults@2`** so per-stage **pass rates** show up in the ADO test UI (Go's default `go test` doesn't publish results). If you'd rather keep PR 1 minimal, the `gotestsum` bits can be dropped and we revert to the `Go@0` test task.
- Go version is lifted into a `goVersion` variable (`1.22.3`).

## Follow-up

A second PR will add the **Managed Identity v1 (IMDS) E2E** stage on the `MISEManagedIdentity` pool (the same agent MSAL .NET uses), plus a Go E2E test.

---

🤖 Prototyped during an investigation with GitHub Copilot.
