### PR TITLE
fix(managedidentity): pin Service Fabric TLS certificate

### DIFF
--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -273,7 +273,7 @@ func New(id ID, options ...ClientOption) (Client, error) {
 		option(&client)
 	}
 	if source == ServiceFabric {
-		serviceFabricClient, serviceFabricURL, err := serviceFabricHTTPClient(client.httpClient)
+		serviceFabricClient, serviceFabricURL, err := serviceFabricCertificateVerifiedHTTPClient(client.httpClient)
 		if err != nil {
 			return Client{}, err
 		}

--- a/apps/managedidentity/managedidentity.go
+++ b/apps/managedidentity/managedidentity.go
@@ -178,6 +178,7 @@ type Client struct {
 	httpClient         ops.HTTPClient
 	miType             ID
 	source             Source
+	serviceFabricURL   string
 	authParams         authority.AuthParams
 	retryPolicyEnabled bool
 	canRefresh         *atomic.Value
@@ -199,7 +200,8 @@ func WithClaims(claims string) AcquireTokenOption {
 	}
 }
 
-// WithHTTPClient allows for a custom HTTP client to be set.
+// WithHTTPClient allows for a custom HTTP client to be set. Service Fabric requires a standard
+// *http.Client with a *http.Transport and does not support custom TLS dialing or verification.
 func WithHTTPClient(httpClient ops.HTTPClient) ClientOption {
 	return func(c *Client) {
 		c.httpClient = httpClient
@@ -269,6 +271,14 @@ func New(id ID, options ...ClientOption) (Client, error) {
 	}
 	for _, option := range options {
 		option(&client)
+	}
+	if source == ServiceFabric {
+		serviceFabricClient, serviceFabricURL, err := serviceFabricHTTPClient(client.httpClient)
+		if err != nil {
+			return Client{}, err
+		}
+		client.httpClient = serviceFabricClient
+		client.serviceFabricURL = serviceFabricURL
 	}
 	fakeAuthInfo, err := authority.NewInfoFromAuthorityURI("https://login.microsoftonline.com/managed_identity", false, true)
 	if err != nil {
@@ -410,7 +420,7 @@ func (c Client) acquireTokenForAzureML(ctx context.Context, resource string) (Au
 }
 
 func (c Client) acquireTokenForServiceFabric(ctx context.Context, resource string) (AuthResult, error) {
-	req, err := createServiceFabricAuthRequest(ctx, resource)
+	req, err := createServiceFabricAuthRequest(ctx, c.serviceFabricURL, resource)
 	if err != nil {
 		return AuthResult{}, err
 	}

--- a/apps/managedidentity/servicefabric.go
+++ b/apps/managedidentity/servicefabric.go
@@ -5,13 +5,127 @@ package managedidentity
 
 import (
 	"context"
+
+	/* #nosec */
+	"crypto/sha1"
+	"crypto/subtle"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
 	"net/http"
 	"os"
+	"strings"
+	"unicode"
 )
 
-func createServiceFabricAuthRequest(ctx context.Context, resource string) (*http.Request, error) {
-	identityEndpoint := os.Getenv(identityEndpointEnvVar)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, identityEndpoint, nil)
+// serviceFabricHTTPClient derives a client with Service Fabric's required certificate pinning.
+// Only standard clients and transports can be safely cloned and augmented without changing the
+// caller's behavior for other requests.
+func serviceFabricHTTPClient(httpClient interface {
+	Do(*http.Request) (*http.Response, error)
+	CloseIdleConnections()
+}) (*http.Client, string, error) {
+	endpoint, err := serviceFabricEndpoint()
+	if err != nil {
+		return nil, "", err
+	}
+	pin, err := serviceFabricThumbprint(os.Getenv(identityServerThumbprintEnvVar))
+	if err != nil {
+		return nil, "", err
+	}
+
+	callerClient, ok := httpClient.(*http.Client)
+	if !ok {
+		return nil, "", errors.New("Service Fabric managed identity requires a standard *http.Client")
+	}
+	derivedClient := *callerClient
+
+	var callerTransport *http.Transport
+	if callerClient.Transport == nil {
+		var ok bool
+		callerTransport, ok = http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return nil, "", errors.New("Service Fabric managed identity requires a standard *http.Transport")
+		}
+	} else {
+		var ok bool
+		callerTransport, ok = callerClient.Transport.(*http.Transport)
+		if !ok {
+			return nil, "", errors.New("Service Fabric managed identity requires a standard *http.Transport")
+		}
+	}
+	//nolint:staticcheck // DialTLS must be rejected because it bypasses TLSClientConfig.
+	if callerTransport.DialTLS != nil || callerTransport.DialTLSContext != nil {
+		return nil, "", errors.New("Service Fabric managed identity does not support a transport with custom TLS dialing")
+	}
+	if callerTransport.TLSClientConfig != nil &&
+		(callerTransport.TLSClientConfig.VerifyPeerCertificate != nil || callerTransport.TLSClientConfig.VerifyConnection != nil) {
+		return nil, "", errors.New("Service Fabric managed identity does not support custom TLS verification")
+	}
+	if callerTransport.TLSNextProto != nil {
+		return nil, "", errors.New("Service Fabric managed identity does not support custom TLS protocol handlers")
+	}
+	derivedTransport := callerTransport.Clone()
+	tlsConfig := derivedTransport.TLSClientConfig.Clone()
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+	tlsConfig.InsecureSkipVerify = true // #nosec G402 -- VerifyConnection below pins the Service Fabric self-signed certificate.
+	tlsConfig.VerifyConnection = func(connectionState tls.ConnectionState) error {
+		if len(connectionState.PeerCertificates) == 0 {
+			return errors.New("Service Fabric TLS connection did not provide a certificate")
+		}
+		if subtle.ConstantTimeCompare(serviceFabricCertificateThumbprint(connectionState.PeerCertificates[0]), pin) != 1 {
+			return errors.New("Service Fabric TLS certificate thumbprint did not match IDENTITY_SERVER_THUMBPRINT")
+		}
+		return nil
+	}
+	derivedTransport.TLSClientConfig = tlsConfig
+	derivedClient.Transport = derivedTransport
+	derivedClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return errors.New("Service Fabric managed identity redirects are not permitted")
+	}
+	return &derivedClient, endpoint, nil
+}
+
+func serviceFabricEndpoint() (string, error) {
+	endpoint := os.Getenv(identityEndpointEnvVar)
+	request, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	if request.URL.Scheme != "https" || request.URL.Host == "" {
+		return "", errors.New("Service Fabric managed identity endpoint must use HTTPS")
+	}
+	return request.URL.String(), nil
+}
+
+func serviceFabricThumbprint(value string) ([]byte, error) {
+	normalized := strings.Map(func(r rune) rune {
+		if r == ':' || unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, value)
+	if len(normalized) != 40 {
+		return nil, errors.New("IDENTITY_SERVER_THUMBPRINT must be a SHA-1 certificate thumbprint")
+	}
+	thumbprint, err := hex.DecodeString(normalized)
+	if err != nil || len(thumbprint) != 20 {
+		return nil, errors.New("IDENTITY_SERVER_THUMBPRINT must be a SHA-1 certificate thumbprint")
+	}
+	return thumbprint, nil
+}
+
+func serviceFabricCertificateThumbprint(certificate *x509.Certificate) []byte {
+	// Service Fabric exposes SHA-1 certificate thumbprints through IDENTITY_SERVER_THUMBPRINT.
+	thumbprint := sha1.Sum(certificate.Raw) // #nosec G401 -- Service Fabric publishes SHA-1 thumbprints.
+	return thumbprint[:]
+}
+
+func createServiceFabricAuthRequest(ctx context.Context, endpoint, resource string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/managedidentity/servicefabric.go
+++ b/apps/managedidentity/servicefabric.go
@@ -19,10 +19,10 @@ import (
 	"unicode"
 )
 
-// serviceFabricHTTPClient derives a client with Service Fabric's required certificate pinning.
+// serviceFabricCertificateVerifiedHTTPClient derives a client with Service Fabric's required certificate pinning.
 // Only standard clients and transports can be safely cloned and augmented without changing the
 // caller's behavior for other requests.
-func serviceFabricHTTPClient(httpClient interface {
+func serviceFabricCertificateVerifiedHTTPClient(httpClient interface {
 	Do(*http.Request) (*http.Response, error)
 	CloseIdleConnections()
 }) (*http.Client, string, error) {
@@ -120,7 +120,7 @@ func serviceFabricThumbprint(value string) ([]byte, error) {
 
 func serviceFabricCertificateThumbprint(certificate *x509.Certificate) []byte {
 	// Service Fabric exposes SHA-1 certificate thumbprints through IDENTITY_SERVER_THUMBPRINT.
-	thumbprint := sha1.Sum(certificate.Raw) // #nosec G401 -- Service Fabric publishes SHA-1 thumbprints.
+	thumbprint := sha1.Sum(certificate.Raw) /* #nosec G401 -- Service Fabric publishes SHA-1 thumbprints. */ // NOSONAR -- Service Fabric defines IDENTITY_SERVER_THUMBPRINT as the SHA-1 hash of its self-signed endpoint certificate; this compares that platform-defined identifier, not a security digest.
 	return thumbprint[:]
 }
 

--- a/apps/managedidentity/servicefabric_test.go
+++ b/apps/managedidentity/servicefabric_test.go
@@ -5,112 +5,369 @@ package managedidentity
 
 import (
 	"context"
+	"crypto/sha1"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"net"
 	"net/http"
-	"net/url"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/base"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/base/storage"
-	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/mock"
 )
 
-func TestServiceFabricAcquireTokenReturnsTokenSuccess(t *testing.T) {
-	setEnvVars(t, ServiceFabric)
-	testCases := []struct {
-		resource string
-		miType   ID
-	}{
-		{resource: resource, miType: SystemAssigned()},
-		{resource: resourceDefaultSuffix, miType: SystemAssigned()},
+type serviceFabricCustomHTTPClient struct{}
+
+func (serviceFabricCustomHTTPClient) Do(*http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (serviceFabricCustomHTTPClient) CloseIdleConnections() {}
+
+type serviceFabricRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f serviceFabricRoundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestServiceFabricAcquireTokenWithPinnedCertificate(t *testing.T) {
+	var requests int32
+	var receivedRequest *http.Request
+	responseBody, err := getSuccessfulResponse(resource, true)
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, testCase := range testCases {
-		t.Run(string(DefaultToIMDS)+"-"+testCase.miType.value(), func(t *testing.T) {
-			endpoint := imdsDefaultEndpoint
-			var localUrl *url.URL
-			var localHeader http.Header
-			mockClient := mock.NewClient()
-			responseBody, err := getSuccessfulResponse(resource, true)
-			if err != nil {
-				t.Fatalf(errorFormingJsonResponse, err.Error())
-			}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		receivedRequest = request.Clone(request.Context())
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write(responseBody)
+	}))
+	defer server.Close()
 
-			mockClient.AppendResponse(mock.WithHTTPStatusCode(http.StatusOK), mock.WithBody(responseBody), mock.WithCallback(func(r *http.Request) {
-				localUrl = r.URL
-				localHeader = r.Header
-			}))
-			// resetting cache
-			before := cacheManager
-			defer func() { cacheManager = before }()
-			cacheManager = storage.New(nil)
+	setServiceFabricEnvironment(t, server.URL, serviceFabricServerThumbprint(server))
+	resetServiceFabricCache(t)
 
-			client, err := New(testCase.miType, WithHTTPClient(mockClient))
-			if err != nil {
-				t.Fatal(err)
-			}
-			result, err := client.AcquireToken(context.Background(), testCase.resource)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if localUrl == nil || !strings.HasPrefix(localUrl.String(), "http://localhost:40342/metadata/identity/oauth2/token") {
-				t.Fatalf("url request is not on %s got %s", endpoint, localUrl)
-			}
-			query := localUrl.Query()
+	client, err := New(SystemAssigned(), WithHTTPClient(server.Client()), WithRetryPolicyDisabled())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var changedEndpointRequests int32
+	changedEndpoint := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		atomic.AddInt32(&changedEndpointRequests, 1)
+		if request.Header.Get("Secret") != "" {
+			t.Error("Secret was sent after IDENTITY_ENDPOINT changed")
+		}
+		response.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer changedEndpoint.Close()
+	t.Setenv(identityEndpointEnvVar, changedEndpoint.URL)
 
-			if got := query.Get(apiVersionQueryParameterName); got != serviceFabricAPIVersion {
-				t.Fatalf("api-version not on %s got %s", serviceFabricAPIVersion, got)
-			}
-			if query.Get(resourceQueryParameterName) != strings.TrimSuffix(testCase.resource, "/.default") {
-				t.Fatal("suffix /.default was not removed.")
-			}
-			if localHeader.Get("Accept") != "application/json" {
-				t.Fatalf("expected Accept header to be application/json, got %s", localHeader.Get("Accept"))
-			}
-			if localHeader.Get("Secret") != "secret" {
-				t.Fatalf("expected secret to be secret, got %s", query.Get("Secret"))
-			}
-			if result.Metadata.TokenSource != base.TokenSourceIdentityProvider {
-				t.Fatalf("expected IndenityProvider tokensource, got %d", result.Metadata.TokenSource)
-			}
-			if result.AccessToken != token {
-				t.Fatalf("wanted %q, got %q", token, result.AccessToken)
-			}
-			result, err = client.AcquireToken(context.Background(), testCase.resource)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if result.Metadata.TokenSource != base.TokenSourceCache {
-				t.Fatalf("wanted cache token source, got %d", result.Metadata.TokenSource)
-			}
-			secondFakeClient, err := New(testCase.miType, WithHTTPClient(mockClient))
-			if err != nil {
-				t.Fatal(err)
-			}
-			result, err = secondFakeClient.AcquireToken(context.Background(), testCase.resource)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if result.Metadata.TokenSource != base.TokenSourceCache {
-				t.Fatalf("cache result wanted cache token source, got %d", result.Metadata.TokenSource)
-			}
-		})
+	result, err := client.AcquireToken(context.Background(), resourceDefaultSuffix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receivedRequest == nil {
+		t.Fatal("expected Service Fabric request")
+	}
+	if receivedRequest.URL.Query().Get(apiVersionQueryParameterName) != serviceFabricAPIVersion {
+		t.Fatalf("expected api version %q", serviceFabricAPIVersion)
+	}
+	if receivedRequest.URL.Query().Get(resourceQueryParameterName) != resource {
+		t.Fatalf("expected resource %q", resource)
+	}
+	if receivedRequest.Header.Get("Accept") != "application/json" {
+		t.Fatalf("expected Accept header to be application/json, got %q", receivedRequest.Header.Get("Accept"))
+	}
+	if receivedRequest.Header.Get("Secret") != "secret" {
+		t.Fatalf("expected Secret header to be set, got %q", receivedRequest.Header.Get("Secret"))
+	}
+	if result.Metadata.TokenSource != base.TokenSourceIdentityProvider {
+		t.Fatalf("expected identity provider token source, got %d", result.Metadata.TokenSource)
+	}
+	if result.AccessToken != token {
+		t.Fatalf("wanted %q, got %q", token, result.AccessToken)
+	}
+
+	result, err = client.AcquireToken(context.Background(), resource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Metadata.TokenSource != base.TokenSourceCache {
+		t.Fatalf("expected cache token source, got %d", result.Metadata.TokenSource)
+	}
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("expected one Service Fabric request, got %d", got)
+	}
+	if got := atomic.LoadInt32(&changedEndpointRequests); got != 0 {
+		t.Fatalf("expected no request to changed endpoint, got %d", got)
 	}
 }
+
+func TestServiceFabricRejectsMismatchedCertificateBeforeRequest(t *testing.T) {
+	var requests int32
+	var receivedSecret string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		receivedSecret = request.Header.Get("Secret")
+		response.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	setServiceFabricEnvironment(t, server.URL, strings.Repeat("0", 40))
+	resetServiceFabricCache(t)
+
+	client, err := New(SystemAssigned(), WithHTTPClient(server.Client()), WithRetryPolicyDisabled())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.AcquireToken(context.Background(), resource)
+	if err == nil {
+		t.Fatal("expected a thumbprint validation error")
+	}
+	if got := atomic.LoadInt32(&requests); got != 0 {
+		t.Fatalf("expected no HTTP request after a thumbprint mismatch, got %d", got)
+	}
+	if receivedSecret != "" {
+		t.Fatalf("expected no Secret to be transmitted, got %q", receivedSecret)
+	}
+}
+
+func TestServiceFabricDerivedClientPreservesCallerConfiguration(t *testing.T) {
+	responseBody, err := getSuccessfulResponse(resource, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write(responseBody)
+	}))
+	defer server.Close()
+
+	setServiceFabricEnvironment(t, server.URL, serviceFabricServerThumbprint(server))
+	resetServiceFabricCache(t)
+
+	callerTransport := server.Client().Transport.(*http.Transport).Clone()
+	callerTLSConfig := callerTransport.TLSClientConfig.Clone()
+	callerTLSConfig.MinVersion = tls.VersionTLS12
+	callerTLSConfig.ServerName = "caller.example"
+	callerTransport.TLSClientConfig = callerTLSConfig
+	callerTransport.MaxIdleConns = 17
+	callerTransport.ResponseHeaderTimeout = 3 * time.Second
+	callerClient := &http.Client{
+		Transport: callerTransport,
+		Timeout:   4 * time.Second,
+	}
+
+	client, err := New(SystemAssigned(), WithHTTPClient(callerClient), WithRetryPolicyDisabled())
+	if err != nil {
+		t.Fatal(err)
+	}
+	derivedClient, ok := client.httpClient.(*http.Client)
+	if !ok {
+		t.Fatalf("expected derived *http.Client, got %T", client.httpClient)
+	}
+	if derivedClient == callerClient {
+		t.Fatal("Service Fabric client must not reuse the caller client")
+	}
+	if derivedClient.Timeout != callerClient.Timeout {
+		t.Fatalf("expected timeout %v, got %v", callerClient.Timeout, derivedClient.Timeout)
+	}
+	derivedTransport, ok := derivedClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected derived *http.Transport, got %T", derivedClient.Transport)
+	}
+	if derivedTransport == callerTransport {
+		t.Fatal("Service Fabric client must not reuse the caller transport")
+	}
+	if derivedTransport.MaxIdleConns != callerTransport.MaxIdleConns {
+		t.Fatalf("expected MaxIdleConns %d, got %d", callerTransport.MaxIdleConns, derivedTransport.MaxIdleConns)
+	}
+	if derivedTransport.ResponseHeaderTimeout != callerTransport.ResponseHeaderTimeout {
+		t.Fatalf("expected ResponseHeaderTimeout %v, got %v", callerTransport.ResponseHeaderTimeout, derivedTransport.ResponseHeaderTimeout)
+	}
+	if derivedTransport.TLSClientConfig == callerTLSConfig {
+		t.Fatal("Service Fabric client must not reuse the caller TLS config")
+	}
+	if derivedTransport.TLSClientConfig.MinVersion != callerTLSConfig.MinVersion {
+		t.Fatalf("expected TLS minimum version %d, got %d", callerTLSConfig.MinVersion, derivedTransport.TLSClientConfig.MinVersion)
+	}
+	if derivedTransport.TLSClientConfig.ServerName != callerTLSConfig.ServerName {
+		t.Fatalf("expected TLS server name %q, got %q", callerTLSConfig.ServerName, derivedTransport.TLSClientConfig.ServerName)
+	}
+	if callerTLSConfig.InsecureSkipVerify {
+		t.Fatal("caller TLS config was modified")
+	}
+
+	if derivedTransport.TLSClientConfig.VerifyConnection == nil {
+		t.Fatal("expected Service Fabric TLS verification callback")
+	}
+	if _, err = client.AcquireToken(context.Background(), resource); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServiceFabricRejectsUnsupportedClientsAndEndpoints(t *testing.T) {
+	server := httptest.NewTLSServer(http.NotFoundHandler())
+	defer server.Close()
+	validThumbprint := serviceFabricServerThumbprint(server)
+
+	t.Run("HTTP endpoint", func(t *testing.T) {
+		setServiceFabricEnvironment(t, strings.Replace(server.URL, "https://", "http://", 1), validThumbprint)
+		_, err := New(SystemAssigned(), WithHTTPClient(server.Client()))
+		if err == nil || !strings.Contains(err.Error(), "must use HTTPS") {
+			t.Fatalf("expected HTTPS endpoint error, got %v", err)
+		}
+	})
+	t.Run("invalid thumbprint", func(t *testing.T) {
+		setServiceFabricEnvironment(t, server.URL, "not-a-thumbprint")
+		_, err := New(SystemAssigned(), WithHTTPClient(server.Client()))
+		if err == nil || !strings.Contains(err.Error(), identityServerThumbprintEnvVar) {
+			t.Fatalf("expected thumbprint error, got %v", err)
+		}
+	})
+	t.Run("custom HTTP client", func(t *testing.T) {
+		setServiceFabricEnvironment(t, server.URL, validThumbprint)
+		_, err := New(SystemAssigned(), WithHTTPClient(serviceFabricCustomHTTPClient{}))
+		if err == nil || !strings.Contains(err.Error(), "*http.Client") {
+			t.Fatalf("expected standard client error, got %v", err)
+		}
+	})
+	t.Run("custom transport", func(t *testing.T) {
+		setServiceFabricEnvironment(t, server.URL, validThumbprint)
+		customClient := &http.Client{Transport: serviceFabricRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("not implemented")
+		})}
+		_, err := New(SystemAssigned(), WithHTTPClient(customClient))
+		if err == nil || !strings.Contains(err.Error(), "*http.Transport") {
+			t.Fatalf("expected standard transport error, got %v", err)
+		}
+	})
+	t.Run("custom TLS dialer", func(t *testing.T) {
+		setServiceFabricEnvironment(t, server.URL, validThumbprint)
+		customTransport := server.Client().Transport.(*http.Transport).Clone()
+		customTransport.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("not implemented")
+		}
+		_, err := New(SystemAssigned(), WithHTTPClient(&http.Client{Transport: customTransport}))
+		if err == nil || !strings.Contains(err.Error(), "custom TLS dialing") {
+			t.Fatalf("expected custom TLS dialer error, got %v", err)
+		}
+	})
+	t.Run("custom TLS verification", func(t *testing.T) {
+		setServiceFabricEnvironment(t, server.URL, validThumbprint)
+		customTransport := server.Client().Transport.(*http.Transport).Clone()
+		customTransport.TLSClientConfig = customTransport.TLSClientConfig.Clone()
+		customTransport.TLSClientConfig.VerifyConnection = func(tls.ConnectionState) error { return nil }
+		_, err := New(SystemAssigned(), WithHTTPClient(&http.Client{Transport: customTransport}))
+		if err == nil || !strings.Contains(err.Error(), "custom TLS verification") {
+			t.Fatalf("expected custom TLS verification error, got %v", err)
+		}
+	})
+	t.Run("custom TLS protocol handler", func(t *testing.T) {
+		setServiceFabricEnvironment(t, server.URL, validThumbprint)
+		customTransport := server.Client().Transport.(*http.Transport).Clone()
+		customTransport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+		_, err := New(SystemAssigned(), WithHTTPClient(&http.Client{Transport: customTransport}))
+		if err == nil || !strings.Contains(err.Error(), "custom TLS protocol handlers") {
+			t.Fatalf("expected custom TLS protocol handler error, got %v", err)
+		}
+	})
+}
+
+func TestServiceFabricRejectsHTTPRedirectBeforeSendingSecret(t *testing.T) {
+	var redirectedRequests int32
+	var redirectedSecret string
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		atomic.AddInt32(&redirectedRequests, 1)
+		redirectedSecret = request.Header.Get("Secret")
+		response.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer redirectTarget.Close()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		http.Redirect(response, request, redirectTarget.URL, http.StatusFound)
+	}))
+	defer server.Close()
+	setServiceFabricEnvironment(t, server.URL, serviceFabricServerThumbprint(server))
+	resetServiceFabricCache(t)
+
+	client, err := New(SystemAssigned(), WithHTTPClient(server.Client()), WithRetryPolicyDisabled())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.AcquireToken(context.Background(), resource)
+	if err == nil || !strings.Contains(err.Error(), "redirects are not permitted") {
+		t.Fatalf("expected redirect rejection, got %v", err)
+	}
+	if got := atomic.LoadInt32(&redirectedRequests); got != 0 {
+		t.Fatalf("expected no HTTP redirect request, got %d", got)
+	}
+	if redirectedSecret != "" {
+		t.Fatalf("expected no Secret on HTTP redirect, got %q", redirectedSecret)
+	}
+}
+
+func TestServiceFabricLeavesCustomClientAvailableToOtherSources(t *testing.T) {
+	t.Setenv(identityEndpointEnvVar, "")
+	t.Setenv(identityHeaderEnvVar, "")
+	t.Setenv(identityServerThumbprintEnvVar, "")
+	t.Setenv(msiEndpointEnvVar, "")
+	t.Setenv(msiSecretEnvVar, "")
+	t.Setenv(imdsEndVar, "")
+	customClient := serviceFabricCustomHTTPClient{}
+
+	client, err := New(SystemAssigned(), WithHTTPClient(customClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.httpClient != customClient {
+		t.Fatal("non-Service Fabric clients must not be changed")
+	}
+}
+
 func TestServiceFabricErrors(t *testing.T) {
 	setEnvVars(t, ServiceFabric)
-	mockClient := mock.NewClient()
+	customClient := serviceFabricCustomHTTPClient{}
 
 	for _, testCase := range []ID{
 		UserAssignedObjectID("ObjectId"),
 		UserAssignedResourceID("resourceid"),
-		UserAssignedClientID("ClientID")} {
-		_, err := New(testCase, WithHTTPClient(mockClient))
+		UserAssignedClientID("ClientID"),
+	} {
+		_, err := New(testCase, WithHTTPClient(customClient))
 		if err == nil {
-			t.Fatal("expected error: Service Fabric API doesn't support specifying a user-assigned identity. The identity is determined by cluster resource configuration. See https://aka.ms/servicefabricmi")
+			t.Fatal("expected Service Fabric user-assigned identity error")
 		}
 		if err.Error() != "Service Fabric API doesn't support specifying a user-assigned identity. The identity is determined by cluster resource configuration. See https://aka.ms/servicefabricmi" {
-			t.Fatalf("expected error: Service Fabric API doesn't support specifying a user-assigned identity. The identity is determined by cluster resource configuration. See https://aka.ms/servicefabricmi, got error: %q", err)
+			t.Fatalf("unexpected error: %q", err)
 		}
-
 	}
+}
+
+func setServiceFabricEnvironment(t *testing.T, endpoint, thumbprint string) {
+	t.Helper()
+	t.Setenv(identityEndpointEnvVar, endpoint)
+	t.Setenv(identityHeaderEnvVar, "secret")
+	t.Setenv(identityServerThumbprintEnvVar, thumbprint)
+	t.Setenv(msiEndpointEnvVar, "")
+	t.Setenv(msiSecretEnvVar, "")
+	t.Setenv(imdsEndVar, "")
+}
+
+func resetServiceFabricCache(t *testing.T) {
+	t.Helper()
+	originalCacheManager := cacheManager
+	cacheManager = storage.New(nil)
+	t.Cleanup(func() { cacheManager = originalCacheManager })
+}
+
+func serviceFabricServerThumbprint(server *httptest.Server) string {
+	thumbprint := sha1.Sum(server.Certificate().Raw) // #nosec G401 -- Service Fabric uses SHA-1 thumbprints.
+	return hex.EncodeToString(thumbprint[:])
 }


### PR DESCRIPTION
Pins the Service Fabric managed identity TLS peer certificate to IDENTITY_SERVER_THUMBPRINT before sending Secret. Clones supported caller HTTP clients/transports without mutation, fails closed for unsafe transport extensions and redirects, and adds self-contained TLS coverage for matching/mismatching pins and request isolation.