### PR TITLE
Prepare MSAL Go 1.9.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,21 @@
 *.swp
 *.pprof
 
+# Certificates and private keys
+*.pem
+*.crt
+*.cer
+*.cert
+*.der
+*.p7b
+*.p7c
+*.p12
+*.pfx
+*.key
+*.jks
+*.keystore
+
+
 # OSX specific os files
 *.DS_Store
 

--- a/apps/internal/version/version.go
+++ b/apps/internal/version/version.go
@@ -8,4 +8,4 @@ package version
 const SKU = "MSAL.Go"
 
 // Version is the version of this client package that is communicated to the server.
-const Version = "1.8.0"
+const Version = "1.9.0"


### PR DESCRIPTION
## Summary
- Update the communicated MSAL Go version to `1.9.0`.
- Ignore common certificate and private-key file formats.

## Validation
- Main branch CI is green.
- Azure SDK `azidentity` compatibility tests pass.
- MSAL Go package tests pass.
