### PR TITLE
Fix ID token credential type casing

### DIFF
--- a/apps/internal/base/storage/items.go
+++ b/apps/internal/base/storage/items.go
@@ -180,7 +180,7 @@ func NewIDToken(homeID, env, realm, clientID, idToken string) IDToken {
 		HomeAccountID:  homeID,
 		Environment:    env,
 		Realm:          realm,
-		CredentialType: "IDToken",
+		CredentialType: "IdToken",
 		ClientID:       clientID,
 		Secret:         idToken,
 	}

--- a/apps/internal/base/storage/items_test.go
+++ b/apps/internal/base/storage/items_test.go
@@ -419,6 +419,13 @@ func TestKeyForIDToken(t *testing.T) {
 	}
 }
 
+func TestNewIDToken(t *testing.T) {
+	got := NewIDToken(idHid, idEnv, idRealm, idClient, idTokSecret)
+	if diff := pretty.Compare(idToken, got); diff != "" {
+		t.Errorf("TestNewIDToken: -want/+got:\n%s", diff)
+	}
+}
+
 func TestIDTokenUnmarshal(t *testing.T) {
 	jsonMap := map[string]interface{}{
 		"home_account_id": "HID",


### PR DESCRIPTION
Change the serialized ID-token credential type to IdToken for cache compatibility.\n\nFixes #652