### PR TITLE
Harden regional authority validation

### DIFF
--- a/apps/confidential/confidential_test.go
+++ b/apps/confidential/confidential_test.go
@@ -222,6 +222,28 @@ func TestAcquireTokenByCredentialWithCache(t *testing.T) {
 
 }
 
+func TestInvalidMSALForceRegionIsRejectedBeforeHTTP(t *testing.T) {
+	t.Setenv("MSAL_FORCE_REGION", "hostile.example/x")
+
+	cred, err := NewCredFromSecret(fakeSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := New(
+		fmt.Sprintf(authorityFmt, "login.microsoftonline.com", "tenant"),
+		fakeClientID,
+		cred,
+		WithHTTPClient(&errorClient{}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.AcquireTokenByCredential(context.Background(), tokenScope); err == nil || !strings.Contains(err.Error(), "invalid region") {
+		t.Fatalf("AcquireTokenByCredential() error = %v, want invalid region error", err)
+	}
+}
+
 func TestRegionAutoEnable_EmptyRegion_EnvRegion(t *testing.T) {
 	cred, err := NewCredFromSecret(fakeSecret)
 	if err != nil {

--- a/apps/internal/oauth/ops/authority/authority.go
+++ b/apps/internal/oauth/ops/authority/authority.go
@@ -44,8 +44,8 @@ const (
 	loginMicrosoftOnline = defaultHost
 )
 
-// validRegion matches Azure region names: lowercase alphanumeric and hyphens only.
-var validRegion = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+// validRegion matches Azure region names that are valid lowercase ASCII DNS labels.
+var validRegion = regexp.MustCompile(`^[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
 
 // jsonCaller is an interface that allows us to mock the JSONCall method.
 type jsonCaller interface {
@@ -669,14 +669,14 @@ func (c Client) AADInstanceDiscovery(ctx context.Context, authorityInfo Info) (I
 	var err error
 	resp := InstanceDiscoveryResponse{}
 	if authorityInfo.Region != "" && authorityInfo.Region != autoDetectRegion {
+		if !validRegion.MatchString(authorityInfo.Region) {
+			return resp, fmt.Errorf("invalid region %q: region must be a lowercase ASCII DNS label of at most 63 characters", authorityInfo.Region)
+		}
 		region = authorityInfo.Region
 	} else if authorityInfo.Region == autoDetectRegion {
 		region = detectRegion(ctx)
 	}
 	if region != "" {
-		if !validRegion.MatchString(region) {
-			return resp, fmt.Errorf("invalid region %q: region must contain only lowercase alphanumeric characters and hyphens", region)
-		}
 		environment := authorityInfo.Host
 		switch environment {
 		case loginMicrosoft, loginWindows, loginSTSWindows, defaultHost:
@@ -717,8 +717,10 @@ func (c Client) AADInstanceDiscovery(ctx context.Context, authorityInfo Info) (I
 func detectRegion(ctx context.Context) string {
 	region := os.Getenv(regionName)
 	if region != "" {
-		region = strings.ReplaceAll(region, " ", "")
-		return strings.ToLower(region)
+		if validRegion.MatchString(region) {
+			return region
+		}
+		return ""
 	}
 	// HTTP call to IMDS endpoint to get region
 	// Refer : https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=%2FPinAuthToRegion%2FAAD%20SDK%20Proposal%20to%20Pin%20Auth%20to%20region.md&_a=preview&version=GBdev
@@ -758,6 +760,9 @@ type imdsComputeResponse struct {
 func parseRegionFromIMDSResponse(body []byte) string {
 	var parsed imdsComputeResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	if !validRegion.MatchString(parsed.Location) {
 		return ""
 	}
 	return parsed.Location

--- a/apps/internal/oauth/ops/authority/authority_test.go
+++ b/apps/internal/oauth/ops/authority/authority_test.go
@@ -313,9 +313,16 @@ func TestAADInstanceDiscoveryInvalidRegion(t *testing.T) {
 		{"contains space", "east us"},
 		{"starts with digit", "1eastus"},
 		{"starts with hyphen", "-eastus"},
+		{"ends with hyphen", "eastus-"},
 		{"contains underscore", "east_us"},
 		{"contains special char", "east$us"},
 		{"path traversal attempt", "../evil"},
+		{"URL", "https://eastus.example.com"},
+		{"port", "eastus:443"},
+		{"whitespace", " eastus"},
+		{"tab", "eastus\t"},
+		{"Unicode", "eastusé"},
+		{"too long", "a" + strings.Repeat("b", 63)},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			authInfo := Info{Host: "login.microsoft.com", Tenant: "tenant", Region: test.region}
@@ -340,6 +347,7 @@ func TestAADInstanceDiscoveryValidRegion(t *testing.T) {
 		"a",
 		"a1",
 		"a-1",
+		"a" + strings.Repeat("b", 61),
 	} {
 		t.Run(region, func(t *testing.T) {
 			authInfo := Info{Host: "login.microsoft.com", Tenant: "tenant", Region: region}
@@ -1032,8 +1040,18 @@ func TestParseRegionFromIMDSResponse(t *testing.T) {
 	}{
 		{name: "valid location", body: `{"location":"westus2"}`, want: "westus2"},
 		{name: "location among other fields", body: `{"location":"eastus","name":"vm"}`, want: "eastus"},
+		{name: "maximum length", body: `{"location":"a` + strings.Repeat("b", 61) + `"}`, want: "a" + strings.Repeat("b", 61)},
 		{name: "missing location", body: `{}`, want: ""},
 		{name: "null location", body: `{"location":null}`, want: ""},
+		{name: "trailing hyphen", body: `{"location":"westus-"}`, want: ""},
+		{name: "uppercase", body: `{"location":"WestUS"}`, want: ""},
+		{name: "dot", body: `{"location":"west.us"}`, want: ""},
+		{name: "URL", body: `{"location":"https://westus.example.com"}`, want: ""},
+		{name: "port", body: `{"location":"westus:443"}`, want: ""},
+		{name: "path", body: `{"location":"westus/path"}`, want: ""},
+		{name: "whitespace", body: `{"location":" westus "}`, want: ""},
+		{name: "Unicode", body: `{"location":"westusé"}`, want: ""},
+		{name: "too long", body: `{"location":"a` + strings.Repeat("b", 63) + `"}`, want: ""},
 		{name: "malformed json", body: `not json`, want: ""},
 		{name: "empty body", body: ``, want: ""},
 	}
@@ -1041,6 +1059,40 @@ func TestParseRegionFromIMDSResponse(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := parseRegionFromIMDSResponse([]byte(test.body)); got != test.want {
 				t.Fatalf("parseRegionFromIMDSResponse(%q) = %q, want %q", test.body, got, test.want)
+			}
+		})
+	}
+}
+
+func TestAADInstanceDiscoveryInvalidAutoDetectedRegionFallsBackToGlobal(t *testing.T) {
+	for _, region := range []string{
+		"westus-",
+		"WestUS",
+		"west.us",
+		" https://westus.example.com ",
+		"eastus:443",
+		"eastus/path",
+		"eastusé",
+		"a" + strings.Repeat("b", 63),
+	} {
+		t.Run(region, func(t *testing.T) {
+			t.Setenv(regionName, region)
+			fake := &fakeJSONCaller{}
+			client := Client{fake}
+
+			resp, err := client.AADInstanceDiscovery(context.Background(), Info{
+				Host:   defaultHost,
+				Tenant: "tenant",
+				Region: autoDetectRegion,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if fake.gotEndpoint != fmt.Sprintf(aadInstanceDiscoveryEndpoint, defaultHost) {
+				t.Fatalf("got endpoint %q, want global discovery endpoint", fake.gotEndpoint)
+			}
+			if len(resp.Metadata) != 0 || resp.TenantDiscoveryEndpoint != "" {
+				t.Fatalf("invalid auto-detected region must not produce regional metadata: %#v", resp)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- enforce lowercase ASCII DNS-label validation for explicit regional authorities
- ignore invalid `REGION_NAME` and IMDS regions so discovery falls back to global behavior
- cover DNS-label boundaries and invalid automatic-detection values

## Testing
- `go test ./apps/internal/oauth/ops/authority -count=1`