### PR TITLE
Fix WS-Trust endpoint selection helper

### DIFF
--- a/apps/internal/oauth/ops/wstrust/defs/wstrust_mex_document.go
+++ b/apps/internal/oauth/ops/wstrust/defs/wstrust_mex_document.go
@@ -34,15 +34,14 @@ type MexDocument struct {
 	bindings                 map[string]wsEndpointData
 }
 
-func updateEndpoint(cached *Endpoint, found Endpoint) {
-	if cached == nil || cached.Version == TrustUnknown {
-		*cached = found
-		return
+func updateEndpoint(cached Endpoint, found Endpoint) Endpoint {
+	if cached.Version == TrustUnknown {
+		return found
 	}
-	if (*cached).Version == Trust2005 && found.Version == Trust13 {
-		*cached = found
-		return
+	if cached.Version == Trust2005 && found.Version == Trust13 {
+		return found
 	}
+	return cached
 }
 
 // TODO(msal): Someone needs to write tests for everything below.
@@ -147,9 +146,9 @@ func endpoints(defs Definitions, bindings map[string]wsEndpointData) (userPass, 
 
 			switch binding.EndpointType {
 			case etUsernamePassword:
-				updateEndpoint(&userPass, endpoint)
+				userPass = updateEndpoint(userPass, endpoint)
 			case etWindowsTransport:
-				updateEndpoint(&windows, endpoint)
+				windows = updateEndpoint(windows, endpoint)
 			default:
 				return Endpoint{}, Endpoint{}, errors.New("found unknown port type in MEX document")
 			}

--- a/apps/internal/oauth/ops/wstrust/defs/wstrust_mex_document_test.go
+++ b/apps/internal/oauth/ops/wstrust/defs/wstrust_mex_document_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package defs
+
+import "testing"
+
+func TestUpdateEndpoint(t *testing.T) {
+	testCases := []struct {
+		name   string
+		cached Endpoint
+		found  Endpoint
+		want   Endpoint
+	}{
+		{
+			name:   "selects first endpoint",
+			cached: Endpoint{},
+			found:  Endpoint{Version: Trust2005, URL: "https://2005.example"},
+			want:   Endpoint{Version: Trust2005, URL: "https://2005.example"},
+		},
+		{
+			name:   "upgrades from WS-Trust 2005 to 1.3",
+			cached: Endpoint{Version: Trust2005, URL: "https://2005.example"},
+			found:  Endpoint{Version: Trust13, URL: "https://13.example"},
+			want:   Endpoint{Version: Trust13, URL: "https://13.example"},
+		},
+		{
+			name:   "retains WS-Trust 1.3 over 2005",
+			cached: Endpoint{Version: Trust13, URL: "https://13.example"},
+			found:  Endpoint{Version: Trust2005, URL: "https://2005.example"},
+			want:   Endpoint{Version: Trust13, URL: "https://13.example"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := updateEndpoint(testCase.cached, testCase.found); got != testCase.want {
+				t.Errorf("updateEndpoint(%+v, %+v) = %+v, want %+v", testCase.cached, testCase.found, got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replaces the pointer-based endpoint selection helper with a value-based contract to eliminate its invalid nil state. Adds tests for initial selection and WS-Trust 1.3 preference.
#571 