### PR TITLE
Demo apps for the msal-go mTLS PR stack

### DIFF
--- a/apps/tests/devapps/mtls/README.md
+++ b/apps/tests/devapps/mtls/README.md
@@ -1,0 +1,79 @@
+# msal-go mTLS demo app
+
+`package main` demos for the msal-go mutual-TLS (mTLS) PR stack. Each subcommand isolates one
+capability and prints clearly labelled output suitable for a live presentation.
+
+This app targets an **integration branch** that combines five as-yet-unmerged PRs. It will not compile
+against `main` until that stack merges, because the samples use APIs those PRs introduce.
+
+## Subcommands and which PR each maps to
+
+| Subcommand         | PR                                              | Demonstrates |
+|--------------------|-------------------------------------------------|--------------|
+| `mtls-pop`         | **#632** mTLS PoP                               | An `mtls_pop` token: `Metadata.TokenType == "mtls_pop"`, `BindingCertificateThumbprint()`, and the token's decoded `cnf["x5t#S256"]` claim all agree — the token is bound to the certificate. |
+| `bearer-over-mtls` | **#643** bearer-over-mTLS                       | The same certificate, client built with `WithSendCertificateOverMtls()`: `TokenType` is `Bearer` and `BindingCertificate` is nil — an unbound token that still travelled over the mTLS transport. |
+| `cache-isolation`  | **#632 + #643**                                 | PoP and Bearer tokens for the same client/scope occupy separate cache entries and never collide (each type is re-served from cache on a second call). |
+| `signer`           | **#647** `NewCredFromTLSCertificate` / **#649** signer-backed JWT assertions | A `crypto.Signer` whose private key is never exported (the exact API shape a KeyGuard/TPM/HSM key uses), driving a real client-certificate TLS handshake against a local `httptest` server. Runs fully offline. |
+| `fic`              | **#633** FIC leg 2 (`NewCredFromSignedAssertionCallback`) | The developer-orchestrated two-leg federated identity credential (FIC) flow over mTLS PoP. Explains the flow always; runs live only when a second federated app is configured. Never fabricates a token. |
+
+> KeyGuard itself is Windows/VBS-specific and is shown from a pre-existing recording. The `signer`
+> subcommand here uses a **software** RSA key wrapped in a signer-only type so it demonstrates the
+> identical API shape while running on any platform (CI builds this with `go build ./apps/...` on
+> Linux).
+
+## Building
+
+```sh
+go build ./apps/tests/devapps/mtls/...
+# or run directly:
+go run ./apps/tests/devapps/mtls <subcommand> [flags]
+```
+
+## Configuration
+
+Defaults are the known-good lab values proven by #632's passing integration tests
+(`apps/tests/integration/mtls_pop_integration_test.go`). They are public identifiers, not secrets, and
+every one is overridable by flag or environment variable.
+
+| Flag              | Env var              | Default |
+|-------------------|----------------------|---------|
+| `-client-id`      | `MTLS_CLIENT_ID`     | `163ffef9-a313-45b4-ab2f-c7e2f5e0e23e` |
+| `-authority`      | `MTLS_AUTHORITY`     | `https://login.microsoftonline.com/bea21ebe-8b64-4d06-9f6d-6a889b120a7c` |
+| `-region`         | `MTLS_REGION`        | `westus3` |
+| `-cert`           | `MTLS_CERT_PATH`     | *(none — required by the network subcommands)* |
+| `-scope`          | `MTLS_POP_SCOPE`     | `https://vault.azure.net/.default` |
+
+`fic` adds `-fic-client-id` (`MTLS_FIC_CLIENT_ID`), `-fic-authority` (`MTLS_FIC_AUTHORITY`), and
+`-exchange-scope` (`MTLS_EXCHANGE_SCOPE`, default `api://AzureADTokenExchange/.default`).
+
+**The certificate is never embedded or committed.** Supply the SN/I certificate and its private key as
+a single PEM file via `-cert` / `MTLS_CERT_PATH`. If it is missing, the network subcommands fail with a
+clear, actionable message rather than a panic.
+
+## Running
+
+Offline (no certificate or network needed):
+
+```sh
+go run ./apps/tests/devapps/mtls signer
+go run ./apps/tests/devapps/mtls fic          # prints the two-leg explanation, then exits
+```
+
+Network subcommands (need the SN/I certificate and the lab):
+
+```sh
+export MTLS_CERT_PATH=/path/to/sni-cert.pem
+go run ./apps/tests/devapps/mtls mtls-pop
+go run ./apps/tests/devapps/mtls bearer-over-mtls
+go run ./apps/tests/devapps/mtls cache-isolation
+```
+
+Live two-leg FIC (needs a second federated app in addition to the certificate):
+
+```sh
+export MTLS_CERT_PATH=/path/to/sni-cert.pem
+export MTLS_FIC_CLIENT_ID=<second-app-client-id>
+go run ./apps/tests/devapps/mtls fic
+```
+
+Run `go run ./apps/tests/devapps/mtls <subcommand> -h` to see a subcommand's flags.

--- a/apps/tests/devapps/mtls/bearer.go
+++ b/apps/tests/devapps/mtls/bearer.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+)
+
+// runBearerOverMtls demonstrates PR #643: the same certificate credential, but the client is built
+// with WithSendCertificateOverMtls. The certificate is presented on the mutual-TLS handshake and the
+// request is routed to the mtlsauth.* endpoint, yet the returned token is an ordinary, UNBOUND Bearer
+// token: TokenType stays "Bearer" and AuthResult.BindingCertificate is nil.
+func runBearerOverMtls(args []string) error {
+	fs := flag.NewFlagSet("bearer-over-mtls", flag.ExitOnError)
+	var cfg config
+	registerCommonFlags(fs, &cfg)
+	fs.StringVar(&cfg.scope, "scope", env("MTLS_POP_SCOPE", defaultPoPScope), "resource scope to request")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	section("Bearer over mTLS (PR #643)")
+	kv("authority", cfg.authority)
+	kv("client id", cfg.clientID)
+	kv("scope", cfg.scope)
+
+	cred, leaf, err := loadCertificate(cfg.certPath)
+	if err != nil {
+		return err
+	}
+	kv("certificate x5t#S256", thumbprintOfCert(leaf))
+
+	// WithSendCertificateOverMtls is an app-level option: the certificate authenticates the transport
+	// but the token is not bound to it.
+	app, err := buildClient(cfg, cred, confidential.WithSendCertificateOverMtls())
+	if err != nil {
+		return fmt.Errorf("confidential.New failed: %w", err)
+	}
+
+	result, err := app.AcquireTokenByCredential(context.Background(), []string{cfg.scope})
+	if err != nil {
+		return fmt.Errorf("AcquireTokenByCredential over mTLS failed: %w", err)
+	}
+
+	section("result")
+	kv("Metadata.TokenType", result.Metadata.TokenType)
+	if result.BindingCertificate == nil {
+		kv("AuthResult.BindingCertificate", "<nil>")
+	} else {
+		kv("AuthResult.BindingCertificate", "<non-nil!>")
+	}
+	cnf, err := cnfThumbprintFromToken(result.AccessToken)
+	if err != nil {
+		return fmt.Errorf("could not read the cnf claim from the token: %w", err)
+	}
+	if cnf == "" {
+		kv("token cnf[\"x5t#S256\"]", "<absent — unbound token>")
+	} else {
+		kv("token cnf[\"x5t#S256\"]", cnf)
+	}
+
+	section("verification")
+	if result.Metadata.TokenType != "Bearer" {
+		return fmt.Errorf("expected token_type Bearer, got %q", result.Metadata.TokenType)
+	}
+	if result.BindingCertificate != nil {
+		return fmt.Errorf("expected a nil BindingCertificate for an unbound Bearer token")
+	}
+	if cnf != "" {
+		return fmt.Errorf("unexpected cnf claim %q on a Bearer token: it should be unbound", cnf)
+	}
+	fmt.Println("  OK: token_type is Bearer and BindingCertificate is nil.")
+	fmt.Println("  The token is unbound, yet the request travelled over the mutual-TLS transport")
+	fmt.Println("  (the certificate authenticated the connection to the mtlsauth.* endpoint).")
+	return nil
+}

--- a/apps/tests/devapps/mtls/cache.go
+++ b/apps/tests/devapps/mtls/cache.go
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+)
+
+func tokenSourceName(s confidential.TokenSource) string {
+	switch s {
+	case confidential.TokenSourceCache:
+		return "cache"
+	case confidential.TokenSourceIdentityProvider:
+		return "identity-provider"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(s))
+	}
+}
+
+// runCacheIsolation demonstrates that mTLS PoP and Bearer tokens for the same client and scope occupy
+// separate cache entries and never collide. It acquires each token type twice: the first call hits the
+// identity provider, the second is served from cache, proving the entry exists — and the two types
+// remain distinct (mtls_pop vs Bearer), so acquiring one never returns or evicts the other.
+func runCacheIsolation(args []string) error {
+	fs := flag.NewFlagSet("cache-isolation", flag.ExitOnError)
+	var cfg config
+	registerCommonFlags(fs, &cfg)
+	fs.StringVar(&cfg.scope, "scope", env("MTLS_POP_SCOPE", defaultPoPScope), "resource scope to request")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	section("Cache isolation: PoP vs Bearer (PR #632 + #643)")
+	kv("authority", cfg.authority)
+	kv("client id", cfg.clientID)
+	kv("scope", cfg.scope)
+
+	ctx := context.Background()
+
+	// PoP client: mTLS PoP is a per-request option.
+	popCred, _, err := loadCertificate(cfg.certPath)
+	if err != nil {
+		return err
+	}
+	popApp, err := buildClient(cfg, popCred)
+	if err != nil {
+		return fmt.Errorf("confidential.New (PoP client) failed: %w", err)
+	}
+
+	// Bearer client: WithSendCertificateOverMtls is an app-level option, so it needs its own client.
+	bearerCred, _, err := loadCertificate(cfg.certPath)
+	if err != nil {
+		return err
+	}
+	bearerApp, err := buildClient(cfg, bearerCred, confidential.WithSendCertificateOverMtls())
+	if err != nil {
+		return fmt.Errorf("confidential.New (Bearer client) failed: %w", err)
+	}
+
+	acquirePoP := func() (confidential.AuthResult, error) {
+		return popApp.AcquireTokenByCredential(ctx, []string{cfg.scope}, confidential.WithMtlsProofOfPossession())
+	}
+	acquireBearer := func() (confidential.AuthResult, error) {
+		return bearerApp.AcquireTokenByCredential(ctx, []string{cfg.scope})
+	}
+
+	section("acquire PoP, then PoP again")
+	pop1, err := acquirePoP()
+	if err != nil {
+		return fmt.Errorf("first PoP acquisition failed: %w", err)
+	}
+	kv("PoP #1 token_type / source", pop1.Metadata.TokenType+" / "+tokenSourceName(pop1.Metadata.TokenSource))
+	pop2, err := acquirePoP()
+	if err != nil {
+		return fmt.Errorf("second PoP acquisition failed: %w", err)
+	}
+	kv("PoP #2 token_type / source", pop2.Metadata.TokenType+" / "+tokenSourceName(pop2.Metadata.TokenSource))
+
+	section("acquire Bearer, then Bearer again (same scope)")
+	b1, err := acquireBearer()
+	if err != nil {
+		return fmt.Errorf("first Bearer acquisition failed: %w", err)
+	}
+	kv("Bearer #1 token_type / source", b1.Metadata.TokenType+" / "+tokenSourceName(b1.Metadata.TokenSource))
+	b2, err := acquireBearer()
+	if err != nil {
+		return fmt.Errorf("second Bearer acquisition failed: %w", err)
+	}
+	kv("Bearer #2 token_type / source", b2.Metadata.TokenType+" / "+tokenSourceName(b2.Metadata.TokenSource))
+
+	section("verification")
+	if pop1.Metadata.TokenType != "mtls_pop" {
+		return fmt.Errorf("expected PoP token_type mtls_pop, got %q", pop1.Metadata.TokenType)
+	}
+	if b1.Metadata.TokenType != "Bearer" {
+		return fmt.Errorf("expected Bearer token_type Bearer, got %q", b1.Metadata.TokenType)
+	}
+	if pop2.Metadata.TokenSource != confidential.TokenSourceCache {
+		fmt.Println("  NOTE: the second PoP call was not served from cache (token may have been near expiry).")
+	}
+	if b2.Metadata.TokenSource != confidential.TokenSourceCache {
+		fmt.Println("  NOTE: the second Bearer call was not served from cache (token may have been near expiry).")
+	}
+	fmt.Println("  OK: the same client/scope holds two distinct cache entries — one mtls_pop, one Bearer.")
+	fmt.Println("  Acquiring one token type never returns or evicts the other; the two do not collide.")
+	return nil
+}

--- a/apps/tests/devapps/mtls/common.go
+++ b/apps/tests/devapps/mtls/common.go
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package main
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+)
+
+// Known-good lab defaults, proven by #632's passing integration tests in
+// apps/tests/integration/mtls_pop_integration_test.go. They are public identifiers, not secrets, and
+// every one is overridable with a flag or environment variable (see config).
+const (
+	defaultClientID  = "163ffef9-a313-45b4-ab2f-c7e2f5e0e23e"
+	defaultAuthority = "https://login.microsoftonline.com/bea21ebe-8b64-4d06-9f6d-6a889b120a7c"
+	defaultRegion    = "westus3"
+	defaultPoPScope  = "https://vault.azure.net/.default"
+
+	// tokenExchangeScope is the audience the first leg of a two-leg S2S FIC exchange requests: it
+	// yields a federated assertion rather than a resource token. Mirrors MSAL .NET's TokenExchangeUrl.
+	tokenExchangeScope = "api://AzureADTokenExchange/.default"
+)
+
+// config holds the values common to every subcommand. Each subcommand registers these flags on its
+// own flag.FlagSet so `mtls <cmd> -h` lists exactly what that command accepts.
+type config struct {
+	clientID  string
+	authority string
+	region    string
+	certPath  string
+	scope     string
+}
+
+// loadCertificate reads a PEM file (certificate + private key) and builds a NewCredFromCert
+// credential from it, exactly the way apps/tests/integration/config_helpers_test.go's
+// getCertDataFromFile does. It returns the parsed leaf certificate too, so callers can compute the
+// x5t#S256 thumbprint themselves. No certificate, key or secret is ever embedded or logged.
+func loadCertificate(certPath string) (confidential.Credential, *x509.Certificate, error) {
+	if strings.TrimSpace(certPath) == "" {
+		return confidential.Credential{}, nil, fmt.Errorf(
+			"no certificate supplied: pass -cert <path-to-pem> or set MTLS_CERT_PATH to a PEM file " +
+				"containing the SN/I certificate and its private key")
+	}
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return confidential.Credential{}, nil, fmt.Errorf("reading certificate file %q failed: %w", certPath, err)
+	}
+	certs, privateKey, err := confidential.CertFromPEM(data, "")
+	if err != nil {
+		return confidential.Credential{}, nil, fmt.Errorf("parsing certificate PEM %q failed: %w", certPath, err)
+	}
+	if len(certs) == 0 {
+		return confidential.Credential{}, nil, fmt.Errorf("certificate PEM %q contained no certificates", certPath)
+	}
+	cred, err := confidential.NewCredFromCert(certs, privateKey)
+	if err != nil {
+		return confidential.Credential{}, nil, fmt.Errorf("NewCredFromCert failed: %w", err)
+	}
+	return cred, certs[0], nil
+}
+
+// cnfThumbprintFromToken decodes an access token's JWT body and returns its cnf["x5t#S256"] claim, the
+// thumbprint of the certificate the token is bound to. It reuses the approach in
+// apps/tests/integration/mtls_pop_integration_test.go's checkTokenBoundToCertificate. It returns an
+// empty string (not an error) when the token carries no such claim, so callers can report "unbound".
+func cnfThumbprintFromToken(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("access token is not a JWT: got %d segments, want 3", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decoding the JWT payload failed: %w", err)
+	}
+	var claims struct {
+		Cnf map[string]string `json:"cnf"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parsing the JWT payload failed: %w", err)
+	}
+	return claims.Cnf["x5t#S256"], nil
+}
+
+// thumbprintOfCert returns the base64url-encoded SHA-256 thumbprint (x5t#S256) of a certificate, the
+// value that appears in an mtls_pop token's cnf claim.
+func thumbprintOfCert(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// section prints a labelled banner so projected output is easy to follow on a screen.
+func section(title string) {
+	fmt.Println()
+	fmt.Println("== " + title + " ==")
+}
+
+// kv prints an aligned "key: value" line.
+func kv(key, value string) {
+	fmt.Printf("  %-32s %s\n", key+":", value)
+}
+
+// env returns the environment variable value if set, otherwise def.
+func env(name, def string) string {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		return v
+	}
+	return def
+}
+
+// registerCommonFlags wires the flags shared by the network subcommands onto fs, seeding defaults from
+// environment variables so the demo works with zero flags in the known-good lab, yet stays fully
+// overridable. It does not register -scope; each subcommand sets its own scope default.
+func registerCommonFlags(fs *flag.FlagSet, cfg *config) {
+	fs.StringVar(&cfg.clientID, "client-id", env("MTLS_CLIENT_ID", defaultClientID), "application (client) ID")
+	fs.StringVar(&cfg.authority, "authority", env("MTLS_AUTHORITY", defaultAuthority), "authority URL (must be tenanted for mTLS PoP)")
+	fs.StringVar(&cfg.region, "region", env("MTLS_REGION", defaultRegion), "Azure region for the regional token endpoint (empty to disable)")
+	fs.StringVar(&cfg.certPath, "cert", env("MTLS_CERT_PATH", ""), "path to a PEM file with the SN/I certificate and its private key")
+}

--- a/apps/tests/devapps/mtls/fic.go
+++ b/apps/tests/devapps/mtls/fic.go
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+)
+
+// runFIC demonstrates PR #633: leg 2 of a developer-orchestrated two-leg federated identity credential
+// (FIC) flow over mTLS PoP, via NewCredFromSignedAssertionCallback returning a SignedAssertion carrying
+// both the assertion and its binding certificate.
+//
+// Leg 2 needs a SECOND, federated application (distinct client ID) that trusts leg 1's assertion. We do
+// not have one, so this subcommand ALWAYS prints the full explanation of the flow, and only attempts a
+// live run when the second app is configured (via -fic-client-id / MTLS_FIC_CLIENT_ID). It never fakes
+// a token: absent the config it exits 0 after explaining.
+func runFIC(args []string) error {
+	fs := flag.NewFlagSet("fic", flag.ExitOnError)
+	var cfg config
+	registerCommonFlags(fs, &cfg)
+	var ficClientID, ficAuthority, exchangeScope, finalScope string
+	fs.StringVar(&ficClientID, "fic-client-id", env("MTLS_FIC_CLIENT_ID", ""), "client ID of the SECOND (federated) app for leg 2 — required to run live")
+	fs.StringVar(&ficAuthority, "fic-authority", env("MTLS_FIC_AUTHORITY", ""), "authority for the second app (defaults to -authority)")
+	fs.StringVar(&exchangeScope, "exchange-scope", env("MTLS_EXCHANGE_SCOPE", tokenExchangeScope), "leg 1 exchange audience")
+	fs.StringVar(&finalScope, "scope", env("MTLS_POP_SCOPE", defaultPoPScope), "final resource scope for leg 2")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if ficAuthority == "" {
+		ficAuthority = cfg.authority
+	}
+
+	section("Two-leg FIC over mTLS PoP (PR #633)")
+	fmt.Println("  The application orchestrates two mTLS proof-of-possession calls:")
+	fmt.Println()
+	fmt.Println("    Leg 1  SN/I certificate  ->  a certificate-bound FEDERATED ASSERTION")
+	fmt.Println("           (WithMtlsProofOfPossession against the token-exchange audience;")
+	fmt.Printf("            here: %s)\n", exchangeScope)
+	fmt.Println()
+	fmt.Println("    Leg 2  that assertion (sent as a jwt-pop client assertion) + the SAME binding")
+	fmt.Println("           certificate  ->  the final mtls_pop token for the resource.")
+	fmt.Println()
+	fmt.Println("  Leg 2 uses NewCredFromSignedAssertionCallback, whose callback returns ONE")
+	fmt.Println("  confidential.SignedAssertion{Assertion, BindingCertificate}. Returning both from a")
+	fmt.Println("  single callback keeps them paired: a certificate rotation between the legs can never")
+	fmt.Println("  pair one leg's assertion with another leg's certificate. This is the only API that")
+	fmt.Println("  supplies leg 2's binding certificate — there is deliberately no call-site option.")
+
+	if ficClientID == "" {
+		section("live run skipped")
+		fmt.Println("  No second (federated) app configured, so this demo cannot run the exchange without")
+		fmt.Println("  fabricating a token — which it will not do.")
+		fmt.Println()
+		fmt.Println("  To run it live, supply a federated app that trusts leg 1's assertion:")
+		fmt.Println("    -fic-client-id <client-id>   (or MTLS_FIC_CLIENT_ID)")
+		fmt.Println("    -cert <path-to-pem>          (or MTLS_CERT_PATH) for the SN/I certificate")
+		fmt.Println("  Optionally -fic-authority, -exchange-scope, -scope.")
+		return nil
+	}
+
+	// Live path: both apps are configured.
+	if cfg.certPath == "" {
+		return fmt.Errorf("a live FIC run needs the SN/I certificate: pass -cert or set MTLS_CERT_PATH")
+	}
+	section("live run")
+	kv("leg 1 authority", cfg.authority)
+	kv("leg 1 client id", cfg.clientID)
+	kv("exchange scope", exchangeScope)
+	kv("leg 2 authority", ficAuthority)
+	kv("leg 2 client id", ficClientID)
+	kv("final scope", finalScope)
+
+	ctx := context.Background()
+
+	// Leg 1: SN/I cert -> cert-bound federated assertion (itself an mTLS PoP request).
+	leg1Cred, _, err := loadCertificate(cfg.certPath)
+	if err != nil {
+		return err
+	}
+	leg1App, err := buildClient(cfg, leg1Cred)
+	if err != nil {
+		return fmt.Errorf("leg 1 confidential.New failed: %w", err)
+	}
+	leg1, err := leg1App.AcquireTokenByCredential(ctx, []string{exchangeScope},
+		confidential.WithMtlsProofOfPossession())
+	if err != nil {
+		return fmt.Errorf("leg 1 AcquireTokenByCredential with mTLS PoP failed: %w", err)
+	}
+	kv("leg 1 token_type", leg1.Metadata.TokenType)
+	if leg1.Metadata.TokenType != "mtls_pop" {
+		return fmt.Errorf("leg 1 token_type = %q, want mtls_pop", leg1.Metadata.TokenType)
+	}
+	if leg1.BindingCertificate == nil {
+		return fmt.Errorf("leg 1 returned no binding certificate")
+	}
+
+	// Leg 2: federated assertion (jwt-pop) + the SAME binding certificate -> final mtls_pop token.
+	leg2Cred := confidential.NewCredFromSignedAssertionCallback(
+		func(context.Context, confidential.AssertionRequestOptions) (confidential.SignedAssertion, error) {
+			return confidential.SignedAssertion{
+				Assertion:          leg1.AccessToken,
+				BindingCertificate: leg1.BindingCertificate,
+			}, nil
+		})
+	leg2App, err := confidential.New(ficAuthority, ficClientID, leg2Cred)
+	if err != nil {
+		return fmt.Errorf("leg 2 confidential.New failed: %w", err)
+	}
+	final, err := leg2App.AcquireTokenByCredential(ctx, []string{finalScope},
+		confidential.WithMtlsProofOfPossession())
+	if err != nil {
+		return fmt.Errorf("leg 2 AcquireTokenByCredential with mTLS PoP failed: %w", err)
+	}
+
+	section("result")
+	kv("final token_type", final.Metadata.TokenType)
+	kv("final BindingCertificateThumbprint()", final.BindingCertificateThumbprint())
+	if final.Metadata.TokenType != "mtls_pop" {
+		return fmt.Errorf("final token_type = %q, want mtls_pop", final.Metadata.TokenType)
+	}
+	fmt.Println("  OK: both legs produced mtls_pop tokens; leg 2 was bound to leg 1's certificate.")
+	return nil
+}

--- a/apps/tests/devapps/mtls/main.go
+++ b/apps/tests/devapps/mtls/main.go
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Command mtls is a set of runnable demos for the msal-go mTLS PR stack. Each subcommand isolates one
+// capability and prints clearly labelled output suitable for a live presentation.
+//
+// Subcommands:
+//
+//	mtls-pop         acquire an mTLS proof-of-possession token (PR #632)
+//	bearer-over-mtls acquire a Bearer token that still travels over the mTLS transport (PR #643)
+//	cache-isolation  prove PoP and Bearer tokens do not collide in the cache (PR #632 + #643)
+//	signer           authenticate with a crypto.Signer whose key is never exported (PR #647/#649)
+//	fic              explain and (with config) run the two-leg FIC over mTLS PoP flow (PR #633)
+//
+// Run `mtls <subcommand> -h` for the flags a subcommand accepts. The signer subcommand and the
+// explanatory path of fic run fully offline; the rest require the SN/I certificate and network access.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// subcommand describes one demo.
+type subcommand struct {
+	name string
+	desc string
+	run  func(args []string) error
+}
+
+func subcommands() []subcommand {
+	return []subcommand{
+		{"mtls-pop", "Acquire an mTLS proof-of-possession token (PR #632)", runMtlsPoP},
+		{"bearer-over-mtls", "Acquire a Bearer token over the mTLS transport (PR #643)", runBearerOverMtls},
+		{"cache-isolation", "Prove PoP and Bearer tokens do not collide in the cache (PR #632 + #643)", runCacheIsolation},
+		{"signer", "Authenticate with a non-exportable crypto.Signer (PR #647/#649)", runSigner},
+		{"fic", "Two-leg federated identity credential over mTLS PoP (PR #633)", runFIC},
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "mtls — demos for the msal-go mTLS PR stack")
+	fmt.Fprintln(os.Stderr, "\nUsage: mtls <subcommand> [flags]")
+	fmt.Fprintln(os.Stderr, "\nSubcommands:")
+	for _, c := range subcommands() {
+		fmt.Fprintf(os.Stderr, "  %-16s %s\n", c.name, c.desc)
+	}
+	fmt.Fprintln(os.Stderr, "\nRun 'mtls <subcommand> -h' for a subcommand's flags.")
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	name := os.Args[1]
+	if name == "-h" || name == "--help" || name == "help" {
+		usage()
+		return
+	}
+	for _, c := range subcommands() {
+		if c.name == name {
+			if err := c.run(os.Args[2:]); err != nil {
+				fmt.Fprintf(os.Stderr, "\nerror: %s\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+	}
+	fmt.Fprintf(os.Stderr, "unknown subcommand %q\n\n", name)
+	usage()
+	os.Exit(2)
+}

--- a/apps/tests/devapps/mtls/pop.go
+++ b/apps/tests/devapps/mtls/pop.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+)
+
+// buildClient constructs a confidential client from a certificate credential, applying the regional
+// endpoint when a region is configured. Extra options (for example WithSendCertificateOverMtls) are
+// appended by the caller.
+func buildClient(cfg config, cred confidential.Credential, extra ...confidential.Option) (confidential.Client, error) {
+	opts := extra
+	if cfg.region != "" {
+		opts = append(opts, confidential.WithAzureRegion(cfg.region))
+	}
+	return confidential.New(cfg.authority, cfg.clientID, cred, opts...)
+}
+
+// runMtlsPoP demonstrates PR #632: an mTLS proof-of-possession token. It acquires a token with
+// WithMtlsProofOfPossession, then shows that the token_type is mtls_pop and that the certificate MSAL
+// returned (BindingCertificateThumbprint) is the same one named in the token's cnf["x5t#S256"] claim.
+func runMtlsPoP(args []string) error {
+	fs := flag.NewFlagSet("mtls-pop", flag.ExitOnError)
+	var cfg config
+	registerCommonFlags(fs, &cfg)
+	fs.StringVar(&cfg.scope, "scope", env("MTLS_POP_SCOPE", defaultPoPScope), "resource scope to request")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	section("mTLS proof-of-possession (PR #632)")
+	kv("authority", cfg.authority)
+	kv("client id", cfg.clientID)
+	kv("scope", cfg.scope)
+
+	cred, leaf, err := loadCertificate(cfg.certPath)
+	if err != nil {
+		return err
+	}
+	kv("certificate x5t#S256", thumbprintOfCert(leaf))
+
+	app, err := buildClient(cfg, cred)
+	if err != nil {
+		return fmt.Errorf("confidential.New failed: %w", err)
+	}
+
+	result, err := app.AcquireTokenByCredential(context.Background(), []string{cfg.scope},
+		confidential.WithMtlsProofOfPossession())
+	if err != nil {
+		return fmt.Errorf("AcquireTokenByCredential with mTLS PoP failed: %w", err)
+	}
+
+	section("result")
+	kv("Metadata.TokenType", result.Metadata.TokenType)
+	kv("BindingCertificateThumbprint()", result.BindingCertificateThumbprint())
+
+	cnf, err := cnfThumbprintFromToken(result.AccessToken)
+	if err != nil {
+		return fmt.Errorf("could not read the cnf claim from the token: %w", err)
+	}
+	if cnf == "" {
+		return fmt.Errorf("the token carries no cnf[\"x5t#S256\"] claim, so it is not certificate-bound")
+	}
+	kv("token cnf[\"x5t#S256\"]", cnf)
+
+	section("verification")
+	if result.Metadata.TokenType != "mtls_pop" {
+		return fmt.Errorf("expected token_type mtls_pop, got %q", result.Metadata.TokenType)
+	}
+	if result.BindingCertificateThumbprint() != cnf {
+		return fmt.Errorf("thumbprint mismatch: result %q vs token cnf %q",
+			result.BindingCertificateThumbprint(), cnf)
+	}
+	fmt.Println("  OK: token_type is mtls_pop and the binding thumbprint matches the token's cnf claim.")
+	fmt.Println("  The token is cryptographically bound to the certificate presented on the TLS handshake.")
+	return nil
+}

--- a/apps/tests/devapps/mtls/signer.go
+++ b/apps/tests/devapps/mtls/signer.go
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package main
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"flag"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+)
+
+// nonExportableSigner wraps a private key and exposes ONLY the crypto.Signer surface: Public() and
+// Sign(). It deliberately provides no accessor for the underlying key, so once a key is wrapped there
+// is no way to retrieve the private material through this type. This is the exact API shape a
+// KeyGuard, TPM or HSM key presents in Go — the key lives behind an opaque signer — except that here
+// the key is an ordinary software RSA key so the demo runs anywhere with no special hardware.
+type nonExportableSigner struct {
+	// key is unexported and never surfaced; the only operations offered are Public and Sign.
+	key *rsa.PrivateKey
+}
+
+func (s nonExportableSigner) Public() crypto.PublicKey {
+	return s.key.Public()
+}
+
+func (s nonExportableSigner) Sign(rn io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return s.key.Sign(rn, digest, opts)
+}
+
+var _ crypto.Signer = nonExportableSigner{}
+
+// runSigner demonstrates PR #647/#649: NewCredFromTLSCertificate with a crypto.Signer whose private
+// key is never exported. It builds a self-signed leaf, wraps its key in nonExportableSigner, and uses
+// the resulting tls.Certificate to complete a client-certificate handshake against a local httptest
+// TLS server that requires one. No network, lab, or special hardware is needed, so this runs offline.
+func runSigner(args []string) error {
+	fs := flag.NewFlagSet("signer", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	section("Signer-backed credential over mTLS (PR #647/#649)")
+	fmt.Println("  Demonstrating a crypto.Signer whose private key is never exported.")
+
+	// Generate a software RSA key and a self-signed certificate for it. In production the key would
+	// live in KeyGuard/TPM/HSM; here it is software so the demo is portable, but we still only ever
+	// hand MSAL the signer, never the key.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return fmt.Errorf("generating the demo RSA key failed: %w", err)
+	}
+	leafDER, err := selfSignedLeaf(key)
+	if err != nil {
+		return err
+	}
+
+	signer := nonExportableSigner{key: key}
+	kv("signer type", fmt.Sprintf("%T (crypto.Signer only)", signer))
+	kv("signer.Public() type", fmt.Sprintf("%T", signer.Public()))
+
+	// The tls.Certificate carries the DER chain and the OPAQUE signer as its PrivateKey. MSAL never
+	// sees an *rsa.PrivateKey.
+	clientTLSCert := tls.Certificate{
+		Certificate: [][]byte{leafDER},
+		PrivateKey:  signer,
+	}
+
+	// NewCredFromTLSCertificate accepts the signer-backed certificate. This is the credential a
+	// KeyGuard/HSM caller builds; MSAL adds no platform-specific dependency.
+	cred, err := confidential.NewCredFromTLSCertificate(clientTLSCert)
+	if err != nil {
+		return fmt.Errorf("NewCredFromTLSCertificate failed: %w", err)
+	}
+	// A confidential client can be constructed from it. We do not send a token request (that needs a
+	// real authority); the handshake below exercises the same signer MSAL would use on the mTLS leg.
+	if _, err := confidential.New("https://login.microsoftonline.com/common", "11111111-1111-1111-1111-111111111111", cred); err != nil {
+		return fmt.Errorf("confidential.New with the signer-backed credential failed: %w", err)
+	}
+	fmt.Println("  Built a confidential client from the signer-backed credential (no private key exported).")
+
+	// Stand up a local TLS server that REQUIRES a client certificate, then present the signer-backed
+	// certificate to it. A successful handshake proves crypto/tls signed the handshake through the
+	// opaque signer — exactly what happens on MSAL's mutual-TLS leg.
+	leaf, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		return fmt.Errorf("parsing the demo leaf failed: %w", err)
+	}
+	clientCAs := x509.NewCertPool()
+	clientCAs.AddCert(leaf)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "ok")
+	}))
+	server.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  clientCAs,
+		MinVersion: tls.VersionTLS12,
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	// Trust the server's own certificate, and present our signer-backed client certificate.
+	serverCAs := x509.NewCertPool()
+	serverCAs.AddCert(server.Certificate())
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      serverCAs,
+				Certificates: []tls.Certificate{clientTLSCert},
+				MinVersion:   tls.VersionTLS12,
+			},
+		},
+	}
+
+	section("client-certificate handshake against a local TLS server")
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		return fmt.Errorf("the mutual-TLS handshake with the signer-backed certificate failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		return fmt.Errorf("reading the response failed: %w", err)
+	}
+
+	kv("negotiated TLS version", tlsVersionName(resp.TLS.Version))
+	kv("HTTP status", resp.Status)
+	fmt.Println("  OK: the server required a client certificate and the handshake succeeded.")
+	fmt.Println("  crypto/tls signed the handshake through the opaque signer; the private key never left it.")
+	return nil
+}
+
+// selfSignedLeaf builds a minimal self-signed certificate for key and returns its DER bytes.
+func selfSignedLeaf(key *rsa.PrivateKey) ([]byte, error) {
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "msal-go mtls signer demo"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, key.Public(), key)
+	if err != nil {
+		return nil, fmt.Errorf("creating the self-signed certificate failed: %w", err)
+	}
+	return der, nil
+}
+
+func tlsVersionName(v uint16) string {
+	switch v {
+	case tls.VersionTLS13:
+		return "TLS 1.3"
+	case tls.VersionTLS12:
+		return "TLS 1.2"
+	case tls.VersionTLS11:
+		return "TLS 1.1"
+	case tls.VersionTLS10:
+		return "TLS 1.0"
+	default:
+		return fmt.Sprintf("0x%04x", v)
+	}
+}


### PR DESCRIPTION
## What this is

Runnable demo/sample apps showcasing the msal-go **mTLS PR stack**, for a live presentation.

`apps/tests/devapps/mtls/` is a standalone `package main` with CLI subcommands, one per capability:

| Subcommand         | PR | Demonstrates |
|--------------------|----|--------------|
| `mtls-pop`         | **#632** | An `mtls_pop` token: `Metadata.TokenType == "mtls_pop"`, `BindingCertificateThumbprint()`, and the decoded `cnf["x5t#S256"]` claim all match — the token is bound to the certificate. |
| `bearer-over-mtls` | **#643** | Same certificate, client built with `WithSendCertificateOverMtls()`: `TokenType` is `Bearer` and `BindingCertificate` is nil — an unbound token that still travelled over the mTLS transport. |
| `cache-isolation`  | **#632 + #643** | PoP and Bearer tokens for the same client/scope occupy separate cache entries and never collide. |
| `signer`           | **#647** `NewCredFromTLSCertificate` / **#649** signer-backed JWT assertions | A `crypto.Signer` whose private key is never exported (the exact API shape a KeyGuard/TPM/HSM key uses), driving a real client-certificate TLS handshake against a local `httptest` server. Runs fully **offline**. |
| `fic`              | **#633** FIC leg 2 (`NewCredFromSignedAssertionCallback`) | The developer-orchestrated two-leg FIC flow over mTLS PoP. Always explains the flow; runs live only when a second federated app is configured. Never fabricates a token. |

## Why this targets an integration branch, not `main`

The samples use APIs from **five unmerged PRs** (#632, #633, #643, #647, #649) and **would not compile against `main`**. The base branch `robbie/mtls-demo-base` is those five PRs merged together (three ordinary merge commits on top of #632). This PR's diff is therefore limited to the new sample files.

**This PR is for demonstration and should be retargeted to `main` once the stack merges.**

## Notes

- No certificate, key, or secret is embedded or committed. The SN/I certificate is supplied at runtime via `-cert` / `MTLS_CERT_PATH`; missing config yields a clear, actionable error, never a panic.
- Cross-platform: no Windows-only code, no build tags. KeyGuard itself is shown from a recording; the `signer` demo uses a software RSA key wrapped in a signer-only type to demonstrate the identical API shape on any platform. CI's `go build ./apps/...` passes on Linux.
- `signer` and `fic`'s explanatory path run with no network. Defaults are the known-good lab values from #632's passing integration tests.

See `apps/tests/devapps/mtls/README.md` for full run instructions.
